### PR TITLE
SLO estimation path, per-GPU observability, barebone orca ls/web, optional S3 model paths, added/fixed logging, timeseries export

### DIFF
--- a/models/requests.py
+++ b/models/requests.py
@@ -55,8 +55,8 @@ class BatchedRequest(BaseModel):
     # Use on-demand instances instead of spot (default: prefer spot)
     prefer_spot: Optional[bool] = True
 
-    # Load model weights from S3 instead of HuggingFace (faster, requires prior upload)
-    s3_models: Optional[bool] = False
+    # S3 URI to model weights — if set, loads from S3 instead of HuggingFace
+    s3_model_path: Optional[str] = None
     # HuggingFace token for gated models (Llama, etc.)
     hf_token: Optional[str] = None
     # OpenRouter API key for LLM-based placement solver

--- a/models/resources.py
+++ b/models/resources.py
@@ -16,6 +16,9 @@ class MagicOutput(BaseModel):
     throughput_tokens_per_sec: Optional[float] = None
     cost_per_hour: Optional[float] = None
     cost_per_million_tokens: Optional[float] = None
+    # SLO estimates (populated when slo_deadline_hours is set)
+    estimated_runtime_hours: Optional[float] = None
+    meets_slo: Optional[bool] = None
 
     @property
     def num_nodes(self) -> int:

--- a/orca
+++ b/orca
@@ -355,6 +355,19 @@ def cmd_deploy(args):
         print(f"\n  {RED}Error:{RESET} Input file not found: {input_file}")
         sys.exit(1)
 
+    # ── Phase 0: Validate --s3-models path if provided ───────────────────
+    s3_model_path = getattr(args, 's3_models', None)
+    if s3_model_path:
+        step(f"Validating S3 model path: {c(s3_model_path, DIM)}")
+        import subprocess as _sp
+        _check = _sp.run(["aws", "s3", "ls", s3_model_path.rstrip("/") + "/"],
+                         capture_output=True, text=True, timeout=15)
+        if _check.returncode != 0 or not _check.stdout.strip():
+            print(f"\n  {RED}Error:{RESET} Model not found at {s3_model_path}")
+            print(f"  {DIM}Check the path and try again.{RESET}\n")
+            sys.exit(1)
+        step(f"Model found at S3 {c('OK', GREEN)}")
+
     # ── Phase 1: Parse input ─────────────────────────────────────────────
     if is_s3:
         step("Using S3 input (stats parsed by server)...")
@@ -424,7 +437,7 @@ def cmd_deploy(args):
         "slo_mode": "batch",
         "slo_deadline_hours": args.slo,
         "placement": "aws",
-        "s3_models": False,
+        "s3_model_path": getattr(args, 's3_models', None),
         "persist": args.persist,
         "prefer_spot": not args.on_demand,
         "hf_token": os.environ.get("HF_TOKEN", ""),
@@ -1973,6 +1986,8 @@ Examples:
     p_deploy.add_argument("--on-demand", action="store_true", help="Use on-demand instances instead of spot")
     p_deploy.add_argument("--replicas", type=int, default=None, help="Number of replica clusters (auto if omitted)")
     p_deploy.add_argument("--chunk-size", type=int, default=None, help="Lines per chunk for multi-replica (default: 1000)")
+    p_deploy.add_argument("--s3-models", type=str, default=None, metavar="S3_URI",
+                          help="S3 path to model weights (e.g. s3://tandemn-model-shards/hf-models/Qwen/Qwen3-32B)")
     p_deploy.add_argument("--log-level", default="info", choices=["debug", "info", "warning"])
 
     # plan

--- a/orca
+++ b/orca
@@ -1714,7 +1714,7 @@ def cmd_history(args):
 
 
 def cmd_ls(args):
-    """List all jobs with detailed info — one box per job, most recent first."""
+    """List all jobs in a clean table, most recent first."""
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     STATUS_COLORS = {
@@ -1725,12 +1725,23 @@ def cmd_ls(args):
         "model_ready": BLUE,
         "launching": YELLOW,
         "queued": YELLOW,
+        "running": CYAN,
+        "cancelled": DIM,
+    }
+    STATUS_ICONS = {
+        "succeeded": f"{GREEN}\u2713{RESET}",
+        "failed": f"{RED}\u2717{RESET}",
+        "cancelled": f"{DIM}\u2717{RESET}",
+    }
+    STATUS_LABELS = {
+        "loading_model": "loading model",
+        "model_ready": "model ready",
     }
     INACTIVE = {"succeeded", "failed", "cancelled"}
 
     resp = api("get", "/jobs", timeout=15)
     if resp.status_code != 200:
-        print(f"\n  {RED}Error:{RESET} {resp.text}\n")
+        print(f"{RED}Error:{RESET} {resp.text}")
         return
 
     jobs = resp.json()
@@ -1738,9 +1749,7 @@ def cmd_ls(args):
         jobs = jobs.get("jobs", [])
 
     if not jobs:
-        print(LOGO)
-        header("JOBS")
-        print(f"\n  {DIM}No jobs found.{RESET}\n")
+        print(f"{DIM}No jobs found.{RESET}")
         return
 
     # Sort by created_at descending
@@ -1752,6 +1761,8 @@ def cmd_ls(args):
         return
 
     # --- Enrichment ---
+    verbose = getattr(args, "verbose", False)
+
     def enrich(job):
         jid = job.get("job_id") or job.get("id", "")
         info = {"replicas": [], "chunks": {}, "metrics": {}, "detail": {}}
@@ -1774,17 +1785,16 @@ def cmd_ls(args):
                 info["chunks"] = r.json()
         except Exception:
             pass
-        try:
-            r = api("get", f"/job/{jid}/metrics", timeout=8)
-            if r.status_code == 200:
-                info["metrics"] = r.json()
-        except Exception:
-            pass
+        if verbose:
+            try:
+                r = api("get", f"/job/{jid}/metrics", timeout=8)
+                if r.status_code == 200:
+                    info["metrics"] = r.json()
+            except Exception:
+                pass
         return jid, info
 
     enrich_all = getattr(args, "all", False)
-    active_jobs = {(j.get("job_id") or j.get("id", "")): j for j in jobs
-                   if j.get("status") not in INACTIVE}
     enrichment: dict = {}
 
     jobs_to_enrich = jobs if enrich_all else [j for j in jobs if j.get("status") not in INACTIVE]
@@ -1798,135 +1808,158 @@ def cmd_ls(args):
                 except Exception:
                     pass
 
-    # --- Render ---
-    print(LOGO)
-    header("JOBS")
+    # --- Helpers ---
+    def _status_display(status):
+        icon = STATUS_ICONS.get(status, f"{STATUS_COLORS.get(status, DIM)}\u25cf{RESET}")
+        label = STATUS_LABELS.get(status, status)
+        return f"{icon} {c(label, STATUS_COLORS.get(status, DIM))}"
+
+    def _progress_str(job, info):
+        num_lines = job.get("num_lines", 0) or 0
+        chunks = info.get("chunks", {})
+        # Use chunk-level completed count if available (more accurate for chunked jobs)
+        done_reqs = 0
+        if chunks.get("completed", 0) and chunks.get("total", 0):
+            # Estimate completed prompts from chunk ratio
+            chunk_ratio = chunks["completed"] / chunks["total"]
+            done_reqs = int(num_lines * chunk_ratio)
+        elif job.get("progress") is not None:
+            done_reqs = int(num_lines * float(job["progress"]))
+        elif job.get("status") == "succeeded":
+            done_reqs = num_lines
+        if num_lines:
+            return f"{done_reqs:,d}/{num_lines:,d}"
+        return f"{DIM}\u2014{RESET}"
+
+    def _instance_str(job, info):
+        replicas = info.get("replicas", [])
+        detail = info.get("detail", {})
+        instance = ""
+        if replicas:
+            instance = replicas[0].get("instance_type", "")
+        if not instance:
+            instance = detail.get("instance_type", "")
+        if not instance:
+            return f"{DIM}\u2014{RESET}", ""
+        num_replicas = len(replicas) if replicas else 1
+        inst_str = instance
+        if num_replicas > 1:
+            inst_str += f" {DIM}(\u00d7{num_replicas}){RESET}"
+        return inst_str, instance
+
+    def _region_str(info):
+        replicas = info.get("replicas", [])
+        if replicas:
+            region = replicas[0].get("region") or ""
+            if region:
+                return f"aws {region}"
+        return ""
+
+    # --- Render table ---
     print()
+    hdr = (
+        f"  {BOLD}{DIM}{'MODEL':<34s} {'STATUS':<20s} {'PROGRESS':<16s} "
+        f"{'INSTANCE':<24s} {'REGION':<16s}{RESET}"
+    )
+    print(hdr)
+    print(f"  {DIM}{'─' * 110}{RESET}")
 
     for job in jobs:
         jid = job.get("job_id") or job.get("id", "")
-        short_id = jid[:24]
         model = job.get("model_name", "?")
         status = job.get("status", "unknown")
-        status_color = STATUS_COLORS.get(status, DIM)
-        num_lines = job.get("num_lines", 0) or 0
-        created_str = ""
-        if job.get("created_at"):
-            try:
-                created_str = datetime.fromtimestamp(job["created_at"]).strftime("%Y-%m-%d %H:%M")
-            except Exception:
-                created_str = str(job["created_at"])
-
-        # Progress
-        pct = 0.0
-        if job.get("progress") is not None:
-            pct = float(job["progress"])
-        elif status == "succeeded":
-            pct = 1.0
-
-        lines = []
-        status_str = c(status, status_color + BOLD)
-        lines.append(
-            f"{DIM}Status:{RESET}     {status_str:<28s} {DIM}Progress:{RESET} {bar(pct, 30)}"
-        )
-        prompts_str = f"{num_lines:,d}" if num_lines else "—"
-        lines.append(
-            f"{DIM}Prompts:{RESET}    {prompts_str:<20s}       {DIM}Created:{RESET}  {created_str}"
-        )
-
         info = enrichment.get(jid, {})
-        enrich_all = getattr(args, "all", False)
 
-        if status not in INACTIVE or enrich_all:
-            # Instance / config from replicas or detail
-            replicas = info.get("replicas", [])
-            detail = info.get("detail", {})
-            # Try to get instance_type from first replica
-            instance = ""
-            if replicas:
-                instance = replicas[0].get("instance_type", "")
-            if not instance:
-                instance = detail.get("instance_type", "")
-            if instance:
-                lines.append(f"{DIM}Instance:{RESET}   {c(instance, WHITE+BOLD)}")
+        # Truncate model name if too long
+        model_display = model if len(model) <= 32 else model[:29] + "..."
+
+        status_display = _status_display(status)
+        progress = _progress_str(job, info)
+        inst_display, _ = _instance_str(job, info)
+        region = _region_str(info)
+
+        # Build row — use visible_len-aware padding for colored fields
+        model_pad = 34 - visible_len(model_display)
+        status_pad = 20 - visible_len(status_display)
+        progress_pad = 16 - visible_len(progress)
+        inst_pad = 24 - visible_len(inst_display)
+
+        row = (
+            f"  {model_display}{' ' * max(0, model_pad)}"
+            f" {status_display}{' ' * max(0, status_pad)}"
+            f" {progress}{' ' * max(0, progress_pad)}"
+            f" {inst_display}{' ' * max(0, inst_pad)}"
+            f" {region}"
+        )
+        print(row)
+
+        # --- Verbose: detail lines under each active job ---
+        if verbose and (status not in INACTIVE or enrich_all):
+            detail_parts = []
 
             # Endpoint
-            endpoint = detail.get("endpoint_url", "")
+            endpoint = info.get("detail", {}).get("endpoint_url", "")
             if endpoint:
-                lines.append(f"{DIM}Endpoint:{RESET}   {endpoint}")
+                detail_parts.append(f"endpoint: {endpoint}")
 
-            # Chunks (keys match /job/{id}/chunks/progress response)
+            # Chunks
             chunks = info.get("chunks", {})
-            completed = chunks.get("completed", 0)
-            inflight = chunks.get("inflight", 0)
-            pending = chunks.get("pending", 0)
-            failed = chunks.get("failed", 0)
             total_chunks = chunks.get("total", 0)
             if total_chunks:
-                chunk_line = f"{DIM}Chunks:{RESET}     {c(str(completed), GREEN)}/{total_chunks} done"
+                chunk_parts = [f"{chunks.get('completed', 0)}/{total_chunks} chunks"]
+                inflight = chunks.get("inflight", 0)
                 if inflight:
-                    chunk_line += f"  {c(str(inflight), CYAN)} in-flight"
-                if pending:
-                    chunk_line += f"  {pending} pending"
+                    chunk_parts.append(f"{c(str(inflight), CYAN)} in-flight")
+                failed = chunks.get("failed", 0)
                 if failed:
-                    chunk_line += f"  {c(str(failed), RED)} failed"
-                lines.append(chunk_line)
+                    chunk_parts.append(f"{c(str(failed), RED)} failed")
+                detail_parts.append("  ".join(chunk_parts))
 
-            # Metrics (keys match /job/{id}/metrics response - MetricsSnapshot.to_dict())
+            # Metrics
             metrics = info.get("metrics", {})
             tps = metrics.get("avg_generation_throughput_toks_per_s")
             kv = metrics.get("gpu_cache_usage_perc")
             running = metrics.get("num_requests_running")
-            waiting = metrics.get("num_requests_waiting")
-            done_reqs = metrics.get("request_success_total")
-            if any(v is not None for v in [tps, kv, running, waiting]):
-                parts = []
+            if any(v is not None for v in [tps, kv, running]):
+                m_parts = []
                 if tps is not None:
-                    parts.append(f"{c(f'{tps:,.0f}', GREEN+BOLD)} tok/s")
+                    m_parts.append(f"{c(f'{tps:,.0f}', GREEN)} tok/s")
                 if kv is not None:
                     kv_pct = kv * 100 if kv <= 1 else kv
-                    parts.append(f"KV {kv_pct:.0f}%")
+                    m_parts.append(f"KV {kv_pct:.0f}%")
                 if running is not None:
-                    parts.append(f"{c(str(int(running)), CYAN)} running")
-                if waiting is not None and int(waiting) > 0:
-                    parts.append(f"{int(waiting)} waiting")
-                if done_reqs is not None and int(done_reqs) > 0:
-                    parts.append(f"{int(done_reqs)} done")
-                lines.append(f"{DIM}Metrics:{RESET}    {'   '.join(parts)}")
+                    m_parts.append(f"{int(running)} running")
+                detail_parts.append("  ".join(m_parts))
 
-                # GPU utilization if available
-                gpu_sm = metrics.get("gpu_sm_util_pct")
-                gpu_bw = metrics.get("gpu_mem_bw_util_pct")
-                if gpu_sm and gpu_sm > 0:
-                    gpu_parts = [f"GPU SM {gpu_sm:.0f}%"]
-                    if gpu_bw and gpu_bw > 0:
-                        gpu_parts.append(f"MemBW {gpu_bw:.0f}%")
-                    lines.append(f"{DIM}GPU:{RESET}        {'   '.join(gpu_parts)}")
+            if detail_parts:
+                print(f"  {DIM}{'':34s} {' \u00b7 '.join(detail_parts)}{RESET}")
 
-            # Replicas (keys match /job/{id}/replicas response)
-            if replicas:
-                lines.append(f"{DIM}Replicas:{RESET}")
+            # Replicas
+            replicas = info.get("replicas", [])
+            if replicas and len(replicas) > 1:
                 PHASE_COLORS = {"running": GREEN, "generating": GREEN, "launching": YELLOW,
                                 "provisioned": CYAN, "completed": GREEN, "failed": RED,
                                 "dead": RED, "swapped_out": DIM}
                 for rep in replicas:
                     rid = rep.get("replica_id", "?")
-                    # Short label: last part after last dash
                     short_r = rid.rsplit("-", 1)[-1] if "-r" in rid else rid[-8:]
                     phase = rep.get("phase", "?")
                     phase_color = PHASE_COLORS.get(phase, DIM)
-                    region = rep.get("region") or ""
+                    r_region = rep.get("region") or ""
                     market = rep.get("market") or ""
                     inst = rep.get("instance_type") or ""
