### PR TITLE
fix: cold-start failure detection and OOM classification

### DIFF
--- a/orca_server/koi_contract.py
+++ b/orca_server/koi_contract.py
@@ -38,6 +38,8 @@ class ReasonCode(str, Enum):
     MONITOR_THREAD_EXITED = "monitor_thread_exited"
     KOI_INITIATED_KILL = "koi_initiated_kill"
     MODEL_LOAD_TIMEOUT = "model_load_timeout"
+    STARTUP_OOM = "startup_oom"
+    STARTUP_CRASH = "startup_crash"
     UNKNOWN = "unknown"
 
 

--- a/orca_server/launcher.py
+++ b/orca_server/launcher.py
@@ -56,6 +56,29 @@ _koi_launch_heartbeats = {}
 _koi_launch_heartbeat_lock = Lock()
 
 
+def _classify_attempt_failure(reason: str) -> str:
+    """Mirror of Koi's _classify_failure regex so /job/launch-failed payload
+    carries a structured failure_category per attempted config. Keep the
+    pattern set in sync with koi/koi/server.py:_FAILURE_PATTERNS."""
+    lc = (reason or "").lower()
+    if (
+        "out of memory" in lc
+        or "outofmemory" in lc
+        or "cuda oom" in lc
+        or "oom" in lc
+    ):
+        return "oom"
+    if "insufficient" in lc and "capacity" in lc:
+        return "no_capacity"
+    if "no capacity" in lc:
+        return "no_capacity"
+    if "spot" in lc or "preempt" in lc:
+        return "spot_preemption"
+    if "quota" in lc:
+        return "quota"
+    return "unknown"
+
+
 def _requested_market(
     request: BatchedRequest, config: Optional[MagicOutput] = None
 ) -> Optional[str]:
@@ -952,6 +975,7 @@ async def launch_chunked_replicas(
                     failure_reason=str(e)[:500],
                 )
                 with _attempt_log_lock:
+                    _err_str = str(e)
                     _attempt_log.append(
                         {
                             "gpu_type": _cfg.INSTANCE_TO_GPU.get(
@@ -960,7 +984,8 @@ async def launch_chunked_replicas(
                             "instance_type": cfg.instance_type,
                             "region": "unknown",
                             "market": requested_market,
-                            "reason": str(e)[:500],
+                            "reason": _err_str[:500],
+                            "failure_category": _classify_attempt_failure(_err_str),
                         }
                     )
                 if j < len(configs) - 1:
@@ -1302,10 +1327,28 @@ async def _launch_chunked_replica(
                         f"[Chunked] Replica {replica_id} exited but chunks still pending — treating as failure"
                     )
                 cm.set_replica_state(parent_job_id, replica_id, phase="failed")
-                _emit_replica_failed(
-                    ReasonCode.CLEAN_EXIT_PENDING_CHUNKS,
-                    "Clean exit with pending chunks (likely killed)",
-                )
+
+                # If the runner reported a structured startup_failed phase
+                # before exiting, use its reason text to pick a more specific
+                # ReasonCode (STARTUP_OOM vs STARTUP_CRASH). Otherwise fall
+                # back to CLEAN_EXIT_PENDING_CHUNKS (the legacy default for
+                # mid-job kills with no other signal).
+                _state = cm.get_replica_states(parent_job_id).get(replica_id, {})
+                _startup_reason = _state.get("startup_failure_reason", "")
+                if _startup_reason:
+                    _lc = _startup_reason.lower()
+                    if "out of memory" in _lc or "cuda oom" in _lc:
+                        _rc = ReasonCode.STARTUP_OOM
+                    elif "during startup" in _lc:
+                        _rc = ReasonCode.STARTUP_CRASH
+                    else:
+                        _rc = ReasonCode.CLEAN_EXIT_PENDING_CHUNKS
+                    _emit_replica_failed(_rc, _startup_reason)
+                else:
+                    _emit_replica_failed(
+                        ReasonCode.CLEAN_EXIT_PENDING_CHUNKS,
+                        "Clean exit with pending chunks (likely killed)",
+                    )
             else:
                 if job_logger:
                     job_logger.info(f"[Chunked] Replica {replica_id} completed")

--- a/server.py
+++ b/server.py
@@ -865,6 +865,23 @@ async def update_job_phase(
         )
         return {"ok": True}
 
+    if phase == "startup_failed" and replica_id:
+        # Runner crashed during vLLM startup (OOM, missing arch, etc.).
+        # Stash the runner's structured reason on the replica state so
+        # monitor_replica can pick it up and emit the right ReasonCode.
+        cm = app.state.cluster_manager
+        cm.set_replica_state(
+            job_id,
+            replica_id,
+            startup_failure_reason=body.get("reason", "")[:500],
+        )
+        logger.info(
+            "[Phase] Replica %s reported startup_failed: %s",
+            replica_id,
+            body.get("reason", "")[:200],
+        )
+        return {"ok": True}
+
     if phase:
         get_job_tracker().update_status(job_id, phase)
         if phase == "generating":

--- a/templates/vllm_batch_runner_chunked.py
+++ b/templates/vllm_batch_runner_chunked.py
@@ -68,7 +68,7 @@ def write_progress(done: int, total: int, status: str = "running"):
         pass
 
 
-def _report_phase(phase: str):
+def _report_phase(phase: str, reason: Optional[str] = None):
     if not ORCA_URL or not JOB_ID:
         return
     try:
@@ -78,6 +78,8 @@ def _report_phase(phase: str):
         body = {"phase": phase}
         if REPLICA_ID:
             body["replica_id"] = REPLICA_ID
+        if reason:
+            body["reason"] = reason[:500]
         requests.post(f"{ORCA_URL}/job/{JOB_ID}/phase",
                       json=body, headers=headers, timeout=5)
     except Exception:
@@ -962,12 +964,36 @@ def start_vllm_server(args, log_collector: Optional[LogCollector] = None) -> sub
     return subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=env)
 
 
-def wait_for_server(proc: subprocess.Popen, timeout_sec: int = 1200) -> float:
+_OOM_MARKERS = ("out of memory", "cuda oom", "cuda out of memory", "outofmemoryerror")
+
+
+def _classify_startup_exit(rc: int, log_collector: Optional["LogCollector"]) -> str:
+    """Build a structured reason string for a non-zero vLLM startup exit.
+
+    Drains the runner's own log buffer (captured via LogCollector) and pattern-
+    matches for CUDA OOM signatures. Returns a string Koi's _classify_failure
+    regex will tag as "oom" when applicable.
+    """
+    tail = log_collector.drain(max_lines=200) if log_collector else []
+    is_oom = any(
+        any(marker in line.get("msg", "").lower() for marker in _OOM_MARKERS)
+        for line in tail
+    )
+    if is_oom:
+        return f"vLLM exited with code {rc} during startup — CUDA out of memory"
+    return f"vLLM exited with code {rc} during startup"
+
+
+def wait_for_server(
+    proc: subprocess.Popen,
+    timeout_sec: int = 1200,
+    log_collector: Optional["LogCollector"] = None,
+) -> float:
     start = time.time()
     while time.time() - start < timeout_sec:
         rc = proc.poll()
         if rc is not None:
-            raise RuntimeError(f"vLLM exited with code {rc} during startup")
+            raise RuntimeError(_classify_startup_exit(rc, log_collector))
         try:
             if requests.get(f"{BASE_URL}/health", timeout=5).status_code == 200:
                 return time.time() - start
@@ -1494,7 +1520,14 @@ def main():
     proc = start_vllm_server(args, log_collector=log_collector)
     try:
         print("[Runner] Waiting for vLLM server to be ready...")
-        model_load_sec = wait_for_server(proc)
+        try:
+            model_load_sec = wait_for_server(proc, log_collector=log_collector)
+        except (RuntimeError, TimeoutError) as exc:
+            # Report structured startup failure to control plane before re-raising
+            # so monitor_replica can classify (OOM vs crash vs timeout) and
+            # forward an actionable reason_code to Koi.
+            _report_phase("startup_failed", reason=str(exc))
+            raise
         print(f"[Runner] Server ready in {model_load_sec:.2f}s")
         _report_phase("model_ready")
 

--- a/templates/vllm_batch_runner_chunked.py
+++ b/templates/vllm_batch_runner_chunked.py
@@ -962,9 +962,12 @@ def start_vllm_server(args, log_collector: Optional[LogCollector] = None) -> sub
     return subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=env)
 
 
-def wait_for_server(timeout_sec: int = 1200) -> float:
+def wait_for_server(proc: subprocess.Popen, timeout_sec: int = 1200) -> float:
     start = time.time()
     while time.time() - start < timeout_sec:
+        rc = proc.poll()
+        if rc is not None:
+            raise RuntimeError(f"vLLM exited with code {rc} during startup")
         try:
             if requests.get(f"{BASE_URL}/health", timeout=5).status_code == 200:
                 return time.time() - start
@@ -1491,7 +1494,7 @@ def main():
     proc = start_vllm_server(args, log_collector=log_collector)
     try:
         print("[Runner] Waiting for vLLM server to be ready...")
-        model_load_sec = wait_for_server()
+        model_load_sec = wait_for_server(proc)
         print(f"[Runner] Server ready in {model_load_sec:.2f}s")
         _report_phase("model_ready")
 

--- a/templates/vllm_batch_runner_server.py
+++ b/templates/vllm_batch_runner_server.py
@@ -539,9 +539,12 @@ def start_vllm_server(args) -> subprocess.Popen:
     return subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=env)
 
 
-def wait_for_server(timeout_sec: int = 1200) -> float:
+def wait_for_server(proc: subprocess.Popen, timeout_sec: int = 1200) -> float:
     start = time.time()
     while time.time() - start < timeout_sec:
+        rc = proc.poll()
+        if rc is not None:
+            raise RuntimeError(f"vLLM exited with code {rc} during startup")
         try:
             if requests.get(f"{BASE_URL}/health", timeout=5).status_code == 200:
                 return time.time() - start
@@ -1179,7 +1182,7 @@ def main():
     try:
         # 2. Wait until healthy
         print("[Runner] Waiting for vLLM server to be ready...")
-        model_load_sec = wait_for_server()
+        model_load_sec = wait_for_server(proc)
         print(f"[Runner] Server ready in {model_load_sec:.2f}s")
         _report_phase("model_ready")
 

--- a/tests/test_batch_runner_chunked.py
+++ b/tests/test_batch_runner_chunked.py
@@ -1,0 +1,126 @@
+"""Unit tests for templates/vllm_batch_runner_chunked.py.
+
+Currently focused on the cold-start failure classification path —
+``_classify_startup_exit`` and the ``wait_for_server`` integration that
+drains the LogCollector buffer to decide whether the vLLM subprocess
+crashed with a CUDA OOM signature or some other startup error.
+"""
+import importlib.util
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_runner_path = os.path.join(
+    os.path.dirname(__file__), "..", "templates", "vllm_batch_runner_chunked.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "vllm_batch_runner_chunked", _runner_path
+)
+runner = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(runner)
+
+
+# ---------------------------------------------------------------------------
+# _classify_startup_exit
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyStartupExit:
+    def _collector_with(self, lines):
+        col = MagicMock()
+        col.drain.return_value = [{"ts": time.time(), "msg": m} for m in lines]
+        return col
+
+    def test_no_collector_returns_basic_message(self):
+        out = runner._classify_startup_exit(1, None)
+        assert "vLLM exited with code 1 during startup" in out
+        assert "CUDA out of memory" not in out
+
+    def test_oom_lower_case_in_log_tail(self):
+        col = self._collector_with(["RuntimeError: out of memory while warming up"])
+        out = runner._classify_startup_exit(1, col)
+        assert "CUDA out of memory" in out
+        assert "exit" in out.lower() and "1" in out
+
+    def test_cuda_oom_marker_matched(self):
+        col = self._collector_with(["[CUDA OOM] failed allocation"])
+        out = runner._classify_startup_exit(2, col)
+        assert "CUDA out of memory" in out
+
+    def test_non_oom_crash_no_oom_marker(self):
+        col = self._collector_with(["AssertionError: model arch mismatch"])
+        out = runner._classify_startup_exit(1, col)
+        assert "CUDA out of memory" not in out
+        assert "during startup" in out
+
+    def test_empty_log_tail_no_oom(self):
+        col = self._collector_with([])
+        out = runner._classify_startup_exit(1, col)
+        assert "CUDA out of memory" not in out
+
+
+# ---------------------------------------------------------------------------
+# wait_for_server (chunked variant)
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForServerChunked:
+    @staticmethod
+    def _live_proc():
+        p = MagicMock()
+        p.poll.return_value = None
+        return p
+
+    def test_health_ok_returns_elapsed(self):
+        with patch.object(runner.requests, "get", return_value=MagicMock(status_code=200)), \
+             patch.object(runner.time, "sleep"):
+            elapsed = runner.wait_for_server(self._live_proc(), timeout_sec=60)
+        assert isinstance(elapsed, float)
+
+    def test_proc_exit_with_oom_in_log_raises_oom_message(self):
+        """The runner's wait_for_server should drain its LogCollector buffer
+        when the subprocess dies and surface a reason string Koi's
+        _classify_failure regex tags as OOM."""
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 1
+        col = MagicMock()
+        col.drain.return_value = [
+            {"ts": time.time(), "msg": "torch.cuda.OutOfMemoryError: CUDA out of memory"}
+        ]
+        with patch.object(runner.requests, "get", side_effect=ConnectionRefusedError), \
+             patch.object(runner.time, "sleep"):
+            with pytest.raises(RuntimeError, match="CUDA out of memory"):
+                runner.wait_for_server(dead_proc, timeout_sec=1200, log_collector=col)
+
+    def test_proc_exit_without_oom_marker_raises_generic_startup_message(self):
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 1
+        col = MagicMock()
+        col.drain.return_value = [
+            {"ts": time.time(), "msg": "ValueError: unsupported architecture qwen3_5"}
+        ]
+        with patch.object(runner.requests, "get", side_effect=ConnectionRefusedError), \
+             patch.object(runner.time, "sleep"):
+            with pytest.raises(RuntimeError) as excinfo:
+                runner.wait_for_server(dead_proc, timeout_sec=1200, log_collector=col)
+        assert "during startup" in str(excinfo.value)
+        assert "CUDA out of memory" not in str(excinfo.value)
+
+    def test_proc_exit_without_log_collector_uses_basic_message(self):
+        """Backward-compatible path: callers that don't pass a log_collector
+        still get a sensible RuntimeError, just without OOM classification."""
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 137
+        with patch.object(runner.requests, "get", side_effect=ConnectionRefusedError), \
+             patch.object(runner.time, "sleep"):
+            with pytest.raises(RuntimeError, match="exited with code 137"):
+                runner.wait_for_server(dead_proc, timeout_sec=1200)
+
+    def test_timeout_when_proc_alive_but_health_never_ready(self):
+        with patch.object(runner.requests, "get", return_value=MagicMock(status_code=503)), \
+             patch.object(runner.time, "sleep"), \
+             patch.object(runner.time, "time", side_effect=[0.0, 61.0]):
+            with pytest.raises(TimeoutError):
+                runner.wait_for_server(self._live_proc(), timeout_sec=60)