-                    lines.append(
-                        f"  {short_r:<6s} {c(phase, phase_color):<22s} {region:<14s} {market:<12s} {inst}"
+                    print(
+                        f"  {'':34s} {DIM}{short_r}{RESET}  "
+                        f"{c(phase, phase_color):<18s}  {r_region}  {market}  {inst}"
                     )
 
-        title = f"{short_id} {DIM}─{RESET} {model}"
-        print(box(lines, title=title))
-        print()
+        # blank line between jobs only in verbose mode
+        if verbose:
+            print()
 
-    print(f"  {DIM}{len(jobs)} job(s) total{RESET}\n")
+    print()
+    print(f"  {DIM}{len(jobs)} job(s){RESET}")
+    print()
 
 
 def cmd_web(args):
@@ -2067,6 +2100,7 @@ Examples:
     p_ls = subparsers.add_parser("ls", help="List all jobs with detailed info")
     p_ls.add_argument("--all", "-a", action="store_true", help="Fetch metrics/replicas for completed jobs too")
     p_ls.add_argument("--json", action="store_true", help="Output as JSON")
+    p_ls.add_argument("-v", "--verbose", action="store_true", help="Show detailed metrics, chunks, and replica info")
 
     args = parser.parse_args()
 

--- a/orca
+++ b/orca
@@ -632,6 +632,12 @@ def cmd_plan(args):
             cph = cfg.get("cost_per_hour")
             if cph:
                 lines.append(f"{DIM}Est. cost:{RESET}   ${cph:.2f}/hr {DIM}(on-demand){RESET}")
+            eta = cfg.get("estimated_runtime_hours")
+            if eta is not None:
+                slo_ok = cfg.get("meets_slo", True)
+                eta_color = GREEN if slo_ok else RED
+                slo_label = "" if slo_ok else f"  {c('MISSES SLO', RED+BOLD)}"
+                lines.append(f"{DIM}Est. time:{RESET}   {c(f'{eta:.2f}h', eta_color)} / {args.slo:.1f}h SLO{slo_label}")
             if cfg.get("quota_warning"):
                 lines.append(f"{YELLOW}Quota:{RESET}       {cfg['quota_warning']}")
             print(box(lines, title="FEASIBILITY CHECK"))
@@ -673,7 +679,17 @@ def cmd_plan(args):
         cph = cfg.get("cost_per_hour")
         if cph:
             lines.append(f"{DIM}Est. cost:{RESET}   ${cph:.2f}/hr {DIM}(on-demand){RESET}")
+        eta = cfg.get("estimated_runtime_hours")
+        if eta is not None:
+            slo_ok = cfg.get("meets_slo", True)
+            eta_color = GREEN if slo_ok else RED
+            slo_label = "" if slo_ok else f"  {c('MISSES SLO', RED+BOLD)}"
+            lines.append(f"{DIM}Est. time:{RESET}   {c(f'{eta:.2f}h', eta_color)} / {args.slo:.1f}h SLO{slo_label}")
         print(box(lines, title=f"CONFIG {rank_label}"))
+        print()
+
+    if data.get("slo_warning"):
+        print(f"  {YELLOW}SLO warning:{RESET} {data['slo_warning']}")
         print()
 
     if args.verbose and data.get("solver_log"):

--- a/orca
+++ b/orca
@@ -30,6 +30,7 @@ def _hours(value):
         return float(s[:-1]) / 60
     return float(s.rstrip("hH"))
 
+import math
 import os
 import re
 import sys
@@ -215,8 +216,28 @@ def upload_to_server(local_path: str, user: str = "orca-cli") -> str:
 
 
 def split_and_upload_chunks(input_file: str, chunk_size: int) -> list:
-    """Split a local JSONL file into chunks, upload each to S3, return chunk metadata."""
+    """Split a JSONL file into chunks, upload each to S3, return chunk metadata.
+
+    For S3 inputs, downloads to a temp file first.
+    """
     import tempfile as _tf
+
+    # If input is on S3, download to a local temp file first
+    tmp_download = None
+    if input_file.startswith("s3://"):
+        step(f"Downloading S3 input for chunking: {c(input_file, DIM)}")
+        tmp_download = _tf.NamedTemporaryFile(suffix='.jsonl', delete=False)
+        tmp_download.close()
+        resp = api("get", "/storage/download_s3", params={"path": input_file})
+        if resp.status_code != 200:
+            print(f"\n  {RED}Failed to download S3 input for chunking:{RESET} {resp.text}")
+            sys.exit(1)
+        with open(tmp_download.name, "wb") as df:
+            df.write(resp.content)
+        local_file = tmp_download.name
+    else:
+        local_file = input_file
+
     chunks = []
     current_lines = []
     chunk_idx = 0
@@ -230,7 +251,7 @@ def split_and_upload_chunks(input_file: str, chunk_size: int) -> list:
         os.unlink(tmp.name)
         return {"chunk_id": cid, "s3_input_path": s3_uri, "num_lines": len(lines)}
 
-    with open(input_file) as f:
+    with open(local_file) as f:
         for line in f:
             if not line.strip():
                 continue
@@ -241,6 +262,8 @@ def split_and_upload_chunks(input_file: str, chunk_size: int) -> list:
                 chunk_idx += 1
     if current_lines:
         chunks.append(_flush(current_lines, chunk_idx))
+    if tmp_download:
+        os.unlink(tmp_download.name)
     return chunks
 
 
@@ -1677,6 +1700,244 @@ def cmd_history(args):
     print()
 
 
+def cmd_ls(args):
+    """List all jobs with detailed info — one box per job, most recent first."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    STATUS_COLORS = {
+        "succeeded": GREEN,
+        "failed": RED,
+        "generating": CYAN,
+        "loading_model": BLUE,
+        "model_ready": BLUE,
+        "launching": YELLOW,
+        "queued": YELLOW,
+    }
+    INACTIVE = {"succeeded", "failed", "cancelled"}
+
+    resp = api("get", "/jobs", timeout=15)
+    if resp.status_code != 200:
+        print(f"\n  {RED}Error:{RESET} {resp.text}\n")
+        return
+
+    jobs = resp.json()
+    if isinstance(jobs, dict):
+        jobs = jobs.get("jobs", [])
+
+    if not jobs:
+        print(LOGO)
+        header("JOBS")
+        print(f"\n  {DIM}No jobs found.{RESET}\n")
+        return
+
+    # Sort by created_at descending
+    jobs.sort(key=lambda j: j.get("created_at", 0), reverse=True)
+
+    # --- JSON mode ---
+    if getattr(args, "json", False):
+        print(json.dumps(jobs, indent=2, default=str))
+        return
+
+    # --- Enrichment ---
+    def enrich(job):
+        jid = job.get("job_id") or job.get("id", "")
+        info = {"replicas": [], "chunks": {}, "metrics": {}, "detail": {}}
+        try:
+            r = api("get", f"/job/{jid}", timeout=8)
+            if r.status_code == 200:
+                info["detail"] = r.json()
+        except Exception:
+            pass
+        try:
+            r = api("get", f"/job/{jid}/replicas", timeout=8)
+            if r.status_code == 200:
+                data = r.json()
+                info["replicas"] = data if isinstance(data, list) else data.get("replicas", [])
+        except Exception:
+            pass
+        try:
+            r = api("get", f"/job/{jid}/chunks/progress", timeout=8)
+            if r.status_code == 200:
+                info["chunks"] = r.json()
+        except Exception:
+            pass
+        try:
+            r = api("get", f"/job/{jid}/metrics", timeout=8)
+            if r.status_code == 200:
+                info["metrics"] = r.json()
+        except Exception:
+            pass
+        return jid, info
+
+    enrich_all = getattr(args, "all", False)
+    active_jobs = {(j.get("job_id") or j.get("id", "")): j for j in jobs
+                   if j.get("status") not in INACTIVE}
+    enrichment: dict = {}
+
+    jobs_to_enrich = jobs if enrich_all else [j for j in jobs if j.get("status") not in INACTIVE]
+    if jobs_to_enrich:
+        with ThreadPoolExecutor(max_workers=min(8, len(jobs_to_enrich))) as pool:
+            futs = {pool.submit(enrich, j): j for j in jobs_to_enrich}
+            for fut in as_completed(futs):
+                try:
+                    jid, info = fut.result()
+                    enrichment[jid] = info
+                except Exception:
+                    pass
+
+    # --- Render ---
+    print(LOGO)
+    header("JOBS")
+    print()
+
+    for job in jobs:
+        jid = job.get("job_id") or job.get("id", "")
+        short_id = jid[:24]
+        model = job.get("model_name", "?")
+        status = job.get("status", "unknown")
+        status_color = STATUS_COLORS.get(status, DIM)
+        num_lines = job.get("num_lines", 0) or 0
+        created_str = ""
+        if job.get("created_at"):
+            try:
+                created_str = datetime.fromtimestamp(job["created_at"]).strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                created_str = str(job["created_at"])
+
+        # Progress
+        pct = 0.0
+        if job.get("progress") is not None:
+            pct = float(job["progress"])
+        elif status == "succeeded":
+            pct = 1.0
+
+        lines = []
+        status_str = c(status, status_color + BOLD)
+        lines.append(
+            f"{DIM}Status:{RESET}     {status_str:<28s} {DIM}Progress:{RESET} {bar(pct, 30)}"
+        )
+        prompts_str = f"{num_lines:,d}" if num_lines else "—"
+        lines.append(
+            f"{DIM}Prompts:{RESET}    {prompts_str:<20s}       {DIM}Created:{RESET}  {created_str}"
+        )
+
+        info = enrichment.get(jid, {})
+        enrich_all = getattr(args, "all", False)
+
+        if status not in INACTIVE or enrich_all:
+            # Instance / config from replicas or detail
+            replicas = info.get("replicas", [])
+            detail = info.get("detail", {})
+            # Try to get instance_type from first replica
+            instance = ""
+            if replicas:
+                instance = replicas[0].get("instance_type", "")
+            if not instance:
+                instance = detail.get("instance_type", "")
+            if instance:
+                lines.append(f"{DIM}Instance:{RESET}   {c(instance, WHITE+BOLD)}")
+
+            # Endpoint
+            endpoint = detail.get("endpoint_url", "")
+            if endpoint:
+                lines.append(f"{DIM}Endpoint:{RESET}   {endpoint}")
+
+            # Chunks (keys match /job/{id}/chunks/progress response)
+            chunks = info.get("chunks", {})
+            completed = chunks.get("completed", 0)
+            inflight = chunks.get("inflight", 0)
+            pending = chunks.get("pending", 0)
+            failed = chunks.get("failed", 0)
+            total_chunks = chunks.get("total", 0)
+            if total_chunks:
+                chunk_line = f"{DIM}Chunks:{RESET}     {c(str(completed), GREEN)}/{total_chunks} done"
+                if inflight:
+                    chunk_line += f"  {c(str(inflight), CYAN)} in-flight"
+                if pending:
+                    chunk_line += f"  {pending} pending"
+                if failed:
+                    chunk_line += f"  {c(str(failed), RED)} failed"
+                lines.append(chunk_line)
+
+            # Metrics (keys match /job/{id}/metrics response - MetricsSnapshot.to_dict())
+            metrics = info.get("metrics", {})
+            tps = metrics.get("avg_generation_throughput_toks_per_s")
+            kv = metrics.get("gpu_cache_usage_perc")
+            running = metrics.get("num_requests_running")
+            waiting = metrics.get("num_requests_waiting")
+            done_reqs = metrics.get("request_success_total")
+            if any(v is not None for v in [tps, kv, running, waiting]):
+                parts = []
+                if tps is not None:
+                    parts.append(f"{c(f'{tps:,.0f}', GREEN+BOLD)} tok/s")
+                if kv is not None:
+                    kv_pct = kv * 100 if kv <= 1 else kv
+                    parts.append(f"KV {kv_pct:.0f}%")
+                if running is not None:
+                    parts.append(f"{c(str(int(running)), CYAN)} running")
+                if waiting is not None and int(waiting) > 0:
+                    parts.append(f"{int(waiting)} waiting")
+                if done_reqs is not None and int(done_reqs) > 0:
+                    parts.append(f"{int(done_reqs)} done")
+                lines.append(f"{DIM}Metrics:{RESET}    {'   '.join(parts)}")
+
+                # GPU utilization if available
+                gpu_sm = metrics.get("gpu_sm_util_pct")
+                gpu_bw = metrics.get("gpu_mem_bw_util_pct")
+                if gpu_sm and gpu_sm > 0:
+                    gpu_parts = [f"GPU SM {gpu_sm:.0f}%"]
+                    if gpu_bw and gpu_bw > 0:
+                        gpu_parts.append(f"MemBW {gpu_bw:.0f}%")
+                    lines.append(f"{DIM}GPU:{RESET}        {'   '.join(gpu_parts)}")
+
+            # Replicas (keys match /job/{id}/replicas response)
+            if replicas:
+                lines.append(f"{DIM}Replicas:{RESET}")
+                PHASE_COLORS = {"running": GREEN, "generating": GREEN, "launching": YELLOW,
+                                "provisioned": CYAN, "completed": GREEN, "failed": RED,
+                                "dead": RED, "swapped_out": DIM}
+                for rep in replicas:
+                    rid = rep.get("replica_id", "?")
+                    # Short label: last part after last dash
+                    short_r = rid.rsplit("-", 1)[-1] if "-r" in rid else rid[-8:]
+                    phase = rep.get("phase", "?")
+                    phase_color = PHASE_COLORS.get(phase, DIM)
+                    region = rep.get("region") or ""
+                    market = rep.get("market") or ""
+                    inst = rep.get("instance_type") or ""
+                    lines.append(
+                        f"  {short_r:<6s} {c(phase, phase_color):<22s} {region:<14s} {market:<12s} {inst}"
+                    )
+
+        title = f"{short_id} {DIM}─{RESET} {model}"
+        print(box(lines, title=title))
+        print()
+
+    print(f"  {DIM}{len(jobs)} job(s) total{RESET}\n")
+
+
+def cmd_web(args):
+    """Open the Orca web dashboard in browser."""
+    import webbrowser
+    port = getattr(args, 'port', None)
+    if port:
+        url = f"http://localhost:{port}/dashboard"
+    else:
+        url = f"{ORCA_SERVER}/dashboard"
+    print(LOGO)
+    header("WEB DASHBOARD")
+    step(f"Dashboard URL: {c(url, CYAN+BOLD)}")
+    step(f"Opening in browser...")
+    print()
+    try:
+        webbrowser.open(url)
+    except Exception:
+        step(f"Could not open browser. Open manually: {url}")
+    step(f"{DIM}Dashboard connects to server via SSE for live updates.{RESET}")
+    step(f"{DIM}Press Ctrl+C to close.{RESET}")
+    print()
+
+
 # ─── Main ────────────────────────────────────────────────────────────────────
 def main():
     parser = argparse.ArgumentParser(
@@ -1783,6 +2044,15 @@ Examples:
     p_destroy.add_argument("job_id", nargs="?", help="Job ID to destroy clusters for")
     p_destroy.add_argument("--all", action="store_true", help="Destroy ALL Orca clusters")
 
+    # web
+    p_web = subparsers.add_parser("web", help="Open real-time web dashboard")
+    p_web.add_argument("--port", type=int, help="Override server port")
+
+    # ls
+    p_ls = subparsers.add_parser("ls", help="List all jobs with detailed info")
+    p_ls.add_argument("--all", "-a", action="store_true", help="Fetch metrics/replicas for completed jobs too")
+    p_ls.add_argument("--json", action="store_true", help="Output as JSON")
+
     args = parser.parse_args()
 
     if not args.command:
@@ -1804,6 +2074,8 @@ Examples:
         "stream": cmd_stream,
         "destroy": cmd_destroy,
         "swap": cmd_swap,
+        "web": cmd_web,
+        "ls": cmd_ls,
     }
 
     commands[args.command](args)

--- a/orca
+++ b/orca
@@ -342,6 +342,17 @@ def _poll_replica_launch(job_id, num_replicas):
 
 
 # ─── Commands ────────────────────────────────────────────────────────────────
+def _slo_line(cfg: dict, slo_hours: float) -> str | None:
+    """Format SLO ETA line for display boxes. Returns None if no ETA available."""
+    eta = cfg.get("estimated_runtime_hours")
+    if eta is None:
+        return None
+    slo_ok = cfg.get("meets_slo", True)
+    eta_color = GREEN if slo_ok else RED
+    slo_label = "" if slo_ok else f"  {c('MISSES SLO', RED+BOLD)}"
+    return f"{DIM}Est. time:{RESET}   {c(f'{eta:.2f}h', eta_color)} / {slo_hours:.1f}h SLO{slo_label}"
+
+
 def cmd_deploy(args):
     """Deploy a model for batch inference."""
     print(LOGO)
@@ -668,12 +679,9 @@ def cmd_plan(args):
             cph = cfg.get("cost_per_hour")
             if cph:
                 lines.append(f"{DIM}Est. cost:{RESET}   ${cph:.2f}/hr {DIM}(on-demand){RESET}")
-            eta = cfg.get("estimated_runtime_hours")
-            if eta is not None:
-                slo_ok = cfg.get("meets_slo", True)
-                eta_color = GREEN if slo_ok else RED
-                slo_label = "" if slo_ok else f"  {c('MISSES SLO', RED+BOLD)}"
-                lines.append(f"{DIM}Est. time:{RESET}   {c(f'{eta:.2f}h', eta_color)} / {args.slo:.1f}h SLO{slo_label}")
+            slo = _slo_line(cfg, args.slo)
+            if slo:
+                lines.append(slo)
             if cfg.get("quota_warning"):
                 lines.append(f"{YELLOW}Quota:{RESET}       {cfg['quota_warning']}")
             print(box(lines, title="FEASIBILITY CHECK"))
@@ -715,12 +723,9 @@ def cmd_plan(args):
         cph = cfg.get("cost_per_hour")
         if cph:
             lines.append(f"{DIM}Est. cost:{RESET}   ${cph:.2f}/hr {DIM}(on-demand){RESET}")
-        eta = cfg.get("estimated_runtime_hours")
-        if eta is not None:
-            slo_ok = cfg.get("meets_slo", True)
-            eta_color = GREEN if slo_ok else RED
-            slo_label = "" if slo_ok else f"  {c('MISSES SLO', RED+BOLD)}"
-            lines.append(f"{DIM}Est. time:{RESET}   {c(f'{eta:.2f}h', eta_color)} / {args.slo:.1f}h SLO{slo_label}")
+        slo = _slo_line(cfg, args.slo)
+        if slo:
+            lines.append(slo)
         print(box(lines, title=f"CONFIG {rank_label}"))
         print()
 
@@ -883,7 +888,10 @@ def cmd_progress(args):
 
 
 def cmd_status(args):
-    """Show status of all jobs."""
+    """Show status of all jobs. Use -v for rich view with replicas, chunks, and GPU util."""
+    if getattr(args, "verbose", False):
+        return cmd_ls(args)
+
     print(LOGO)
     header("JOB STATUS")
 
@@ -1766,32 +1774,27 @@ def cmd_ls(args):
     def enrich(job):
         jid = job.get("job_id") or job.get("id", "")
         info = {"replicas": [], "chunks": {}, "metrics": {}, "detail": {}}
-        try:
-            r = api("get", f"/job/{jid}", timeout=8)
-            if r.status_code == 200:
-                info["detail"] = r.json()
-        except Exception:
-            pass
-        try:
-            r = api("get", f"/job/{jid}/replicas", timeout=8)
-            if r.status_code == 200:
-                data = r.json()
-                info["replicas"] = data if isinstance(data, list) else data.get("replicas", [])
-        except Exception:
-            pass
-        try:
-            r = api("get", f"/job/{jid}/chunks/progress", timeout=8)
-            if r.status_code == 200:
-                info["chunks"] = r.json()
-        except Exception:
-            pass
+        for label, path, key in [
+            ("details", f"/job/{jid}", "detail"),
+            ("replicas", f"/job/{jid}/replicas", "replicas"),
+            ("chunks", f"/job/{jid}/chunks/progress", "chunks"),
+        ]:
+            try:
+                r = api("get", path, timeout=8)
+                if r.status_code == 200:
+                    data = r.json()
+                    if key == "replicas":
+                        data = data if isinstance(data, list) else data.get("replicas", [])
+                    info[key] = data
+            except Exception as e:
+                print(f"  {DIM}Could not enrich {label} for {jid}: {e}{RESET}", file=sys.stderr)
         if verbose:
             try:
                 r = api("get", f"/job/{jid}/metrics", timeout=8)
                 if r.status_code == 200:
                     info["metrics"] = r.json()
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"  {DIM}Could not enrich metrics for {jid}: {e}{RESET}", file=sys.stderr)
         return jid, info
 
     enrich_all = getattr(args, "all", False)
@@ -1805,8 +1808,8 @@ def cmd_ls(args):
                 try:
                     jid, info = fut.result()
                     enrichment[jid] = info
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(f"  {DIM}Enrichment failed: {e}{RESET}", file=sys.stderr)
 
     # --- Helpers ---
     def _status_display(status):
@@ -2040,7 +2043,10 @@ Examples:
     p_progress.add_argument("job_id", nargs="?", help="Job ID to monitor (optional)")
 
     # status
-    subparsers.add_parser("status", help="Show status of all jobs")
+    p_status = subparsers.add_parser("status", help="Show status of all jobs")
+    p_status.add_argument("-v", "--verbose", action="store_true", help="Rich view with replicas, chunks, GPU util")
+    p_status.add_argument("--all", action="store_true", help="Enrich completed/failed jobs too (verbose mode)")
+    p_status.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # logs
     p_logs = subparsers.add_parser("logs", help="Stream logs from a job cluster")
@@ -2097,11 +2103,6 @@ Examples:
     p_web.add_argument("--port", type=int, help="Override server port")
 
     # ls
-    p_ls = subparsers.add_parser("ls", help="List all jobs with detailed info")
-    p_ls.add_argument("--all", "-a", action="store_true", help="Fetch metrics/replicas for completed jobs too")
-    p_ls.add_argument("--json", action="store_true", help="Output as JSON")
-    p_ls.add_argument("-v", "--verbose", action="store_true", help="Show detailed metrics, chunks, and replica info")
-
     args = parser.parse_args()
 
     if not args.command:
@@ -2124,7 +2125,6 @@ Examples:
         "destroy": cmd_destroy,
         "swap": cmd_swap,
         "web": cmd_web,
-        "ls": cmd_ls,
     }
 
     commands[args.command](args)

--- a/orca_server/dashboard.py
+++ b/orca_server/dashboard.py
@@ -1,0 +1,734 @@
+"""
+Orca Web Dashboard — real-time job monitoring via SSE.
+
+Provides two endpoints:
+  GET /dashboard        → serves the single-page dashboard HTML
+  GET /dashboard/stream → SSE stream of fleet-wide job/metrics/chunk data
+"""
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import asdict
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+dashboard_router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Dashboard HTML (single-page app with inline CSS + JS)
+# ---------------------------------------------------------------------------
+
+DASHBOARD_HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orca Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0f172a;--card:#1e293b;--card-hover:#263348;
+  --text:#e2e8f0;--text-dim:#94a3b8;--text-muted:#64748b;
+  --cyan:#22d3ee;--green:#4ade80;--red:#f87171;--yellow:#facc15;
+  --blue:#60a5fa;--magenta:#c084fc;--orange:#fb923c;
+  --border:#334155;--bar-bg:#0f172a;
+}
+html{font-size:14px}
+body{
+  font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  background:var(--bg);color:var(--text);min-height:100vh;
+}
+a{color:var(--cyan);text-decoration:none}
+a:hover{text-decoration:underline}
+
+/* Header */
+.header{
+  display:flex;align-items:center;justify-content:space-between;
+  padding:1rem 1.5rem;border-bottom:1px solid var(--border);
+  background:#0b1120;position:sticky;top:0;z-index:100;
+}
+.header-left{display:flex;align-items:center;gap:1rem}
+.logo{font-size:1.4rem;font-weight:700;color:var(--cyan);letter-spacing:0.05em}
+.logo-sub{font-size:0.85rem;color:var(--text-dim);font-weight:400}
+.header-right{display:flex;align-items:center;gap:1.25rem}
+.conn-status{display:flex;align-items:center;gap:0.4rem;font-size:0.8rem;color:var(--text-dim)}
+.conn-dot{width:8px;height:8px;border-radius:50%;transition:background 0.3s}
+.conn-dot.ok{background:var(--green)}
+.conn-dot.err{background:var(--red)}
+.conn-dot.connecting{background:var(--yellow);animation:pulse 1s infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:0.4}}
+.server-url{font-size:0.75rem;color:var(--text-muted)}
+
+/* Main container */
+.main{padding:1.5rem;max-width:1600px;margin:0 auto}
+.empty-state{
+  text-align:center;padding:4rem 2rem;color:var(--text-muted);
+  font-size:1rem;
+}
+.empty-state .whale{font-size:3rem;margin-bottom:1rem;display:block}
+
+/* Job cards grid */
+.grid{
+  display:grid;grid-template-columns:1fr;gap:1rem;
+}
+@media(min-width:1024px){.grid{grid-template-columns:repeat(2,1fr)}}
+
+/* Job card */
+.card{
+  background:var(--card);border:1px solid var(--border);border-radius:8px;
+  padding:1.25rem;transition:background 0.2s,border-color 0.2s;
+}
+.card:hover{background:var(--card-hover);border-color:var(--cyan)}
+.card-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:0.75rem}
+.model-name{font-size:1.1rem;font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:70%}
+.badge{
+  display:inline-block;padding:0.15rem 0.55rem;border-radius:4px;
+  font-size:0.7rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;
+}
+.badge-succeeded{background:rgba(74,222,128,0.15);color:var(--green)}
+.badge-failed{background:rgba(248,113,113,0.15);color:var(--red)}
+.badge-generating{background:rgba(34,211,238,0.15);color:var(--cyan)}
+.badge-launching{background:rgba(250,204,21,0.15);color:var(--yellow)}
+.badge-loading_model,.badge-model_ready{background:rgba(96,165,250,0.15);color:var(--blue)}
+.badge-running{background:rgba(34,211,238,0.15);color:var(--cyan)}
+.badge-queued{background:rgba(148,163,184,0.15);color:var(--text-dim)}
+.badge-cancelled{background:rgba(148,163,184,0.15);color:var(--text-muted)}
+
+.job-id{font-size:0.75rem;color:var(--text-muted);margin-bottom:0.75rem;word-break:break-all}
+
+/* Progress bar */
+.progress-wrap{margin-bottom:0.75rem}
+.progress-label{display:flex;justify-content:space-between;font-size:0.75rem;color:var(--text-dim);margin-bottom:0.3rem}
+.progress-bar{
+  height:6px;background:var(--bar-bg);border-radius:3px;overflow:hidden;
+}
+.progress-fill{
+  height:100%;border-radius:3px;transition:width 0.5s ease;
+  background:linear-gradient(90deg,var(--cyan),var(--blue));
+}
+.progress-fill.done{background:linear-gradient(90deg,var(--green),#22c55e)}
+.progress-fill.failed{background:linear-gradient(90deg,var(--red),#dc2626)}
+
+/* Stats row */
+.stats{display:flex;flex-wrap:wrap;gap:0.5rem 1.25rem;margin-bottom:0.75rem}
+.stat{font-size:0.75rem}
+.stat-label{color:var(--text-muted)}
+.stat-value{color:var(--text);font-weight:500}
+
+/* Chunk progress */
+.chunk-section{margin-top:0.75rem;border-top:1px solid var(--border);padding-top:0.75rem}
+.chunk-header{font-size:0.75rem;font-weight:600;color:var(--text-dim);margin-bottom:0.4rem}
+
+/* Replica table */
+.replica-section{margin-top:0.75rem;border-top:1px solid var(--border);padding-top:0.75rem}
+.replica-header{font-size:0.75rem;font-weight:600;color:var(--text-dim);margin-bottom:0.4rem}
+.replica-table{width:100%;font-size:0.7rem;border-collapse:collapse}
+.replica-table th{
+  text-align:left;padding:0.3rem 0.5rem;color:var(--text-muted);
+  border-bottom:1px solid var(--border);font-weight:500;
+}
+.replica-table td{padding:0.3rem 0.5rem;color:var(--text-dim)}
+.replica-table tr:hover td{color:var(--text)}
+.phase-badge{
+  display:inline-block;padding:0.1rem 0.4rem;border-radius:3px;
+  font-size:0.65rem;font-weight:600;text-transform:uppercase;
+}
+.phase-running{background:rgba(34,211,238,0.15);color:var(--cyan)}
+.phase-launching{background:rgba(250,204,21,0.15);color:var(--yellow)}
+.phase-loading_model{background:rgba(96,165,250,0.15);color:var(--blue)}
+.phase-failed{background:rgba(248,113,113,0.15);color:var(--red)}
+.phase-stopped{background:rgba(148,163,184,0.15);color:var(--text-muted)}
+
+/* Charts */
+.charts-grid{display:grid;grid-template-columns:1fr 1fr;gap:0.5rem;margin:0.75rem 0}
+.chart-wrap{background:var(--bg);border-radius:6px;padding:0.5rem;height:200px}
+.chart-wrap canvas{width:100%!important;height:100%!important}
+</style>
+</head>
+<body>
+<div class="header">
+  <div class="header-left">
+    <span class="logo">ORCA</span>
+    <span class="logo-sub">Dashboard</span>
+  </div>
+  <div class="header-right">
+    <div class="conn-status">
+      <span class="conn-dot connecting" id="connDot"></span>
+      <span id="connLabel">Connecting...</span>
+    </div>
+    <span class="server-url" id="serverUrl"></span>
+  </div>
+</div>
+<div class="main">
+  <div id="content">
+    <div class="empty-state">
+      <span class="whale">&#128051;</span>
+      Connecting to Orca server...
+    </div>
+  </div>
+</div>
+<script>
+(function(){
+  const serverUrl = window.location.origin;
+  document.getElementById('serverUrl').textContent = serverUrl;
+
+  let es = null;
+  let reconnectTimer = null;
+
+  /* ---- Timeseries storage ---- */
+  const jobTimeseries = {};   // {job_id: [{timestamp, ...metrics}, ...]}
+  const MAX_TS_POINTS = 300;
+  const ACTIVE_STATUSES = new Set(['launching','loading_model','model_ready','generating','running']);
+
+  function sanitizeId(s) { return s.replace(/[^a-zA-Z0-9]/g, '-'); }
+
+  /* ---- ChartManager ---- */
+  const chartDefaults = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    scales: {
+      x: {
+        grid: {color: '#334155'},
+        ticks: {color: '#94a3b8', font: {size: 9}},
+      },
+      y: {
+        grid: {color: '#334155'},
+        ticks: {color: '#94a3b8', font: {size: 9}},
+        beginAtZero: true,
+      }
+    },
+    plugins: {
+      legend: {
+        labels: {color: '#e2e8f0', font: {size: 9}},
+        position: 'top',
+      }
+    }
+  };
+
+  function mergeOpts(extra) {
+    return JSON.parse(JSON.stringify(Object.assign({}, chartDefaults, extra || {})));
+  }
+
+  function pctScale() {
+    return {y:{grid:{color:'#334155'},ticks:{color:'#94a3b8',font:{size:9}},beginAtZero:true,max:100}};
+  }
+
+  const CHART_DEFS = [
+    {
+      key: 'tp', label: 'Throughput', type: 'line',
+      datasets: [
+        {label:'Gen tok/s', borderColor:'#22d3ee', backgroundColor:'rgba(34,211,238,0.1)', field:'avg_generation_throughput_toks_per_s'},
+        {label:'Prompt tok/s', borderColor:'#4ade80', backgroundColor:'rgba(74,222,128,0.1)', field:'avg_prompt_throughput_toks_per_s'},
+      ],
+    },
+    {
+      key: 'kv', label: 'KV Cache', type: 'line',
+      datasets: [
+        {label:'KV Cache %', borderColor:'#fb923c', backgroundColor:'rgba(251,146,60,0.25)', fill:true, field:'gpu_cache_usage_perc', scale:100},
+      ],
+      opts: {scales: pctScale()},
+    },
+    {
+      key: 'sched', label: 'Scheduler', type: 'line',
+      datasets: [
+        {label:'Running', borderColor:'#22d3ee', backgroundColor:'rgba(34,211,238,0.25)', fill:true, field:'num_requests_running'},
+        {label:'Waiting', borderColor:'#fb923c', backgroundColor:'rgba(251,146,60,0.25)', fill:true, field:'num_requests_waiting'},
+        {label:'Swapped', borderColor:'#94a3b8', backgroundColor:'rgba(148,163,184,0.25)', fill:true, field:'num_requests_swapped'},
+      ],
+    },
+    {
+      key: 'gpu', label: 'GPU Utilization', type: 'line',
+      datasets: [
+        {label:'SM %', borderColor:'#60a5fa', backgroundColor:'rgba(96,165,250,0.1)', field:'gpu_sm_util_pct'},
+        {label:'MemBW %', borderColor:'#4ade80', backgroundColor:'rgba(74,222,128,0.1)', field:'gpu_mem_bw_util_pct'},
+      ],
+      opts: {scales: pctScale()},
+    },
+    {
+      key: 'lat', label: 'Latency', type: 'line',
+      datasets: [
+        {label:'TTFT p50', borderColor:'#60a5fa', backgroundColor:'rgba(96,165,250,0.1)', field:'ttft_ms_p50'},
+        {label:'TTFT p95', borderColor:'#3b82f6', backgroundColor:'rgba(59,130,246,0.1)', field:'ttft_ms_p95', borderDash:[4,2]},
+        {label:'TPOT p50', borderColor:'#fb923c', backgroundColor:'rgba(251,146,60,0.1)', field:'tpot_ms_p50'},
+        {label:'TPOT p95', borderColor:'#f97316', backgroundColor:'rgba(249,115,22,0.1)', field:'tpot_ms_p95', borderDash:[4,2]},
+      ],
+    },
+    {
+      key: 'comp', label: 'Completions', type: 'line',
+      datasets: [
+        {label:'Success', borderColor:'#4ade80', backgroundColor:'rgba(74,222,128,0.1)', field:'request_success_total'},
+        {label:'Preemptions', borderColor:'#f87171', backgroundColor:'rgba(248,113,113,0.1)', field:'num_preemptions_total'},
+      ],
+    },
+  ];
+
+  class ChartManager {
+    constructor() {
+      this.charts = {};  // {job_id: {key: Chart}}
+    }
+
+    getOrCreate(jobId, def, canvasId) {
+      if (!this.charts[jobId]) this.charts[jobId] = {};
+      if (this.charts[jobId][def.key]) return this.charts[jobId][def.key];
+
+      const canvas = document.getElementById(canvasId);
+      if (!canvas) return null;
+      const ctx = canvas.getContext('2d');
+      const opts = mergeOpts(def.opts);
+      opts.plugins = opts.plugins || {};
+      opts.plugins.legend = opts.plugins.legend || {};
+      opts.plugins.legend.labels = {color: '#e2e8f0', font: {size: 9}};
+      opts.plugins.legend.position = 'top';
+      opts.plugins.title = {display: true, text: def.label, color: '#94a3b8', font: {size: 10}};
+
+      const datasets = def.datasets.map(function(ds) {
+        return {
+          label: ds.label,
+          borderColor: ds.borderColor,
+          backgroundColor: ds.backgroundColor || 'transparent',
+          borderWidth: 1.5,
+          borderDash: ds.borderDash || [],
+          tension: 0.3,
+          pointRadius: 0,
+          fill: ds.fill || false,
+          data: [],
+        };
+      });
+
+      const chart = new Chart(ctx, {
+        type: def.type || 'line',
+        data: {labels: [], datasets: datasets},
+        options: opts,
+      });
+      this.charts[jobId][def.key] = chart;
+      return chart;
+    }
+
+    update(jobId, ts) {
+      if (!ts || !ts.length) return;
+      const firstTs = ts[0].timestamp;
+      const labels = ts.map(function(p) { return Math.round(p.timestamp - firstTs); });
+
+      for (const def of CHART_DEFS) {
+        const sid = sanitizeId(jobId);
+        const canvasId = 'chart-' + def.key + '-' + sid;
+        const chart = this.getOrCreate(jobId, def, canvasId);
+        if (!chart) continue;
+
+        chart.data.labels = labels;
+        for (let i = 0; i < def.datasets.length; i++) {
+          const dsDef = def.datasets[i];
+          const scale = dsDef.scale || 1;
+          chart.data.datasets[i].data = ts.map(function(p) {
+            const v = p[dsDef.field];
+            return v != null ? v * scale : null;
+          });
+        }
+        chart.update('none');
+      }
+    }
+
+    cleanup(activeJobIds) {
+      const toRemove = [];
+      for (const jid in this.charts) {
+        if (!activeJobIds.has(jid)) toRemove.push(jid);
+      }
+      for (const jid of toRemove) {
+        for (const key in this.charts[jid]) {
+          this.charts[jid][key].destroy();
+        }
+        delete this.charts[jid];
+      }
+    }
+  }
+
+  const chartMgr = new ChartManager();
+  let prevJobIdSet = new Set();
+
+  function setConnState(state) {
+    const dot = document.getElementById('connDot');
+    const label = document.getElementById('connLabel');
+    dot.className = 'conn-dot ' + ({connected:'ok',disconnected:'err',connecting:'connecting'}[state]||'connecting');
+    label.textContent = {connected:'Connected',disconnected:'Disconnected',connecting:'Connecting...'}[state]||state;
+  }
+
+  function fmt(n) {
+    if (n == null) return '\u2014';
+    if (typeof n === 'number') {
+      if (Number.isInteger(n)) return n.toLocaleString();
+      return n.toLocaleString(undefined, {minimumFractionDigits:1, maximumFractionDigits:1});
+    }
+    return String(n);
+  }
+  function pct(n) {
+    if (n == null) return '\u2014';
+    return (n * 100).toFixed(1) + '%';
+  }
+  function relTime(ts) {
+    if (!ts) return '\u2014';
+    const d = (Date.now()/1000) - ts;
+    if (d < 60) return Math.floor(d) + 's ago';
+    if (d < 3600) return Math.floor(d/60) + 'm ago';
+    if (d < 86400) return Math.floor(d/3600) + 'h ago';
+    return Math.floor(d/86400) + 'd ago';
+  }
+  function absTime(ts) {
+    if (!ts) return '';
+    return new Date(ts * 1000).toLocaleString();
+  }
+  function badgeClass(status) {
+    return 'badge badge-' + (status||'queued');
+  }
+  function phaseBadge(phase) {
+    return 'phase-badge phase-' + (phase||'unknown');
+  }
+  function progressClass(status) {
+    if (status === 'succeeded') return 'progress-fill done';
+    if (status === 'failed') return 'progress-fill failed';
+    return 'progress-fill';
+  }
+
+  function chartsHtml(jobId) {
+    const sid = sanitizeId(jobId);
+    let h = '<div class="charts-grid" id="charts-' + sid + '">';
+    for (const def of CHART_DEFS) {
+      h += '<div class="chart-wrap"><canvas id="chart-' + def.key + '-' + sid + '"></canvas></div>';
+    }
+    h += '</div>';
+    return h;
+  }
+
+  function renderJobs(data) {
+    const container = document.getElementById('content');
+    const jobs = (data.jobs || []).slice().sort(function(a,b) { return (b.created_at||0) - (a.created_at||0); });
+    if (!jobs.length) {
+      container.innerHTML = '<div class="empty-state"><span class="whale">&#128051;</span>No jobs yet. Deploy a model to get started.</div>';
+      chartMgr.cleanup(new Set());
+      prevJobIdSet = new Set();
+      return;
+    }
+
+    const curJobIds = new Set(jobs.map(function(j){ return j.job_id; }));
+    // Only rebuild DOM when the set of job IDs changes
+    const needsRebuild = curJobIds.size !== prevJobIdSet.size || [...curJobIds].some(function(id){ return !prevJobIdSet.has(id); });
+
+    if (needsRebuild) {
+      let html = '<div class="grid">';
+      for (const job of jobs) {
+        const jid = job.job_id;
+        const sid = sanitizeId(jid);
+        const isActive = ACTIVE_STATUSES.has(job.status);
+        html += '<div class="card" id="card-' + sid + '">';
+        html += '<div class="card-header">';
+        html += '<span class="model-name">' + esc(job.model_name||'unknown') + '</span>';
+        html += '<span class="' + badgeClass(job.status) + '" id="badge-' + sid + '">' + esc(job.status||'unknown') + '</span>';
+        html += '</div>';
+        html += '<div class="job-id">' + esc(jid) + '</div>';
+        html += '<div class="progress-wrap" id="progwrap-' + sid + '"></div>';
+        html += '<div class="stats" id="stats-' + sid + '"></div>';
+        if (isActive) html += chartsHtml(jid);
+        html += '<div id="chunks-' + sid + '"></div>';
+        html += '<div id="replicas-' + sid + '"></div>';
+        html += '</div>';
+      }
+      html += '</div>';
+      container.innerHTML = html;
+      prevJobIdSet = curJobIds;
+      // Charts need canvases in DOM before creation, so cleanup old charts
+      chartMgr.cleanup(curJobIds);
+    }
+
+    // Update each card's dynamic content
+    for (const job of jobs) {
+      const jid = job.job_id;
+      const sid = sanitizeId(jid);
+      const m = (data.metrics||{})[jid] || {};
+      const ch = (data.chunks||{})[jid] || null;
+      const reps = (data.replicas||{})[jid] || [];
+      const prog = job.progress || 0;
+      const isActive = ACTIVE_STATUSES.has(job.status);
+
+      // Badge
+      const badgeEl = document.getElementById('badge-' + sid);
+      if (badgeEl) {
+        badgeEl.className = badgeClass(job.status);
+        badgeEl.textContent = job.status || 'unknown';
+      }
+
+      // Progress bar
+      const progEl = document.getElementById('progwrap-' + sid);
+      if (progEl) {
+        progEl.innerHTML = '<div class="progress-label"><span>Progress</span><span>' + pct(prog) + '</span></div>'
+          + '<div class="progress-bar"><div class="' + progressClass(job.status) + '" style="width:' + (prog*100).toFixed(1) + '%"></div></div>';
+      }
+
+      // Stats
+      const statsEl = document.getElementById('stats-' + sid);
+      if (statsEl) {
+        let sh = '';
+        sh += stat('Lines', fmt(job.num_lines));
+        sh += stat('Created', relTime(job.created_at), absTime(job.created_at));
+        sh += stat('Updated', relTime(job.last_updated_at));
+        if (job.instance_type) sh += stat('Instance', job.instance_type);
+        if (job.tp || job.pp) sh += stat('TP/PP', (job.tp||'?') + '/' + (job.pp||'?'));
+        if (m.avg_generation_throughput_toks_per_s) sh += stat('Throughput', fmt(m.avg_generation_throughput_toks_per_s) + ' tok/s');
+        if (m.gpu_cache_usage_perc != null && m.gpu_cache_usage_perc > 0) sh += stat('KV Cache', pct(m.gpu_cache_usage_perc));
+        if (m.num_requests_running != null && m.num_requests_running > 0) sh += stat('Running', fmt(m.num_requests_running));
+        if (m.num_requests_waiting != null && m.num_requests_waiting > 0) sh += stat('Waiting', fmt(m.num_requests_waiting));
+        if (m.request_success_total) sh += stat('Completed', fmt(m.request_success_total));
+        if (m.gpu_sm_util_pct) sh += stat('SM Util', fmt(m.gpu_sm_util_pct) + '%');
+        statsEl.innerHTML = sh;
+      }
+
+      // Chunks
+      const chunksEl = document.getElementById('chunks-' + sid);
+      if (chunksEl) {
+        if (ch && ch.total > 0) {
+          const chProg = ch.total > 0 ? ch.completed / ch.total : 0;
+          chunksEl.innerHTML = '<div class="chunk-section">'
+            + '<div class="chunk-header">Chunks: ' + ch.completed + '/' + ch.total + ' completed</div>'
+            + '<div class="progress-bar"><div class="progress-fill" style="width:' + (chProg*100).toFixed(1) + '%"></div></div>'
+            + '<div class="stats" style="margin-top:0.4rem">'
+            + stat('Pending', fmt(ch.pending))
+            + stat('Inflight', fmt(ch.inflight))
+            + stat('Failed', fmt(ch.failed))
+            + '</div></div>';
+        } else {
+          chunksEl.innerHTML = '';
+        }
+      }
+
+      // Replicas
+      const repsEl = document.getElementById('replicas-' + sid);
+      if (repsEl) {
+        if (reps.length) {
+          let rh = '<div class="replica-section">';
+          rh += '<div class="replica-header">Replicas (' + reps.length + ')</div>';
+          rh += '<table class="replica-table"><thead><tr>';
+          rh += '<th>Replica</th><th>Phase</th><th>Region</th><th>Market</th><th>Instance</th>';
+          rh += '</tr></thead><tbody>';
+          for (const r of reps) {
+            rh += '<tr>';
+            rh += '<td style="font-size:0.65rem">' + esc(r.replica_id||'\u2014') + '</td>';
+            rh += '<td><span class="' + phaseBadge(r.phase) + '">' + esc(r.phase||'\u2014') + '</span></td>';
+            rh += '<td>' + esc(r.region||'\u2014') + '</td>';
+            rh += '<td>' + esc(r.market||'\u2014') + '</td>';
+            rh += '<td>' + esc(r.instance_type||'\u2014') + '</td>';
+            rh += '</tr>';
+          }
+          rh += '</tbody></table></div>';
+          repsEl.innerHTML = rh;
+        } else {
+          repsEl.innerHTML = '';
+        }
+      }
+
+      // Accumulate timeseries and update charts for active jobs
+      if (isActive && Object.keys(m).length > 0) {
+        if (!jobTimeseries[jid]) jobTimeseries[jid] = [];
+        const point = Object.assign({timestamp: Date.now() / 1000}, m);
+        jobTimeseries[jid].push(point);
+        if (jobTimeseries[jid].length > MAX_TS_POINTS) {
+          jobTimeseries[jid] = jobTimeseries[jid].slice(-MAX_TS_POINTS);
+        }
+        chartMgr.update(jid, jobTimeseries[jid]);
+      }
+    }
+
+    // Cleanup charts for removed jobs
+    const curIds = new Set(jobs.map(function(j){ return j.job_id; }));
+    chartMgr.cleanup(curIds);
+    // Clean timeseries for removed jobs
+    for (const jid in jobTimeseries) {
+      if (!curIds.has(jid)) delete jobTimeseries[jid];
+    }
+  }
+
+  function stat(label, value, title) {
+    const t = title ? ' title="' + esc(title) + '"' : '';
+    return '<span class="stat"' + t + '><span class="stat-label">' + esc(label) + ' </span><span class="stat-value">' + esc(String(value)) + '</span></span>';
+  }
+
+  function esc(s) {
+    if (!s) return '';
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function connect() {
+    if (es) { try { es.close(); } catch(e){} }
+    setConnState('connecting');
+    es = new EventSource(serverUrl + '/dashboard/stream');
+    es.onopen = function() { setConnState('connected'); };
+    es.onmessage = function(ev) {
+      try {
+        const data = JSON.parse(ev.data);
+        renderJobs(data);
+      } catch(e) { console.error('parse error', e); }
+    };
+    es.onerror = function() {
+      setConnState('disconnected');
+      es.close();
+      es = null;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      reconnectTimer = setTimeout(connect, 3000);
+    };
+  }
+
+  connect();
+})();
+</script>
+</body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@dashboard_router.get("/dashboard")
+async def serve_dashboard():
+    """Serve the Orca web dashboard."""
+    return HTMLResponse(DASHBOARD_HTML)
+
+
+@dashboard_router.get("/dashboard/stream")
+async def dashboard_stream(request: Request):
+    """SSE endpoint streaming fleet-wide job/metrics/chunk data every 2 s."""
+
+    async def _generate():
+        from orca_server.job_manager import get_job_tracker
+        from orca_server.chunk_manager import get_chunk_manager
+
+        while True:
+            if await request.is_disconnected():
+                break
+
+            payload = {"jobs": [], "metrics": {}, "chunks": {}, "replicas": {}}
+
+            try:
+                # ---- Jobs ----
+                tracker = get_job_tracker()
+                with tracker.lock:
+                    job_items = list(tracker.jobs.items())
+
+                for job_id, rec in job_items:
+                    try:
+                        job_data = {
+                            "job_id": job_id,
+                            "status": rec.status,
+                            "progress": round(rec.state.progress_frac, 4),
+                            "model_name": rec.state.spec.model_name,
+                            "num_lines": rec.state.spec.num_lines,
+                            "created_at": rec.created_at,
+                            "last_updated_at": rec.last_updated_at,
+                            "head_ip": rec.head_ip,
+                            "endpoint_url": rec.endpoint_url,
+                            "instance_type": rec.state.instance_types,
+                            "tp": rec.state.tp,
+                            "pp": rec.state.pp,
+                        }
+                        payload["jobs"].append(job_data)
+                    except Exception:
+                        logger.debug("dashboard: error serialising job %s", job_id, exc_info=True)
+
+                # ---- Metrics ----
+                try:
+                    mc = getattr(request.app.state, "metrics_collector", None)
+                    if mc is not None:
+                        for job_id, _rec in job_items:
+                            try:
+                                snap = mc.get_aggregated(job_id)
+                                if snap is not None:
+                                    payload["metrics"][job_id] = {
+                                        "avg_generation_throughput_toks_per_s": snap.avg_generation_throughput_toks_per_s,
+                                        "avg_prompt_throughput_toks_per_s": snap.avg_prompt_throughput_toks_per_s,
+                                        "gpu_cache_usage_perc": snap.gpu_cache_usage_perc,
+                                        "num_requests_running": snap.num_requests_running,
+                                        "num_requests_waiting": snap.num_requests_waiting,
+                                        "num_requests_swapped": snap.num_requests_swapped,
+                                        "request_success_total": snap.request_success_total,
+                                        "num_preemptions_total": snap.num_preemptions_total,
+                                        "gpu_sm_util_pct": snap.gpu_sm_util_pct,
+                                        "gpu_mem_bw_util_pct": snap.gpu_mem_bw_util_pct,
+                                        "ttft_ms_p50": snap.ttft_ms_p50,
+                                        "ttft_ms_p95": snap.ttft_ms_p95,
+                                        "tpot_ms_p50": snap.tpot_ms_p50,
+                                        "tpot_ms_p95": snap.tpot_ms_p95,
+                                    }
+                            except Exception:
+                                logger.debug("dashboard: metrics error for %s", job_id, exc_info=True)
+                except Exception:
+                    logger.debug("dashboard: metrics_collector error", exc_info=True)
+
+                # ---- Chunks ----
+                try:
+                    if getattr(request.app.state, "redis_available", False):
+                        cm = get_chunk_manager()
+                        for job_id, rec in job_items:
+                            try:
+                                prog = cm.get_progress(job_id)
+                                if prog and prog.get("total", 0) > 0:
+                                    payload["chunks"][job_id] = {
+                                        "total": prog["total"],
+                                        "pending": prog["pending"],
+                                        "inflight": prog["inflight"],
+                                        "completed": prog["completed"],
+                                        "failed": prog["failed"],
+                                    }
+                            except Exception:
+                                logger.debug("dashboard: chunk error for %s", job_id, exc_info=True)
+                except Exception:
+                    logger.debug("dashboard: chunk_manager error", exc_info=True)
+
+                # ---- Replicas ----
+                try:
+                    cluster_mgr = getattr(request.app.state, "cluster_manager", None)
+                    if cluster_mgr is not None:
+                        for job_id, _rec in job_items:
+                            try:
+                                states = cluster_mgr.get_replica_states(job_id)
+                                if states:
+                                    replicas = []
+                                    for rid, rstate in states.items():
+                                        replicas.append({
+                                            "replica_id": rid,
+                                            "phase": rstate.get("phase", "unknown"),
+                                            "region": rstate.get("region", ""),
+                                            "market": rstate.get("market", ""),
+                                            "instance_type": rstate.get("instance_type", ""),
+                                            "has_metrics": rstate.get("has_metrics", False),
+                                        })
+                                    if replicas:
+                                        payload["replicas"][job_id] = replicas
+                            except Exception:
+                                logger.debug("dashboard: replica error for %s", job_id, exc_info=True)
+                except Exception:
+                    logger.debug("dashboard: cluster_manager error", exc_info=True)
+
+            except Exception:
+                logger.debug("dashboard: top-level SSE error", exc_info=True)
+
+            yield f"data: {json.dumps(payload)}\n\n"
+            await asyncio.sleep(2)
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/orca_server/job_templates.py
+++ b/orca_server/job_templates.py
@@ -67,7 +67,7 @@ def replace_run_vllm(
 ):
     replace = {}
 
-    if request.s3_models:
+    if request.s3_model_path:
         replace["model"] = f"/models/{request.model_name}"
     else:
         replace["model"] = request.model_name

--- a/orca_server/launcher.py
+++ b/orca_server/launcher.py
@@ -290,8 +290,9 @@ async def sp_launch_vllm_batch(
                 from orca_server.monitoring import get_metrics_collector
                 from orca_server.metrics_db import get_metrics_db
                 last_snap = get_metrics_collector().get_latest(config.decision_id)
+                db = get_metrics_db()
                 try:
-                    get_metrics_db().push_run(
+                    db.push_run(
                         job_id=config.decision_id,
                         metrics_csv_path=str(base_dir / "metrics.csv"),
                         actual_region=actual_region,
@@ -302,6 +303,33 @@ async def sp_launch_vllm_batch(
                     )
                 except Exception as db_err:
                     job_logger.warning(f"[MetricsDB] Push failed: {db_err}")
+
+                # Export timeseries to local experiment directory
+                try:
+                    import csv as _csv
+                    ts_data = db.get_timeseries(config.decision_id)
+                    if ts_data:
+                        ts_path = base_dir / "timeseries.csv"
+                        all_keys = list(ts_data[0].keys())
+                        with open(ts_path, "w", newline="") as tf:
+                            writer = _csv.DictWriter(tf, fieldnames=all_keys, extrasaction="ignore")
+                            writer.writeheader()
+                            for row in ts_data:
+                                writer.writerow(row)
+                        job_logger.info(f"[Job] Saved timeseries.csv ({len(ts_data)} samples) to {ts_path}")
+
+                        # Generate timeseries PDF
+                        try:
+                            from orca_server.plot_timeseries import plot_timeseries as _plot_ts
+                            pdf_path = base_dir / "timeseries.pdf"
+                            _metrics_csv = str(base_dir / "metrics.csv")
+                            _metrics_arg = _metrics_csv if (base_dir / "metrics.csv").exists() else None
+                            _plot_ts(str(ts_path), str(pdf_path), metrics_csv_path=_metrics_arg)
+                            job_logger.info(f"[Job] Generated timeseries.pdf at {pdf_path}")
+                        except Exception as pe:
+                            job_logger.warning(f"[Job] Timeseries plot failed: {pe}")
+                except Exception as te:
+                    job_logger.warning(f"[Job] Timeseries export failed: {te}")
 
             # Rename dir with success-/failed- prefix
             status = "success" if is_success else "failed"
@@ -406,6 +434,13 @@ async def launch_chunked_replicas(
     Each replica is an independent cluster that pulls chunks from the Redis queue
     via HTTP endpoints on the control plane.
     """
+    if not _cfg.ORCA_SERVER_URL:
+        raise ValueError(
+            "ORCA_SERVER_URL is not set. Chunked replicas need the control plane URL "
+            "to pull chunks. Start the server with --url or --tunnel, or set the "
+            "ORCA_SERVER_URL environment variable."
+        )
+
     if early_messages is None:
         early_messages = []
 
@@ -420,6 +455,7 @@ async def launch_chunked_replicas(
     )
     output_dir = Path(f"outputs/{job_dirname}")
     output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "replicas").mkdir(exist_ok=True)
     job_logger = setup_job_logger(config.decision_id, str(output_dir / "job.log"))
 
     if early_messages:

--- a/orca_server/launcher.py
+++ b/orca_server/launcher.py
@@ -17,8 +17,6 @@ import yaml
 from orca_server import config as _cfg
 from orca_server.config import (
     HF_TOKEN,
-    S3_MODEL_BUCKET,
-    S3_MODEL_PREFIX,
     VLLM_PORT,
     YAML_OUTPUT,
 )
@@ -101,10 +99,8 @@ async def sp_launch_vllm_batch(
     s3_output_dir = f"{s3_base}/{job_dirname}"
 
     # Verify model exists in S3; fall back to HuggingFace if unavailable
-    if request.s3_models:
-        s3_model_path = (
-            f"s3://{S3_MODEL_BUCKET}/{S3_MODEL_PREFIX}/{request.model_name}/"
-        )
+    if request.s3_model_path:
+        s3_model_path = request.s3_model_path.rstrip("/") + "/"
         s3_check = subprocess.run(
             ["aws", "s3", "ls", s3_model_path],
             capture_output=True,
@@ -113,10 +109,10 @@ async def sp_launch_vllm_batch(
         )
         if s3_check.returncode != 0 or not s3_check.stdout.strip():
             job_logger.warning(
-                f"[S3] Model '{request.model_name}' not found at {s3_model_path}. "
+                f"[S3] Model not found at {s3_model_path}. "
                 f"Falling back to HuggingFace download."
             )
-            request = request.model_copy(update={"s3_models": False})
+            request = request.model_copy(update={"s3_model_path": None})
         else:
             job_logger.info(f"[S3] Verified model exists at {s3_model_path}")
 
@@ -208,10 +204,12 @@ async def sp_launch_vllm_batch(
         yaml_data["envs"]["ORCA_API_KEY"] = _cfg.ORCA_API_KEY
 
         # Add S3 model weight mount if requested
-        if request.s3_models:
+        if request.s3_model_path:
+            s3_src = request.s3_model_path
+            s3_src = s3_src.rstrip("/")
             model_mount_path = f"/models/{request.model_name}"
             yaml_data["file_mounts"][model_mount_path] = {
-                "source": f"s3://{S3_MODEL_BUCKET}/{S3_MODEL_PREFIX}/{request.model_name}",
+                "source": s3_src,
                 "mode": "COPY",
             }
 
@@ -240,11 +238,11 @@ async def sp_launch_vllm_batch(
         }
 
         # Add S3 model weight mount if requested
-        if request.s3_models:
+        if request.s3_model_path:
+            s3_src = request.s3_model_path
+            s3_src = s3_src.rstrip("/")
             model_mount_path = f"/models/{request.model_name}"
-            replace_yaml[f"file_mounts.{model_mount_path}.source"] = (
-                f"s3://{S3_MODEL_BUCKET}/{S3_MODEL_PREFIX}/{request.model_name}"
-            )
+            replace_yaml[f"file_mounts.{model_mount_path}.source"] = s3_src
             replace_yaml[f"file_mounts.{model_mount_path}.mode"] = "COPY"
 
         update_yaml_file("templates/vllm.yaml", replace_yaml, YAML_OUTPUT)
@@ -587,6 +585,15 @@ async def _launch_chunked_replica(
         "envs.AVG_OUTPUT_TOKENS": str(request.avg_output_tokens or 1024),
         "envs.VLLM_USE_V1": "1" if _cfg.supports_vllm_v1(config.instance_type) else "0",
     }
+
+    # Add S3 model weight mount if requested
+    if request.s3_model_path:
+        s3_src = request.s3_model_path
+        s3_src = s3_src.rstrip("/")
+        model_mount_path = f"/models/{request.model_name}"
+        replace_yaml[f"file_mounts.{model_mount_path}.source"] = s3_src
+        replace_yaml[f"file_mounts.{model_mount_path}.mode"] = "COPY"
+
     update_yaml_file("templates/vllm_chunked.yaml", replace_yaml, yaml_output)
 
     task = sky.Task.from_yaml(yaml_output)

--- a/orca_server/monitoring.py
+++ b/orca_server/monitoring.py
@@ -110,6 +110,8 @@ class MetricsSnapshot:
     # GPU hardware utilization (from pynvml via sidecar)
     gpu_sm_util_pct: float = 0.0
     gpu_mem_bw_util_pct: float = 0.0
+    # Per-GPU metrics (from pynvml via sidecar): {gpu0_sm_pct, gpu0_membw_pct, gpu0_mem_gb, gpu0_mem_pct, ...}
+    per_gpu: dict | None = None
     # Live per-token counters (from SSE stream via sidecar, smoother than Prometheus)
     live_gen_tokens_total: float = 0.0
     live_prompt_tokens_total: float = 0.0
@@ -164,7 +166,7 @@ class MetricsSnapshot:
         return snap
 
     def to_dict(self) -> dict:
-        return {
+        d = {
             "job_id": self.job_id,
             "timestamp": self.timestamp,
             "replica_id": self.replica_id,
@@ -205,6 +207,10 @@ class MetricsSnapshot:
             "live_gen_tokens_total": self.live_gen_tokens_total,
             "live_prompt_tokens_total": self.live_prompt_tokens_total,
         }
+        # Flatten per-GPU metrics into top-level keys for timeseries CSV
+        if self.per_gpu:
+            d.update(self.per_gpu)
+        return d
 
 
 _SUM_FIELDS = {

--- a/orca_server/plot_timeseries.py
+++ b/orca_server/plot_timeseries.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""
+Generate publication-quality PDF figures from Orca timeseries.csv files.
+
+Usage:
+    python -m orca_server.plot_timeseries outputs/.../timeseries.csv
+    python -m orca_server.plot_timeseries outputs/.../timeseries.csv --metrics outputs/.../metrics.csv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import math
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Colorblind-friendly palette
+# ---------------------------------------------------------------------------
+COLORS = {
+    'gen_throughput': '#C73E1D',
+    'prompt_throughput': '#2E8B57',
+    'kv_cache': '#E69F00',
+    'running': '#0072B2',
+    'waiting': '#D55E00',
+    'swapped': '#009E73',
+    'sm_util': '#0072B2',
+    'membw_util': '#D55E00',
+    'ttft': '#0072B2',
+    'tpot': '#D55E00',
+    'e2e': '#009E73',
+    'completions': '#2E8B57',
+    'preemptions': '#C73E1D',
+}
+
+
+def _apply_style():
+    """Apply publication-quality rcParams (call after importing matplotlib)."""
+    import matplotlib.pyplot as plt
+
+    plt.rcParams.update({
+        'font.family': 'serif',
+        'font.serif': ['Times New Roman', 'DejaVu Serif', 'serif'],
+        'font.size': 10,
+        'axes.titlesize': 11,
+        'axes.labelsize': 10,
+        'xtick.labelsize': 9,
+        'ytick.labelsize': 9,
+        'legend.fontsize': 8,
+        'figure.titlesize': 12,
+        'axes.linewidth': 0.8,
+        'grid.linewidth': 0.5,
+        'lines.linewidth': 1.2,
+        'axes.spines.top': False,
+        'axes.spines.right': False,
+        'figure.dpi': 150,
+        'savefig.dpi': 300,
+        'savefig.bbox': 'tight',
+        'savefig.pad_inches': 0.1,
+    })
+
+
+def _safe_float(val, default=float('nan')):
+    """Convert a value to float, returning *default* for None / empty / non-numeric."""
+    if val is None or val == '' or val == 'None':
+        return default
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _load_csv(path: str) -> list[dict]:
+    """Load a CSV file as a list of dicts."""
+    rows = []
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def _load_metrics_summary(path: str) -> dict:
+    """Load a metrics.csv (metric,value format) into a dict."""
+    result = {}
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            key = row.get('metric', '')
+            val = row.get('value', '')
+            result[key] = val
+    return result
+
+
+def _column_has_data(rows: list[dict], col: str) -> bool:
+    """Return True if *col* exists and has at least one non-zero, non-NaN value."""
+    for row in rows:
+        v = _safe_float(row.get(col))
+        if not math.isnan(v) and v != 0.0:
+            return True
+    return False
+
+
+def plot_timeseries(
+    csv_path: str,
+    output_path: Optional[str] = None,
+    metrics_csv_path: Optional[str] = None,
+) -> str:
+    """Generate a multi-panel timeseries PDF from timeseries.csv.
+
+    Args:
+        csv_path: Path to timeseries.csv.
+        output_path: Output PDF path. Defaults to timeseries.pdf in the same
+            directory as the CSV.
+        metrics_csv_path: Optional path to metrics.csv for a summary text panel.
+
+    Returns:
+        The path to the generated PDF.
+    """
+    # Late imports so the module is importable even without matplotlib.
+    try:
+        import matplotlib
+        matplotlib.use('Agg')  # non-interactive backend
+        import matplotlib.pyplot as plt
+        import matplotlib.ticker as ticker
+        import numpy as np
+    except ImportError:
+        raise RuntimeError(
+            "matplotlib and numpy are required for plotting. "
+            "Install with: pip install matplotlib numpy"
+        )
+
+    _apply_style()
+
+    # ------------------------------------------------------------------
+    # Load data
+    # ------------------------------------------------------------------
+    csv_p = Path(csv_path)
+    if output_path is None:
+        output_path = str(csv_p.with_name('timeseries.pdf'))
+
+    rows = _load_csv(csv_path)
+    if not rows:
+        logger.warning("timeseries.csv is empty — skipping plot generation")
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Parse columns into numpy arrays
+    # ------------------------------------------------------------------
+    timestamps = np.array([_safe_float(r.get('timestamp', 0)) for r in rows])
+    t0 = np.nanmin(timestamps)
+    t_rel = timestamps - t0  # seconds since first sample
+
+    # Filter out pre-warmup rows where all interesting metrics are zero
+    _interesting = [
+        'avg_generation_throughput_toks_per_s',
+        'avg_prompt_throughput_toks_per_s',
+        'num_requests_running',
+        'num_requests_waiting',
+    ]
+    keep_mask = np.zeros(len(rows), dtype=bool)
+    for col in _interesting:
+        vals = np.array([_safe_float(r.get(col)) for r in rows])
+        keep_mask |= (~np.isnan(vals)) & (vals != 0.0)
+    # Always keep all rows if filtering would remove everything
+    if np.any(keep_mask):
+        idx = np.where(keep_mask)[0]
+        rows = [rows[i] for i in idx]
+        t_rel = t_rel[idx]
+
+    n = len(rows)
+    if n == 0:
+        logger.warning("All rows filtered out — skipping plot generation")
+        return output_path
+
+    # Decide time unit
+    time_unit = 's'
+    time_divisor = 1.0
+    if t_rel[-1] > 120:
+        time_unit = 'min'
+        time_divisor = 60.0
+    t_plot = t_rel / time_divisor
+
+    # Helper to extract a column as float array
+    def col(name):
+        return np.array([_safe_float(r.get(name)) for r in rows])
+
+    # ------------------------------------------------------------------
+    # Determine which panels have data
+    # ------------------------------------------------------------------
+    panel_specs = []  # (panel_id, title)
+
+    # 1. Throughput
+    gen_tp = col('avg_generation_throughput_toks_per_s')
+    prompt_tp = col('avg_prompt_throughput_toks_per_s')
+    if np.any(~np.isnan(gen_tp)) or np.any(~np.isnan(prompt_tp)):
+        panel_specs.append('throughput')
+
+    # 2. KV Cache
+    kv_raw = col('gpu_cache_usage_perc')
+    kv_pct = kv_raw * 100.0  # convert 0-1 to 0-100
+    if np.any(~np.isnan(kv_raw)):
+        panel_specs.append('kv_cache')
+
+    # 3. Scheduler Queues
+    running = col('num_requests_running')
+    waiting = col('num_requests_waiting')
+    swapped = col('num_requests_swapped')
+    if np.any(~np.isnan(running)):
+        panel_specs.append('scheduler')
+
+    # 4. GPU Utilization
+    sm_util = col('gpu_sm_util_pct')
+    membw_util = col('gpu_mem_bw_util_pct')
+    if np.any(~np.isnan(sm_util)) or np.any(~np.isnan(membw_util)):
+        panel_specs.append('gpu_util')
+
+    # 5. TTFT
+    ttft_p50 = col('ttft_ms_p50')
+    ttft_p95 = col('ttft_ms_p95')
+    ttft_p99 = col('ttft_ms_p99')
+    if np.any(~np.isnan(ttft_p50)):
+        panel_specs.append('ttft')
+
+    # 6. TPOT
+    tpot_p50 = col('tpot_ms_p50')
+    tpot_p95 = col('tpot_ms_p95')
+    tpot_p99 = col('tpot_ms_p99')
+    if np.any(~np.isnan(tpot_p50)):
+        panel_specs.append('tpot')
+
+    # 7. E2E
+    e2e_p50 = col('e2e_ms_p50')
+    e2e_p95 = col('e2e_ms_p95')
+    e2e_p99 = col('e2e_ms_p99')
+    if np.any(~np.isnan(e2e_p50)):
+        panel_specs.append('e2e')
+
+    # 8. Completions
+    completions = col('request_success_total')
+    preemptions = col('num_preemptions_total')
+    if np.any(~np.isnan(completions)):
+        panel_specs.append('completions')
+
+    # Optional summary panel
+    summary = None
+    if metrics_csv_path and Path(metrics_csv_path).exists():
+        try:
+            summary = _load_metrics_summary(metrics_csv_path)
+            if summary:
+                panel_specs.append('summary')
+        except Exception:
+            pass
+
+    if not panel_specs:
+        logger.warning("No plottable data found — skipping plot generation")
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Precompute KV-full regions for cross-panel shading
+    # ------------------------------------------------------------------
+    kv_full_regions = []
+    if 'kv_cache' in panel_specs:
+        kv_full_mask = kv_pct >= 99.0
+        in_region = False
+        region_start = None
+        for i in range(len(kv_full_mask)):
+            if kv_full_mask[i] and not in_region:
+                region_start = t_plot[i]
+                in_region = True
+            elif not kv_full_mask[i] and in_region:
+                kv_full_regions.append((region_start, t_plot[i]))
+                in_region = False
+        if in_region:
+            kv_full_regions.append((region_start, t_plot[-1]))
+
+    def shade_kv_full(ax):
+        for (a, b) in kv_full_regions:
+            ax.axvspan(a, b, alpha=0.10, color='#DC143C', zorder=0)
+
+    # ------------------------------------------------------------------
+    # Create figure
+    # ------------------------------------------------------------------
+    num_panels = len(panel_specs)
+    fig_height = 2.8 * num_panels
+    fig, axes = plt.subplots(num_panels, 1, figsize=(10, fig_height), sharex=True)
+    if num_panels == 1:
+        axes = [axes]
+
+    ax_map = {pid: axes[i] for i, pid in enumerate(panel_specs)}
+
+    # ------------------------------------------------------------------
+    # Panel 1: Throughput
+    # ------------------------------------------------------------------
+    if 'throughput' in ax_map:
+        ax = ax_map['throughput']
+        shade_kv_full(ax)
+
+        valid_gen = ~np.isnan(gen_tp)
+        valid_prompt = ~np.isnan(prompt_tp)
+
+        if np.any(valid_gen):
+            ax.scatter(t_plot[valid_gen], gen_tp[valid_gen],
+                       color=COLORS['gen_throughput'], alpha=0.45, s=18,
+                       label='Generation tok/s', zorder=2)
+            active = gen_tp[valid_gen & (gen_tp > 0)]
+            if len(active) > 0:
+                mean_gen = np.mean(active)
+                ax.axhline(mean_gen, color=COLORS['gen_throughput'],
+                           linestyle='--', alpha=0.5, linewidth=1.0)
+                ax.text(t_plot[-1], mean_gen, f'  avg {mean_gen:.0f}',
+                        fontsize=8, color=COLORS['gen_throughput'], va='center')
+
+        if np.any(valid_prompt):
+            ax.scatter(t_plot[valid_prompt], prompt_tp[valid_prompt],
+                       color=COLORS['prompt_throughput'], alpha=0.40, s=15,
+                       label='Prompt tok/s', zorder=2)
+
+        ax.set_title('Throughput (tok/s)')
+        ax.set_ylabel('Throughput (tok/s)')
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='upper right', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Panel 2: KV Cache Utilization
+    # ------------------------------------------------------------------
+    if 'kv_cache' in ax_map:
+        ax = ax_map['kv_cache']
+        valid = ~np.isnan(kv_pct)
+        if np.any(valid):
+            ax.plot(t_plot[valid], kv_pct[valid],
+                    color=COLORS['kv_cache'], linewidth=1.5, label='KV Cache Util.')
+            ax.fill_between(t_plot[valid], 0, kv_pct[valid],
+                            alpha=0.3, color=COLORS['kv_cache'])
+        # Shade preemption zones
+        for (a, b) in kv_full_regions:
+            ax.axvspan(a, b, alpha=0.15, color='#DC143C', zorder=0)
+        ax.set_title('KV Cache Utilization (%)')
+        ax.set_ylabel('KV Cache Util. (%)')
+        ax.set_ylim(-2, 105)
+        ax.yaxis.set_major_locator(ticker.MultipleLocator(25))
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='lower right', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Panel 3: Scheduler Queue Depth
+    # ------------------------------------------------------------------
+    if 'scheduler' in ax_map:
+        ax = ax_map['scheduler']
+        shade_kv_full(ax)
+        for arr, name, color_key in [
+            (running, 'Running', 'running'),
+            (waiting, 'Waiting', 'waiting'),
+            (swapped, 'Swapped', 'swapped'),
+        ]:
+            valid = ~np.isnan(arr)
+            if np.any(valid):
+                ax.plot(t_plot[valid], arr[valid],
+                        color=COLORS[color_key], linewidth=1.5, label=name)
+        ax.set_title('Scheduler Queue Depth')
+        ax.set_ylabel('Queue Depth')
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='upper right', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Panel 4: GPU Utilization
+    # ------------------------------------------------------------------
+    if 'gpu_util' in ax_map:
+        ax = ax_map['gpu_util']
+        shade_kv_full(ax)
+        valid_sm = ~np.isnan(sm_util)
+        valid_bw = ~np.isnan(membw_util)
+        if np.any(valid_sm):
+            ax.scatter(t_plot[valid_sm], sm_util[valid_sm],
+                       color=COLORS['sm_util'], alpha=0.45, s=18,
+                       label='SM Util %', zorder=2)
+        if np.any(valid_bw):
+            ax.scatter(t_plot[valid_bw], membw_util[valid_bw],
+                       color=COLORS['membw_util'], alpha=0.40, s=15,
+                       label='Mem BW Util %', zorder=2)
+        ax.set_title('GPU Utilization (%)')
+        ax.set_ylabel('Utilization (%)')
+        ax.set_ylim(-2, 105)
+        ax.yaxis.set_major_locator(ticker.MultipleLocator(25))
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='upper right', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Panel 5: TTFT
+    # ------------------------------------------------------------------
+    if 'ttft' in ax_map:
+        ax = ax_map['ttft']
+        shade_kv_full(ax)
+        base_color = COLORS['ttft']
+        for arr, style, label in [
+            (ttft_p50, '-', 'p50'),
+            (ttft_p95, '--', 'p95'),
+            (ttft_p99, ':', 'p99'),
+        ]:
+            valid = ~np.isnan(arr)
+            if np.any(valid):
+                ax.plot(t_plot[valid], arr[valid],
+                        color=base_color, linestyle=style, linewidth=1.5,
+                        label=label)
+        ax.set_title('Time to First Token (ms)')
+        ax.set_ylabel('TTFT (ms)')
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='upper right', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Panel 6: TPOT
+    # ------------------------------------------------------------------
+    if 'tpot' in ax_map:
+        ax = ax_map['tpot']
+        shade_kv_full(ax)
+        base_color = COLORS['tpot']
+        for arr, style, label in [
+            (tpot_p50, '-', 'p50'),
+            (tpot_p95, '--', 'p95'),
+            (tpot_p99, ':', 'p99'),
+        ]:
+            valid = ~np.isnan(arr)
+            if np.any(valid):
+                ax.plot(t_plot[valid], arr[valid],
+                        color=base_color, linestyle=style, linewidth=1.5,
+                        label=label)
+        ax.set_title('Time Per Output Token (ms)')
+        ax.set_ylabel('TPOT (ms)')
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='upper right', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Panel 7: E2E Latency
+    # ------------------------------------------------------------------
+    if 'e2e' in ax_map:
+        ax = ax_map['e2e']
+        shade_kv_full(ax)
+        base_color = COLORS['e2e']
+        for arr, style, label in [
+            (e2e_p50, '-', 'p50'),
+            (e2e_p95, '--', 'p95'),
+            (e2e_p99, ':', 'p99'),
+        ]:
+            valid = ~np.isnan(arr)
+            if np.any(valid):
+                ax.plot(t_plot[valid], arr[valid],
+                        color=base_color, linestyle=style, linewidth=1.5,
+                        label=label)
+        ax.set_title('End-to-End Latency (ms)')
+        ax.set_ylabel('E2E (ms)')
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='upper right', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Panel 8: Cumulative Completions & Preemptions
+    # ------------------------------------------------------------------
+    if 'completions' in ax_map:
+        ax = ax_map['completions']
+        shade_kv_full(ax)
+        valid_c = ~np.isnan(completions)
+        valid_p = ~np.isnan(preemptions)
+        if np.any(valid_c):
+            ax.plot(t_plot[valid_c], completions[valid_c],
+                    color=COLORS['completions'], linewidth=1.5,
+                    label='Completions')
+        if np.any(valid_p):
+            ax.plot(t_plot[valid_p], preemptions[valid_p],
+                    color=COLORS['preemptions'], linewidth=1.5,
+                    label='Preemptions')
+        ax.set_title('Cumulative Completions & Preemptions')
+        ax.set_ylabel('Count')
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc='upper left', framealpha=0.9)
+
+    # ------------------------------------------------------------------
+    # Summary text panel
+    # ------------------------------------------------------------------
+    if 'summary' in ax_map and summary:
+        ax = ax_map['summary']
+        ax.axis('off')
+
+        def _sv(key, fmt='.1f', fallback='N/A'):
+            v = summary.get(key, '')
+            if v == '' or v == 'None':
+                return fallback
+            try:
+                return f'{float(v):{fmt}}'
+            except (ValueError, TypeError):
+                return str(v)
+
+        sections = [
+            ('Throughput', [
+                ('Total tok/s', _sv('total_tokens_per_sec', '.1f')),
+                ('Prefill tok/s', _sv('input_tokens_per_sec', '.1f')),
+                ('Decode tok/s', _sv('output_tokens_per_sec', '.1f')),
+            ]),
+            ('Cost', [
+                ('Cost', f'${_sv("cost_for_run_usd", ".4f")}'),
+                ('Tok/dollar', _sv('tokens_per_dollar', ',.0f')),
+            ]),
+            ('Runtime', [
+                ('Elapsed', _sv('elapsed_time', '.1f') + 's'),
+                ('Requests', _sv('request_success_total', '.0f')),
+            ]),
+            ('GPU Util (avg)', [
+                ('SM util', _sv('avg_sm_util_pct', '.1f') + '%'),
+                ('Mem BW util', _sv('avg_mem_bw_util_pct', '.1f') + '%'),
+            ]),
+        ]
+
+        col_x = [0.02, 0.26, 0.50, 0.74]
+        y_top = 0.85
+        line_h = 0.20
+
+        for col_idx, (section_title, items) in enumerate(sections):
+            cx = col_x[col_idx]
+            ax.text(cx, y_top, section_title, fontsize=8, fontweight='bold',
+                    color='#1a1a1a', transform=ax.transAxes)
+            for i, (label, value) in enumerate(items):
+                y = y_top - (i + 1) * line_h
+                ax.text(cx + 0.01, y, f'{label}:', fontsize=7,
+                        color='#555555', transform=ax.transAxes)
+                ax.text(cx + 0.13, y, value, fontsize=7, fontweight='bold',
+                        color='#1a1a1a', transform=ax.transAxes)
+
+        ax.set_title('Summary', fontsize=9, fontweight='bold', loc='left', pad=2)
+        for spine in ax.spines.values():
+            spine.set_visible(True)
+            spine.set_edgecolor('#cccccc')
+            spine.set_linewidth(0.8)
+        ax.set_facecolor('#f8f8f8')
+
+    # ------------------------------------------------------------------
+    # Shared x-axis label on the bottom panel
+    # ------------------------------------------------------------------
+    axes[-1].set_xlabel(f'Time ({time_unit})')
+
+    plt.tight_layout()
+    plt.subplots_adjust(hspace=0.85)
+
+    fig.savefig(output_path, format='pdf', bbox_inches='tight')
+    plt.close(fig)
+    logger.info(f"Saved timeseries plot to {output_path}")
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate publication-quality PDF from Orca timeseries.csv')
+    parser.add_argument('csv_path', type=str,
+                        help='Path to timeseries.csv')
+    parser.add_argument('--output', '-o', type=str, default=None,
+                        help='Output PDF path (default: timeseries.pdf next to CSV)')
+    parser.add_argument('--metrics', '-m', type=str, default=None,
+                        help='Path to metrics.csv for summary panel')
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+    if not Path(args.csv_path).exists():
+        logger.error(f"File not found: {args.csv_path}")
+        return 1
+
+    try:
+        out = plot_timeseries(args.csv_path, args.output, args.metrics)
+        print(f"Generated: {out}")
+    except RuntimeError as e:
+        logger.error(str(e))
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/placement/roofline/solver_adapter.py
+++ b/placement/roofline/solver_adapter.py
@@ -68,6 +68,7 @@ class SolverInput:
     output_length: int  # avg_output_tokens
     total_tokens: int  # num_requests * (input + output)
     slo_hours: float  # slo_deadline_hours
+    num_replicas: int = 1  # number of data-parallel replicas sharing the workload
 
     # Max token limits for feasibility checking (0 = use avg as fallback)
     max_input_tokens: int = 0
@@ -116,6 +117,10 @@ class SolverOutput:
     # Memory constraints - max context length this config can actually support
     # This should be passed to vLLM as --max-model-len to avoid KV cache OOM
     max_supported_context: int = 8192
+
+    # SLO
+    estimated_runtime_hours: float = 0.0
+    meets_slo: bool = True
 
     # Error info (if success=False)
     error_message: str = ""
@@ -433,6 +438,10 @@ class PlacementSolverAdapter:
                 max_num_seqs=input.max_num_seqs,
                 max_num_batched_tokens=input.max_num_batched_tokens,
                 gpu_memory_utilization=input.gpu_memory_utilization,
+                # SLO: pass per-replica workload and deadline so solver filters by feasibility
+                # Each replica processes total_tokens/num_replicas (work is split evenly)
+                total_tokens_to_process=input.total_tokens // max(1, input.num_replicas),
+                max_total_runtime_hours=input.slo_hours,
             )
 
             # Solve using homogeneous solver (fast enumeration)
@@ -516,6 +525,8 @@ class PlacementSolverAdapter:
                 gpus_per_instance=gpus_per_instance,
                 total_gpus=homo_cfg.get("instances_used", 1) * gpus_per_instance,
                 max_supported_context=max_context,
+                estimated_runtime_hours=sol.get("estimated_runtime_hours") or 0.0,
+                meets_slo=sol.get("meets_slo", True),
                 solve_log=getattr(solver, 'solve_log', ''),
             )
 
@@ -595,6 +606,7 @@ def create_solver_input_from_request(
     max_num_batched_tokens: int = 16384,
     gpu_memory_utilization: float = 0.90,
     log_level: str = "info",
+    num_replicas: int = 1,
 ) -> SolverInput:
     """
     Create SolverInput from Orca BatchedRequest fields.
@@ -611,6 +623,7 @@ def create_solver_input_from_request(
         max_num_batched_tokens: vLLM max tokens per prefill iteration (0 = fall back to max_model_len)
         gpu_memory_utilization: vLLM gpu_memory_utilization (0.0-1.0)
         log_level: Solver log level ("debug", "info", "warning")
+        num_replicas: Number of data-parallel replicas sharing the workload (for SLO calculation)
 
     Returns:
         SolverInput ready for solver
@@ -621,6 +634,7 @@ def create_solver_input_from_request(
         output_length=avg_output_tokens,
         total_tokens=num_requests * (avg_input_tokens + avg_output_tokens),
         slo_hours=slo_deadline_hours,
+        num_replicas=max(1, num_replicas),
         max_input_tokens=max_input_tokens,
         max_output_tokens=max_output_tokens,
         max_num_seqs=max_num_seqs,

--- a/placement/roofline_magic.py
+++ b/placement/roofline_magic.py
@@ -461,6 +461,7 @@ class RooflineAWSAllocation(VPCMagic):
             max_num_batched_tokens=max_num_batched_tokens,
             gpu_memory_utilization=gpu_memory_utilization,
             log_level=log_level,
+            num_replicas=req.replicas or 1,
         )
 
         # Run solver
@@ -502,6 +503,8 @@ class RooflineAWSAllocation(VPCMagic):
             throughput_tokens_per_sec=result.throughput_tokens_per_sec,
             cost_per_hour=result.cost_per_hour,
             cost_per_million_tokens=result.cost_per_million_tokens,
+            estimated_runtime_hours=result.estimated_runtime_hours or None,
+            meets_slo=result.meets_slo,
         )
 
     def _fallback_config(self, req: BatchedRequest) -> MagicOutput:
@@ -608,6 +611,7 @@ class RooflineAWSAllocation(VPCMagic):
             max_num_batched_tokens=max_num_batched_tokens,
             gpu_memory_utilization=gpu_memory_utilization,
             log_level=log_level,
+            num_replicas=req.replicas or 1,
         )
 
         # Run solver for multiple solutions
@@ -640,6 +644,8 @@ class RooflineAWSAllocation(VPCMagic):
                 throughput_tokens_per_sec=result.throughput_tokens_per_sec,
                 cost_per_hour=result.cost_per_hour,
                 cost_per_million_tokens=result.cost_per_million_tokens,
+                estimated_runtime_hours=result.estimated_runtime_hours or None,
+                meets_slo=result.meets_slo,
             )
             outputs.append(output)
             logger.info(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = tests
+testpaths = tests LLM_placement_solver/tests
 markers =
     solver: tests needing full deps (gurobipy, torch, sky)
 addopts = -m "not solver" --tb=short -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,9 @@ PyYAML
 # Distributed chunk queue
 redis>=5.0
 
+# Plotting (timeseries PDF generation)
+matplotlib
+numpy
+
 # Solver dependencies (swap this line to use a different solver)
 -r LLM_placement_solver/requirements.txt

--- a/server.py
+++ b/server.py
@@ -1162,6 +1162,13 @@ async def submit_batch(request: BatchedRequest):
         msg = f"[Placement] Fallbacks: {len(configs) - 1}"
         logger.info(msg)
         early_messages.append(("INFO", msg))
+    if configs[0].estimated_runtime_hours is not None:
+        eta = configs[0].estimated_runtime_hours
+        slo_ok = configs[0].meets_slo
+        slo_str = "meets SLO" if slo_ok else "MISSES SLO"
+        msg = f"[SLO] ETA: {eta:.2f}h / deadline: {request.slo_deadline_hours:.1f}h — {slo_str}"
+        logger.info(msg)
+        early_messages.append(("WARNING" if not slo_ok else "INFO", msg))
 
     # Pre-launch check: ensure max_model_len can accommodate the longest prompt
     max_output = request.max_output_tokens or request.avg_output_tokens
@@ -1253,7 +1260,7 @@ async def submit_batch(request: BatchedRequest):
     )
 
     if success:
-        return {
+        resp = {
             "status": "launched",
             "job_id": used_config.decision_id,
             "config": {
@@ -1269,6 +1276,11 @@ async def submit_batch(request: BatchedRequest):
             "quota_warning": quota_warning,
             "message": f"Job submitted. Check progress at GET /job/{used_config.decision_id}",
         }
+        if used_config.estimated_runtime_hours is not None:
+            resp["estimated_runtime_hours"] = round(used_config.estimated_runtime_hours, 2)
+            resp["meets_slo"] = used_config.meets_slo
+            resp["slo_deadline_hours"] = request.slo_deadline_hours
+        return resp
     else:
         return {
             "status": "error",
@@ -1397,6 +1409,10 @@ async def test_placement(request: BatchedRequest):
                 cfg["cost_per_hour"] = mo.cost_per_hour
             if mo.cost_per_million_tokens is not None:
                 cfg["cost_per_million_tokens"] = mo.cost_per_million_tokens
+            if mo.estimated_runtime_hours is not None:
+                cfg["estimated_runtime_hours"] = round(mo.estimated_runtime_hours, 2)
+            if mo.meets_slo is not None:
+                cfg["meets_slo"] = mo.meets_slo
             configs.append(cfg)
     else:
         return {
@@ -1416,6 +1432,15 @@ async def test_placement(request: BatchedRequest):
                 f"{required_context} exceeds max_model_len ({configs[0]['max_model_len']})"
             )
 
+    # SLO warning
+    slo_warning = None
+    if configs and configs[0].get("meets_slo") is False:
+        eta = configs[0].get("estimated_runtime_hours", "?")
+        slo_warning = (
+            f"No config meets the {request.slo_deadline_hours:.1f}h SLO. "
+            f"Best estimate: {eta}h. Consider adding more replicas or relaxing the deadline."
+        )
+
     response = {
         "status": "ok",
         "solver": use_solver,
@@ -1428,6 +1453,8 @@ async def test_placement(request: BatchedRequest):
     }
     if context_warning:
         response["context_warning"] = context_warning
+    if slo_warning:
+        response["slo_warning"] = slo_warning
     if solver_log:
         response["solver_log"] = solver_log
         os.makedirs("temp", exist_ok=True)

--- a/server.py
+++ b/server.py
@@ -57,6 +57,46 @@ from quota.tracker import VPCQuotaTracker
 from orca_server.utils import make_job_id as _make_job_id
 
 
+# ---------------------------------------------------------------------------
+# Replica log forwarding
+# ---------------------------------------------------------------------------
+_replica_log_locks: dict[str, threading.Lock] = {}
+_replica_log_locks_lock = threading.Lock()
+
+# Per-replica previous snapshot for computing throughput deltas at ingest time
+_ingest_prev_snaps: dict[str, "MetricsSnapshot"] = {}
+
+
+def _write_replica_logs(job_id: str, replica_id: str, log_lines: list):
+    """Append forwarded log lines to the per-replica log file."""
+    tracker = get_job_tracker()
+    rec = tracker.get(job_id)
+    if not rec:
+        return
+    job_dirname = getattr(rec, "_job_dirname", None)
+    if not job_dirname:
+        return
+
+    replica_dir = Path(f"outputs/{job_dirname}/replicas")
+    replica_dir.mkdir(parents=True, exist_ok=True)
+    log_path = replica_dir / f"{replica_id}.log"
+
+    # Per-file lock to prevent interleaved writes from concurrent requests
+    with _replica_log_locks_lock:
+        if replica_id not in _replica_log_locks:
+            _replica_log_locks[replica_id] = threading.Lock()
+        lock = _replica_log_locks[replica_id]
+
+    with lock:
+        with open(log_path, "a") as f:
+            for entry in log_lines:
+                ts = entry.get("ts", 0)
+                msg = entry.get("msg", "")
+                if msg:
+                    timestr = datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S") if ts else ""
+                    f.write(f"{timestr}  {msg}\n")
+
+
 async def _resolve_input_file(input_file: str) -> tuple[str, str | None]:
     """If input_file is an S3 URI, download via storage backend to a temp file.
 
@@ -442,10 +482,29 @@ async def ingest_job_metrics(
         if live_prompt is not None:
             snap.live_prompt_tokens_total = float(live_prompt)
 
-        # Throughput is NOT computed here — it's computed from the ring buffer
-        # over a fixed window (INSTANT_THROUGHPUT_WINDOW_SEC, default 10s) when
-        # the snapshot is read via latest(). This avoids noisy rates from
-        # variable-interval sidecar batch items.
+        # Compute throughput from counter deltas and persist in the snapshot.
+        # Ring buffer still computes its own windowed throughput for latest(),
+        # but this ensures timeseries CSV has non-zero throughput values.
+        prev_key = f"{job_id}:{replica_id or ''}"
+        prev = _ingest_prev_snaps.get(prev_key)
+        if prev is not None:
+            dt = snap.timestamp - prev.timestamp
+            if dt > 0.1:
+                if snap.live_gen_tokens_total > 0:
+                    snap.avg_generation_throughput_toks_per_s = max(0, (
+                        snap.live_gen_tokens_total - prev.live_gen_tokens_total
+                    ) / dt)
+                    snap.avg_prompt_throughput_toks_per_s = max(0, (
+                        snap.live_prompt_tokens_total - prev.live_prompt_tokens_total
+                    ) / dt)
+                else:
+                    snap.avg_generation_throughput_toks_per_s = max(0, (
+                        snap.generation_tokens_total - prev.generation_tokens_total
+                    ) / dt)
+                    snap.avg_prompt_throughput_toks_per_s = max(0, (
+                        snap.prompt_tokens_total - prev.prompt_tokens_total
+                    ) / dt)
+        _ingest_prev_snaps[prev_key] = snap
 
         # Merge GPU hardware utilization from sidecar payload
         gpu_sm = item.get("gpu_sm_util_pct")
@@ -454,6 +513,11 @@ async def ingest_job_metrics(
             snap.gpu_sm_util_pct = float(gpu_sm)
         if gpu_bw is not None:
             snap.gpu_mem_bw_util_pct = float(gpu_bw)
+
+        # Merge per-GPU metrics (forwarded raw from sidecar's pynvml)
+        per_gpu = item.get("per_gpu")
+        if per_gpu:
+            snap.per_gpu = per_gpu
 
         # Write into aggregated job-level ring buffer
         with mc._lock:
@@ -480,6 +544,11 @@ async def ingest_job_metrics(
             db.append_timeseries(job_id, batch_for_db)
         except Exception as e:
             logger.warning("[Ingest] timeseries write failed for %s: %s", job_id, e)
+
+    # --- Replica log forwarding ---
+    log_lines = body.get("log_lines", [])
+    if log_lines and replica_id:
+        _write_replica_logs(job_id, replica_id, log_lines)
 
     return {"ok": True, "ingested": ingested}
 

--- a/server.py
+++ b/server.py
@@ -7,6 +7,8 @@ import time
 import os
 import tempfile
 import json
+from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import sky
@@ -282,6 +284,7 @@ async def lifespan(app: FastAPI):
     # Shutdown: join non-daemon monitor threads so they can finish teardown
     cm = app.state.cluster_manager
     threads = cm.get_active_threads()
+    stale_clusters = []
     if threads:
         logger.info(f"[Shutdown] Waiting for {len(threads)} monitor thread(s) to finish teardown...")
         for name, t in threads.items():
@@ -289,7 +292,16 @@ async def lifespan(app: FastAPI):
             t.join(timeout=120)
             if t.is_alive():
                 logger.warning(f"[Shutdown] Thread for {name} did not finish within 120s")
+                stale_clusters.append(name)
         logger.info("[Shutdown] All monitor threads joined.")
+
+    # Force-teardown clusters whose monitor threads didn't finish in time
+    for name in stale_clusters:
+        logger.info(f"[Shutdown] Force-tearing down orphaned cluster {name}...")
+        try:
+            sky_down_with_retry(name)
+        except Exception as e:
+            logger.error(f"[Shutdown] Failed to tear down {name}: {e}")
 
 
 app = FastAPI(
@@ -297,6 +309,9 @@ app = FastAPI(
     description="API for receiving job requests",
     lifespan=lifespan,
 )
+
+from orca_server.dashboard import dashboard_router
+app.include_router(dashboard_router)
 
 storage_backend = get_storage_backend()
 
@@ -724,19 +739,22 @@ async def _assemble_output(job_id: str):
         os.unlink(combined_path)
         job_logger.info(f"[Assembly] Uploaded combined output to {final_s3}")
 
-        # Download to local outputs/
-        from orca_server.job_manager import download_output_from_s3, prefix_job_dirname
+        # Write all outputs into the original job directory (where job.log lives),
+        # then rename with success-/partial- prefix — matching single-cluster behavior.
+        from orca_server.job_manager import download_output_from_s3, prefix_job_dirname, close_job_logger
         tracker = get_job_tracker()
         rec = tracker.get(job_id)
-        if rec:
-            job_dirname = getattr(rec, '_job_dirname', job_id)
-            status_prefix = "partial" if failed_ids else "success"
-            job_dirname = prefix_job_dirname(job_dirname, status_prefix)
-            download_output_from_s3(final_s3, job_dirname, logger=job_logger)
+        job_dirname = getattr(rec, '_job_dirname', job_id) if rec else job_id
+        base_dir = Path(f"outputs/{job_dirname}")
+        base_dir.mkdir(parents=True, exist_ok=True)
+
+        # Download assembled output.jsonl into the base directory
+        download_output_from_s3(final_s3, job_dirname, logger=job_logger)
 
         # Aggregate per-replica summaries into job-level metrics
         from orca_server.metrics_db import get_metrics_db
         db = get_metrics_db()
+        local_metrics_path = None
         try:
             agg = db.aggregate_replica_summaries(job_id)
             if agg:
@@ -762,33 +780,71 @@ async def _assemble_output(job_id: str):
                     actual_region=actual_region,
                     actual_market=actual_market,
                     solver=solver,
-                    job_dirname=job_dirname if rec else job_id,
+                    job_dirname=job_dirname,
                 )
                 os.unlink(metrics_csv_path)
                 job_logger.info(f"[Assembly] Wrote aggregated metrics to DB for {job_id}")
 
-                # Upload aggregated metrics.csv to S3
-                agg_metrics_path = f"/tmp/assembly_metrics_final_{job_id}.csv"
-                with open(agg_metrics_path, "w", newline="") as mf:
+                # Save metrics.csv to the base experiment directory
+                local_metrics_path = base_dir / "metrics.csv"
+                with open(local_metrics_path, "w", newline="") as mf:
                     writer = _csv.writer(mf)
                     writer.writerow(["metric", "value"])
                     for k, v in agg.items():
                         if isinstance(v, float):
                             v = f"{v:.4f}"
                         writer.writerow([k, v])
+                job_logger.info(f"[Assembly] Saved metrics.csv to {local_metrics_path}")
+
+                # Upload aggregated metrics.csv to S3
                 metrics_s3 = f"{s3_output_base}/metrics.csv"
-                await storage_backend.upload_file(agg_metrics_path, metrics_s3, user="system")
-                os.unlink(agg_metrics_path)
+                await storage_backend.upload_file(str(local_metrics_path), metrics_s3, user="system")
                 job_logger.info(f"[Assembly] Uploaded aggregated metrics.csv to {metrics_s3}")
             else:
                 job_logger.info(f"[Assembly] No replica summaries found for {job_id}, skipping metrics aggregation")
         except Exception as me:
             job_logger.warning(f"[Assembly] Metrics aggregation failed for {job_id}: {me}")
 
+        # Export timeseries to the base experiment directory
+        try:
+            import csv as _csv2
+            ts_data = db.get_timeseries(job_id)
+            if ts_data:
+                ts_path = base_dir / "timeseries.csv"
+                # Use all keys from first sample as columns
+                all_keys = list(ts_data[0].keys())
+                with open(ts_path, "w", newline="") as tf:
+                    writer = _csv2.DictWriter(tf, fieldnames=all_keys, extrasaction="ignore")
+                    writer.writeheader()
+                    for row in ts_data:
+                        writer.writerow(row)
+                job_logger.info(f"[Assembly] Saved timeseries.csv ({len(ts_data)} samples) to {ts_path}")
+
+                # Generate timeseries PDF
+                try:
+                    from orca_server.plot_timeseries import plot_timeseries as _plot_ts
+                    pdf_path = base_dir / "timeseries.pdf"
+                    _metrics_arg = str(local_metrics_path) if local_metrics_path and local_metrics_path.exists() else None
+                    _plot_ts(str(ts_path), str(pdf_path), metrics_csv_path=_metrics_arg)
+                    job_logger.info(f"[Assembly] Generated timeseries.pdf at {pdf_path}")
+                except Exception as pe:
+                    job_logger.warning(f"[Assembly] Timeseries plot failed: {pe}")
+        except Exception as te:
+            job_logger.warning(f"[Assembly] Timeseries export failed for {job_id}: {te}")
+
         get_job_tracker().update_status(job_id, "succeeded")
         get_job_tracker().update_progress(job_id, 1.0)
         cm.cleanup_job(job_id)
         job_logger.info(f"[Assembly] Job {job_id} completed successfully")
+
+        # Rename directory with success-/partial- prefix (after all writes are done)
+        status_prefix = "partial" if failed_ids else "success"
+        prefixed_dirname = prefix_job_dirname(job_dirname, status_prefix)
+        target_dir = Path(f"outputs/{prefixed_dirname}")
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        job_logger.info(f"[Assembly] {status_prefix.upper()}: outputs/{prefixed_dirname}")
+        close_job_logger(job_logger)
+        base_dir.rename(target_dir)
 
     except Exception as e:
         job_logger.error(f"[Assembly] Failed for {job_id}: {e}")
@@ -796,6 +852,19 @@ async def _assemble_output(job_id: str):
         cm._r.delete(lock_key)  # release assembly lock so retry can happen immediately
         if os.path.exists(combined_path):
             os.unlink(combined_path)
+        # Rename to failed- prefix so the directory is clearly marked
+        try:
+            rec = get_job_tracker().get(job_id)
+            _dirname = getattr(rec, '_job_dirname', job_id) if rec else job_id
+            _base = Path(f"outputs/{_dirname}")
+            if _base.exists():
+                _failed = Path(f"outputs/{prefix_job_dirname(_dirname, 'failed')}")
+                _failed.parent.mkdir(parents=True, exist_ok=True)
+                job_logger.info(f"[Assembly] FAILED: outputs/{prefix_job_dirname(_dirname, 'failed')}")
+                close_job_logger(job_logger)
+                _base.rename(_failed)
+        except Exception:
+            pass
 
 
 @app.get("/job/{job_id}/throughput")

--- a/server.py
+++ b/server.py
@@ -835,6 +835,16 @@ async def _assemble_output(job_id: str):
         get_job_tracker().update_status(job_id, "succeeded")
         get_job_tracker().update_progress(job_id, 1.0)
         cm.cleanup_job(job_id)
+
+        # Clean up per-replica state to prevent memory leaks
+        for key in list(_ingest_prev_snaps):
+            if key.startswith(f"{job_id}:"):
+                del _ingest_prev_snaps[key]
+        with _replica_log_locks_lock:
+            for key in list(_replica_log_locks):
+                if key.startswith(f"{job_id}:") or key.startswith(job_id):
+                    del _replica_log_locks[key]
+
         job_logger.info(f"[Assembly] Job {job_id} completed successfully")
 
         # Rename directory with success-/partial- prefix (after all writes are done)

--- a/templates/vllm_batch_runner_chunked.py
+++ b/templates/vllm_batch_runner_chunked.py
@@ -770,10 +770,64 @@ def build_metrics(
 
 
 # ---------------------------------------------------------------------------
+# Log collector — tee stdout/stderr into a buffer for forwarding
+# ---------------------------------------------------------------------------
+
+class LogCollector:
+    """Tee stdout/stderr into a buffer for forwarding to control plane."""
+
+    def __init__(self):
+        self._buffer: list = []
+        self._lock = threading.Lock()
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+
+    def install(self):
+        sys.stdout = self._Tee(self._orig_stdout, self._buffer, self._lock)
+        sys.stderr = self._Tee(self._orig_stderr, self._buffer, self._lock)
+
+    def drain(self, max_lines: int = 500) -> list:
+        with self._lock:
+            lines = self._buffer[:max_lines]
+            self._buffer = self._buffer[max_lines:]
+            return lines
+
+    class _Tee:
+        def __init__(self, original, buffer, lock):
+            self._original = original
+            self._buffer = buffer
+            self._lock = lock
+
+        def write(self, data):
+            self._original.write(data)
+            if data and data.strip():
+                with self._lock:
+                    # Cap buffer at 5000 lines to prevent memory issues
+                    if len(self._buffer) < 5000:
+                        self._buffer.append({
+                            "ts": time.time(),
+                            "msg": data.rstrip("\n"),
+                        })
+
+        def flush(self):
+            self._original.flush()
+
+        def fileno(self):
+            return self._original.fileno()
+
+        def isatty(self):
+            return False
+
+        # Forward any other attribute access to the original
+        def __getattr__(self, name):
+            return getattr(self._original, name)
+
+
+# ---------------------------------------------------------------------------
 # Sidecar (same as single-cluster runner)
 # ---------------------------------------------------------------------------
 
-def _sidecar_loop(stop_event: threading.Event, gpu_monitor: Optional["GPUMonitor"] = None, live_counter: Optional["LiveTokenCounter"] = None):
+def _sidecar_loop(stop_event: threading.Event, gpu_monitor: Optional["GPUMonitor"] = None, live_counter: Optional["LiveTokenCounter"] = None, log_collector: Optional[LogCollector] = None):
     if not ORCA_URL:
         return
 
@@ -799,6 +853,8 @@ def _sidecar_loop(stop_event: threading.Event, gpu_monitor: Optional["GPUMonitor
                         snap["gpu_sm_util_pct"] = round(sum(sm_vals) / len(sm_vals), 1)
                     if bw_vals:
                         snap["gpu_mem_bw_util_pct"] = round(sum(bw_vals) / len(bw_vals), 1)
+                    # Forward raw per-GPU metrics (sm, membw, mem_gb, mem_pct per GPU)
+                    snap["per_gpu"] = {k: v for k, v in latest.items() if k != "t"}
             # Inject live per-token counters (smooth, no completion-burst)
             if live_counter:
                 snap["live_gen_tokens_total"] = live_counter.generation_tokens
@@ -817,6 +873,10 @@ def _sidecar_loop(stop_event: threading.Event, gpu_monitor: Optional["GPUMonitor
                     payload["total"] = prog.get("total", 0)
                 except Exception:
                     pass
+                if log_collector:
+                    log_lines = log_collector.drain()
+                    if log_lines:
+                        payload["log_lines"] = log_lines
                 requests.post(ingest_url, json=payload, headers=headers, timeout=5)
                 buffer = []
                 last_push = time.time()
@@ -827,7 +887,12 @@ def _sidecar_loop(stop_event: threading.Event, gpu_monitor: Optional["GPUMonitor
 
     if buffer:
         try:
-            requests.post(ingest_url, json={"snapshots": buffer, "replica_id": REPLICA_ID}, headers=headers, timeout=5)
+            final_payload: dict = {"snapshots": buffer, "replica_id": REPLICA_ID}
+            if log_collector:
+                log_lines = log_collector.drain()
+                if log_lines:
+                    final_payload["log_lines"] = log_lines
+            requests.post(ingest_url, json=final_payload, headers=headers, timeout=5)
         except Exception:
             pass
 
@@ -836,7 +901,7 @@ def _sidecar_loop(stop_event: threading.Event, gpu_monitor: Optional["GPUMonitor
 # vLLM server lifecycle
 # ---------------------------------------------------------------------------
 
-def start_vllm_server(args) -> subprocess.Popen:
+def start_vllm_server(args, log_collector: Optional[LogCollector] = None) -> subprocess.Popen:
     cmd = [
         sys.executable, "-m", "vllm.entrypoints.openai.api_server",
         "--model", args.model,
@@ -855,10 +920,33 @@ def start_vllm_server(args) -> subprocess.Popen:
         cmd += ["--max-model-len", str(args.max_model_len)]
     env = os.environ.copy()
     env.setdefault("VLLM_LOG_STATS_INTERVAL", "1")
+
+    if log_collector:
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            env=env, bufsize=1, text=True,
+        )
+
+        def _reader():
+            try:
+                for line in proc.stdout:
+                    log_collector._orig_stdout.write(line)
+                    log_collector._orig_stdout.flush()
+                    stripped = line.rstrip("\n")
+                    if stripped:
+                        with log_collector._lock:
+                            if len(log_collector._buffer) < 5000:
+                                log_collector._buffer.append({"ts": time.time(), "msg": stripped})
+            except Exception:
+                pass
+
+        threading.Thread(target=_reader, daemon=True, name="vllm-log-reader").start()
+        return proc
+
     return subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=env)
 
 
-def wait_for_server(timeout_sec: int = 600) -> float:
+def wait_for_server(timeout_sec: int = 1200) -> float:
     start = time.time()
     while time.time() - start < timeout_sec:
         try:
@@ -1378,9 +1466,13 @@ def main():
     job_start_time = time.time()
     job_start_timestamp = datetime.now().isoformat()
 
+    # 0. Install log collector (before vLLM so we capture startup output)
+    log_collector = LogCollector()
+    log_collector.install()
+
     # 1. Start vLLM server
     _report_phase("loading_model")
-    proc = start_vllm_server(args)
+    proc = start_vllm_server(args, log_collector=log_collector)
     try:
         print("[Runner] Waiting for vLLM server to be ready...")
         model_load_sec = wait_for_server()
@@ -1402,10 +1494,10 @@ def main():
         metrics_poller = MetricsPoller()
         live_counter = LiveTokenCounter()
 
-        # 5. Start sidecar (with GPU monitor + live token counter)
+        # 5. Start sidecar (with GPU monitor + live token counter + log collector)
         stop_sidecar = threading.Event()
         sidecar_thread = threading.Thread(
-            target=_sidecar_loop, args=(stop_sidecar, gpu_monitor, live_counter),
+            target=_sidecar_loop, args=(stop_sidecar, gpu_monitor, live_counter, log_collector),
             daemon=True, name="orca-sidecar",
         )
         sidecar_thread.start()

--- a/templates/vllm_batch_runner_server.py
+++ b/templates/vllm_batch_runner_server.py
@@ -402,7 +402,8 @@ class MetricsPoller:
 # Sidecar — push to control plane (bonus, works when reachable)
 # ---------------------------------------------------------------------------
 
-def _sidecar_loop(stop_event: threading.Event, orca_url: str, orca_key: str, job_id: str, live_counter: Optional[LiveTokenCounter] = None):
+def _sidecar_loop(stop_event: threading.Event, orca_url: str, orca_key: str, job_id: str, live_counter: Optional[LiveTokenCounter] = None, gpu_monitor_ref: list | None = None):
+    """gpu_monitor_ref is a mutable [GPUMonitor | None] list so the monitor can be set after thread start."""
     if not orca_url:
         return
 
@@ -421,6 +422,18 @@ def _sidecar_loop(stop_event: threading.Event, orca_url: str, orca_key: str, job
             if live_counter:
                 snap["live_gen_tokens_total"] = live_counter.generation_tokens
                 snap["live_prompt_tokens_total"] = live_counter.prompt_tokens
+            # Inject GPU hardware utilization from pynvml
+            gpu_mon = gpu_monitor_ref[0] if gpu_monitor_ref else None
+            if gpu_mon:
+                latest = gpu_mon.get_latest()
+                if latest:
+                    sm_vals = [v for k, v in latest.items() if "_sm_pct" in k]
+                    bw_vals = [v for k, v in latest.items() if "_membw_pct" in k]
+                    if sm_vals:
+                        snap["gpu_sm_util_pct"] = round(sum(sm_vals) / len(sm_vals), 1)
+                    if bw_vals:
+                        snap["gpu_mem_bw_util_pct"] = round(sum(bw_vals) / len(bw_vals), 1)
+                    snap["per_gpu"] = {k: v for k, v in latest.items() if k != "t"}
             buffer.append(snap)
         except Exception:
             pass
@@ -526,7 +539,7 @@ def start_vllm_server(args) -> subprocess.Popen:
     return subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=env)
 
 
-def wait_for_server(timeout_sec: int = 600) -> float:
+def wait_for_server(timeout_sec: int = 1200) -> float:
     start = time.time()
     while time.time() - start < timeout_sec:
         try:
@@ -1175,10 +1188,14 @@ def main():
         orca_key = os.getenv("ORCA_API_KEY", "")
         job_id = os.getenv("JOB_ID", "unknown")
         live_counter = LiveTokenCounter()
+        # gpu_monitor is created later (after model loading) but sidecar needs to
+        # start now for phase reporting. Use a mutable container so the sidecar
+        # picks up the monitor once it's ready.
+        gpu_monitor_ref: list = [None]  # [GPUMonitor | None]
         stop_sidecar = threading.Event()
         sidecar_thread = threading.Thread(
             target=_sidecar_loop,
-            args=(stop_sidecar, orca_url, orca_key, job_id, live_counter),
+            args=(stop_sidecar, orca_url, orca_key, job_id, live_counter, gpu_monitor_ref),
             daemon=True, name="orca-sidecar",
         )
         sidecar_thread.start()
@@ -1202,6 +1219,7 @@ def main():
         # 7. Start GPU monitor + scheduler poller (0.5s sampling, matches profiling repo)
         gpu_monitor = GPUMonitor(sample_interval=0.5)
         gpu_monitor.start()
+        gpu_monitor_ref[0] = gpu_monitor  # sidecar thread picks this up on next iteration
         metrics_poller = MetricsPoller(interval=0.5)
         metrics_poller.start()
 


### PR DESCRIPTION
## TLDR;
Summary: End-to-end SLO estimation, deeper GPU observability, adding missing throughput time series saving, replica log forwarding, new CLI commands (orca ls), a real-time web dashboard (orca web), and flexible S3 model weight loading.

## SLO Estimation
  - Thread estimated_runtime_hours and meets_slo through the full stack: solver → SolverOutput → MagicOutput → API response → CLI
  - Pass num_replicas to the solver so it computes per-replica workload ETA against the SLO deadline
  - orca plan displays ETA vs SLO with color-coded pass/fail
  - /test_placement returns slo_warning when no config meets the deadline
  
## Observability
  - Per-GPU metrics: Forward raw per-GPU SM utilization, memory bandwidth, and memory usage from pynvml through sidecar → ingest → MetricsSnapshot, flattened into timeseries CSV
  - Ingest throughput deltas: Compute throughput from counter deltas at ingest time so timeseries CSV captures non-zero values (ring buffer windowed throughput still used for /metrics)
  - Log forwarding: LogCollector in the chunked runner tees stdout/stderr into a buffer; sidecar forwards log lines to control plane, which writes per-replica log files under outputs/<job>/replicas/
  - Single-cluster GPU monitor: Wire GPUMonitor into single-cluster sidecar (previously only chunked runner had it)                                                                                                                                                               
  - Increase wait_for_server timeout 600s → 1200s for large model loads

## Timeseries Export & Output Directory Rework
  - On job completion (both single-cluster and multi-replica assembly), export timeseries.csv and generate timeseries.pdf with throughput/KV/GPU plots                                                                                                                            
  - Rework output directory lifecycle: write all artifacts (output.jsonl, metrics.csv, timeseries.*) first, then rename with success-/partial-/failed- prefix — prevents partial output dirs on failure
  - Add matplotlib, numpy to requirements

## CLI & Dashboard                                                                                                                                                                                                                                                                                                                              
  - orca ls: Rich job listing with live metrics, replica status, chunk progress, GPU utilization
  - orca web: Opens real-time SSE-powered web dashboard in browser
  - Mount /dashboard route on the server
  - S3 input support for split_and_upload_chunks (downloads to temp file first)
  - Force-teardown orphaned clusters on server shutdown

## S3 Model Weights
  - Replace boolean s3_models flag with explicit s3_model_path: str URI on BatchedRequest — users pass the exact S3 path instead of relying on hardcoded bucket/prefix
  - Add --s3-models S3_URI flag to orca deploy with upfront aws s3 ls validation
  - Wire S3 model mounting through both single-cluster and chunked replica launch paths
  - Remove dependency on S3_MODEL_BUCKET/S3_MODEL_PREFIX config constants