--- a/tests/test_batch_runner_server.py
+++ b/tests/test_batch_runner_server.py
@@ -61,6 +61,12 @@ def _make_args(**kwargs):
 # ---------------------------------------------------------------------------
 
 class TestWaitForServer:
+    @staticmethod
+    def _live_proc():
+        p = MagicMock()
+        p.poll.return_value = None
+        return p
+
     def test_ready_after_retries(self):
         responses = [MagicMock(status_code=503), MagicMock(status_code=200)]
         call_count = {"n": 0}
@@ -72,7 +78,7 @@ class TestWaitForServer:
 
         with patch.object(runner.requests, "get", side_effect=fake_get), \
              patch.object(runner.time, "sleep"):
-            elapsed = runner.wait_for_server(timeout_sec=60)
+            elapsed = runner.wait_for_server(self._live_proc(), timeout_sec=60)
         assert isinstance(elapsed, float)
 
     def test_raises_timeout(self):
@@ -80,7 +86,18 @@ class TestWaitForServer:
              patch.object(runner.time, "sleep"), \
              patch.object(runner.time, "time", side_effect=[0.0, 61.0]):
             with pytest.raises(TimeoutError):
-                runner.wait_for_server(timeout_sec=60)
+                runner.wait_for_server(self._live_proc(), timeout_sec=60)
+
+    def test_raises_when_proc_dies_during_startup(self):
+        """Fail-fast: if the vLLM subprocess exits non-zero (e.g. CUDA OOM)
+        before /health ever returns 200, we should raise immediately with
+        the exit code instead of polling for the full timeout window."""
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 1  # subprocess exited with code 1
+        with patch.object(runner.requests, "get", side_effect=ConnectionRefusedError), \
+             patch.object(runner.time, "sleep"):
+            with pytest.raises(RuntimeError, match="exited with code 1"):
+                runner.wait_for_server(dead_proc, timeout_sec=1200)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_monitor_replica_hardening.py
+++ b/tests/test_monitor_replica_hardening.py
@@ -102,3 +102,62 @@ class TestMonitorReplicaReasonCodeUsage:
         assert "ReasonCode.MONITOR_THREAD_EXITED" in src
         assert "ReasonCode.LOG_STREAM_ERROR" in src
         assert "ReasonCode.CLEAN_EXIT_PENDING_CHUNKS" in src
+
+    def test_startup_reason_codes_routed_in_launcher(self):
+        """Cold-start failures should pick STARTUP_OOM or STARTUP_CRASH
+        based on the runner-reported reason text in startup_failure_reason,
+        and fall back to CLEAN_EXIT_PENDING_CHUNKS only when no signal
+        is present."""
+        from pathlib import Path
+
+        src = Path("orca_server/launcher.py").read_text()
+        assert "ReasonCode.STARTUP_OOM" in src
+        assert "ReasonCode.STARTUP_CRASH" in src
+        assert "startup_failure_reason" in src
+
+
+class TestStartupOOMReasonCodes:
+    """The new ReasonCode values added for cold-start failure classification."""
+
+    def test_startup_oom_value(self):
+        assert ReasonCode.STARTUP_OOM.value == "startup_oom"
+
+    def test_startup_crash_value(self):
+        assert ReasonCode.STARTUP_CRASH.value == "startup_crash"
+
+
+class TestClassifyAttemptFailure:
+    """The Orca-side helper that mirrors Koi's _classify_failure regex.
+    Keeps /job/launch-failed payload's failure_category in sync with how
+    Koi will categorize the same reason text."""
+
+    def test_oom_message_classified(self):
+        from orca_server.launcher import _classify_attempt_failure
+
+        assert _classify_attempt_failure("CUDA out of memory") == "oom"
+        assert _classify_attempt_failure("torch.cuda.OutOfMemoryError") == "oom"
+        assert _classify_attempt_failure("OOM during sampler warmup") == "oom"
+
+    def test_no_capacity_classified(self):
+        from orca_server.launcher import _classify_attempt_failure
+
+        assert _classify_attempt_failure("InsufficientInstanceCapacity") == "no_capacity"
+        assert _classify_attempt_failure("no capacity available") == "no_capacity"
+
+    def test_spot_preempt_classified(self):
+        from orca_server.launcher import _classify_attempt_failure
+
+        assert _classify_attempt_failure("spot interruption notice") == "spot_preemption"
+        assert _classify_attempt_failure("instance preempted") == "spot_preemption"
+
+    def test_quota_classified(self):
+        from orca_server.launcher import _classify_attempt_failure
+
+        assert _classify_attempt_failure("quota exceeded for L40S") == "quota"
+
+    def test_unknown_default(self):
+        from orca_server.launcher import _classify_attempt_failure
+
+        assert _classify_attempt_failure("some unrelated error") == "unknown"
+        assert _classify_attempt_failure("") == "unknown"
+        assert _classify_attempt_failure(None) == "unknown"


### PR DESCRIPTION
## Summary

- **Fast failure detection**: `wait_for_server` now checks `proc.poll()` each iteration so a vLLM OOM or crash is detected in ~5 seconds instead of polling for the full 20-minute timeout window
- **OOM classification**: chunked runner drains its LogCollector buffer on startup exit and builds a structured reason string (`CUDA out of memory` marker) that Koi's `_classify_failure` regex tags as `oom`
- **Structured reason codes**: two new `ReasonCode` enum values (`STARTUP_OOM`, `STARTUP_CRASH`) and a `_classify_attempt_failure` helper that mirrors Koi's regex; `monitor_replica` routes cold-start failures to the right code based on the runner's reported `startup_failure_reason`
- **Enriched `/job/launch-failed` payload**: each entry in `configs_tried` now carries a `failure_category` field so Koi can read the per-attempt category directly without re-parsing free-text strings

## Test plan

- [ ] `pytest tests/test_batch_runner_chunked.py` — new file, covers `_classify_startup_exit` and `wait_for_server` OOM vs crash vs no-collector paths
- [ ] `pytest tests/test_batch_runner_server.py` — existing tests updated to pass mock `proc` through new signature, new `test_raises_when_proc_dies_during_startup` test
- [ ] `pytest tests/test_monitor_replica_hardening.py` — new `TestStartupOOMReasonCodes`, `TestClassifyAttemptFailure`, and updated `TestMonitorReplicaReasonCodeUsage`
- [ ] `pytest tests/` — full suite (359 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)