### PR TITLE
Add multicloud abstraction seams

### DIFF
--- a/models/requests.py
+++ b/models/requests.py
@@ -25,7 +25,7 @@ class BatchedRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     user_id: str
-    input_file: str  # S3/local path to the file
+    input_file: str  # storage URI or local path to the file
     output_file: str  # local path to where the output will be saved
     # Input stats - extracted from input_file by server, but can be overridden
     num_lines: int | None = None  # number of prompt lines in the file (parsed from input_file)
@@ -69,7 +69,7 @@ class BatchedRequest(BaseModel):
     preferred_market: Literal["spot", "on_demand"] | None = None
     planned_market: Literal["spot", "on_demand"] | None = None
 
-    # S3 URI to model weights — if set, loads from S3 instead of HuggingFace
+    # Storage URI to model weights — if set, loads from object storage instead of HuggingFace
     s3_model_path: str | None = None
     # HuggingFace token for gated models (Llama, etc.)
     hf_token: str | None = None
@@ -80,7 +80,7 @@ class BatchedRequest(BaseModel):
     # Chunked distributed batch inference
     replicas: int | None = None  # Replica count (from CLI --replicas or solver)
     chunk_size: int | None = None  # Lines per chunk (default: 1000)
-    chunks: list[dict] | None = None  # [{chunk_id, s3_input_path, num_lines}, ...] — CLI uploads
+    chunks: list[dict] | None = None  # [{chunk_id, input_uri, output_uri, num_lines}, ...] — CLI uploads
     koi_alternatives: list[KoiPlacementAlternative] | None = None  # Koi placement alternatives for fallback retry
     koi_decision_id: str | None = None  # Koi decision ID — passed back via /job/started webhook
     koi_predicted_tps: float | None = None  # Koi top-level TPS prediction for webhook propagation

--- a/models/resources.py
+++ b/models/resources.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from orca_server.cloud.models import PlacementCandidate
+
 
 class MagicOutput(BaseModel):
     decision_id: str
@@ -21,6 +23,7 @@ class MagicOutput(BaseModel):
     estimated_runtime_hours: float | None = None
     meets_slo: bool | None = None
     is_fallback: bool = False  # True when solver returned a generic fallback (unsupported model)
+    placement_candidate: PlacementCandidate | None = None
 
     @property
     def num_nodes(self) -> int:

--- a/orca_server/cloud/__init__.py
+++ b/orca_server/cloud/__init__.py
@@ -1,0 +1,32 @@
+"""Provider-neutral cloud abstractions for Orca."""
+
+from .catalog import AWSInstanceCatalog, InstanceCatalog
+from .launch import LaunchBackend, SkyPilotLaunchBackend
+from .models import (
+    InstanceSpec,
+    LaunchRequest,
+    LaunchResult,
+    PlacementCandidate,
+    PricingRequest,
+    QuotaRequest,
+    RegionCandidate,
+)
+from .pricing import PricingProvider, SkyPilotPricingProvider
+from .quota import QuotaProvider
+
+__all__ = [
+    "AWSInstanceCatalog",
+    "InstanceCatalog",
+    "InstanceSpec",
+    "LaunchBackend",
+    "LaunchRequest",
+    "LaunchResult",
+    "PlacementCandidate",
+    "PricingProvider",
+    "PricingRequest",
+    "QuotaProvider",
+    "QuotaRequest",
+    "RegionCandidate",
+    "SkyPilotPricingProvider",
+    "SkyPilotLaunchBackend",
+]

--- a/orca_server/cloud/catalog.py
+++ b/orca_server/cloud/catalog.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+
+from .models import InstanceSpec
+
+V1_UNSUPPORTED_GPUS = {"V100", "T4"}
+
+
+class InstanceCatalog(ABC):
+    """Catalog of launchable instances for one or more providers."""
+
+    @abstractmethod
+    def list_instances(self, cloud: str | None = None) -> list[InstanceSpec]:
+        pass
+
+    @abstractmethod
+    def get_instance(self, cloud: str, instance_type: str) -> InstanceSpec:
+        pass
+
+
+class AWSInstanceCatalog(InstanceCatalog):
+    """AWS implementation backed by Orca's existing static instance table."""
+
+    cloud = "aws"
+
+    def __init__(self, instances: dict[str, tuple[str, int, int, int]]):
+        self._instances = dict(instances)
+
+    def list_instances(self, cloud: str | None = None) -> list[InstanceSpec]:
+        if cloud is not None and cloud.lower() != self.cloud:
+            return []
+        return list(self._iter_specs())
+
+    def get_instance(self, cloud: str, instance_type: str) -> InstanceSpec:
+        if cloud.lower() != self.cloud:
+            raise KeyError(f"AWSInstanceCatalog does not handle cloud={cloud!r}")
+        try:
+            gpu_name, gpu_count, vcpus, vram_gb = self._instances[instance_type]
+        except KeyError as exc:
+            raise KeyError(f"Unknown AWS instance type: {instance_type}") from exc
+        return InstanceSpec(
+            cloud=self.cloud,
+            instance_type=instance_type,
+            gpu_name=gpu_name,
+            gpu_count=gpu_count,
+            vcpus=vcpus,
+            vram_gb=vram_gb,
+            supports_vllm_v1=gpu_name not in V1_UNSUPPORTED_GPUS,
+        )
+
+    def _iter_specs(self) -> Iterable[InstanceSpec]:
+        for instance_type in self._instances:
+            yield self.get_instance(self.cloud, instance_type)

--- a/orca_server/cloud/launch.py
+++ b/orca_server/cloud/launch.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .models import LaunchRequest, LaunchResult, PlacementCandidate
+
+
+class LaunchBackend(ABC):
+    """Launch abstraction that hides SkyPilot/provider-specific resource shape."""
+
+    @abstractmethod
+    def build_resources(self, candidate: PlacementCandidate) -> dict:
+        pass
+
+    @abstractmethod
+    def launch(self, request: LaunchRequest) -> LaunchResult:
+        pass
+
+
+class SkyPilotLaunchBackend(LaunchBackend):
+    """SkyPilot adapter for provider-neutral placement candidates."""
+
+    def __init__(self, disk_size: str = "300GB", ports: int | None = None):
+        self.disk_size = disk_size
+        self.ports = ports
+
+    def build_resources(self, candidate: PlacementCandidate) -> dict:
+        resources = {
+            "instance_type": candidate.instance_type,
+            "disk_size": self.disk_size,
+        }
+        if candidate.region:
+            resources["region"] = candidate.region
+        if candidate.zone:
+            resources["zone"] = candidate.zone
+        if candidate.market is not None:
+            resources["use_spot"] = candidate.market == "spot"
+        if self.ports is not None:
+            resources["ports"] = self.ports
+        return resources
+
+    def launch(self, request: LaunchRequest) -> LaunchResult:
+        raise NotImplementedError("SkyPilot launch wiring remains in orca_server.launcher")

--- a/orca_server/cloud/models.py
+++ b/orca_server/cloud/models.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CloudMarket = Literal["spot", "on_demand"]
+
+
+class InstanceSpec(BaseModel):
+    """Provider-neutral description of a launchable accelerator instance."""
+
+    model_config = ConfigDict(frozen=True)
+
+    cloud: str
+    instance_type: str
+    gpu_name: str
+    gpu_count: int = Field(ge=0)
+    vcpus: int = Field(ge=1)
+    vram_gb: int = Field(ge=0)
+    supports_vllm_v1: bool
+
+
+class PlacementCandidate(BaseModel):
+    """A concrete placement option independent of a specific cloud provider API."""
+
+    model_config = ConfigDict(frozen=True)
+
+    cloud: str
+    region: str | None = None
+    zone: str | None = None
+    instance_type: str
+    gpu_type: str
+    gpus_per_node: int = Field(ge=0)
+    num_nodes: int = Field(ge=1)
+    tp_size: int = Field(ge=1)
+    pp_size: int = Field(ge=1)
+    market: CloudMarket | None = None
+    estimated_cost_per_hour: float | None = Field(default=None, ge=0)
+
+
+class QuotaRequest(BaseModel):
+    """Quota/capacity lookup input for a provider implementation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    cloud: str
+    instance_type: str
+    num_nodes: int = Field(default=1, ge=1)
+    prefer_spot: bool = True
+    target_market: CloudMarket | None = None
+
+
+class RegionCandidate(BaseModel):
+    """A region/market option with enough reported capacity for a request."""
+
+    model_config = ConfigDict(frozen=True)
+    region: str
+    market: CloudMarket
+    available_quota: int = Field(ge=0)
+
+    @property
+    def use_spot(self) -> bool:
+        return self.market == "spot"
+
+    def to_skypilot_resources(
+        self,
+        instance_type: str,
+        disk_size: str = "300GB",
+        ports: int | None = None,
+    ) -> dict:
+        resources = {
+            "region": self.region,
+            "instance_type": instance_type,
+            "use_spot": self.use_spot,
+            "disk_size": disk_size,
+        }
+        if ports is not None:
+            resources["ports"] = ports
+        return resources
+
+
+class PricingRequest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    cloud: str
+    instance_type: str
+    region: str | None = None
+    market: CloudMarket | None = None
+
+
+class LaunchRequest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    job_id: str
+    candidate: PlacementCandidate
+    num_nodes: int = Field(ge=1)
+
+
+class LaunchResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    job_id: str
+    cluster_name: str | None = None
+    endpoint: str | None = None
+    status: str

--- a/orca_server/cloud/pricing.py
+++ b/orca_server/cloud/pricing.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .models import PricingRequest
+
+
+class PricingProvider(ABC):
+    """Provider-specific pricing lookup interface."""
+
+    @abstractmethod
+    def get_hourly_cost(self, request: PricingRequest) -> float | None:
+        pass
+
+
+class SkyPilotPricingProvider(PricingProvider):
+    """Pricing adapter backed by SkyPilot's catalog."""
+
+    def get_hourly_cost(self, request: PricingRequest) -> float | None:
+        try:
+            from sky import catalog
+
+            return catalog.get_hourly_cost(
+                request.instance_type,
+                use_spot=request.market == "spot",
+                region=request.region,
+                zone=None,
+                clouds=request.cloud,
+            )
+        except Exception:
+            return None

--- a/orca_server/cloud/quota.py
+++ b/orca_server/cloud/quota.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .models import QuotaRequest, RegionCandidate
+
+
+class QuotaProvider(ABC):
+    """Provider-specific quota and capacity lookup interface."""
+
+    @abstractmethod
+    def get_region_candidates(self, request: QuotaRequest) -> list[RegionCandidate]:
+        pass

--- a/orca_server/config.py
+++ b/orca_server/config.py
@@ -9,6 +9,8 @@ import os
 
 from dotenv import load_dotenv
 
+from orca_server.cloud.catalog import AWSInstanceCatalog
+
 load_dotenv()
 
 # --------------------------------------------------------------------------- #
@@ -23,8 +25,13 @@ YAML_OUTPUT = "temp/output.yaml"
 S3_MODEL_BUCKET = "tandemn-model-shards"
 S3_MODEL_PREFIX = "hf-models"
 
-S3_UPLOAD_BUCKET = os.getenv("S3_UPLOAD_BUCKET", "tandemn-orca")
-S3_UPLOAD_PREFIX = os.getenv("S3_UPLOAD_PREFIX", "uploads")
+TD_STORAGE_UPLOAD_SCHEME = os.getenv("TD_STORAGE_UPLOAD_SCHEME", "s3")
+TD_STORAGE_UPLOAD_BUCKET = os.getenv("TD_STORAGE_UPLOAD_BUCKET", os.getenv("S3_UPLOAD_BUCKET", "tandemn-orca"))
+TD_STORAGE_UPLOAD_PREFIX = os.getenv("TD_STORAGE_UPLOAD_PREFIX", os.getenv("S3_UPLOAD_PREFIX", "uploads"))
+
+# Backward-compatible names for current callers. New code should use TD_STORAGE_*.
+S3_UPLOAD_BUCKET = TD_STORAGE_UPLOAD_BUCKET
+S3_UPLOAD_PREFIX = TD_STORAGE_UPLOAD_PREFIX
 
 # Solver selection: "roofline" (deterministic) or "user_specified"
 PLACEMENT_SOLVER = os.environ.get("TD_PLACEMENT_SOLVER", "roofline").lower()
@@ -105,21 +112,25 @@ AWS_INSTANCES = {
     "g5.48xlarge": ("A10G", 8, 192, 24),
 }
 
+AWS_INSTANCE_CATALOG = AWSInstanceCatalog(AWS_INSTANCES)
+
 # --------------------------------------------------------------------------- #
 # Derived mappings (all generated from AWS_INSTANCES)
 # --------------------------------------------------------------------------- #
 
 # instance_type -> gpu_name
-INSTANCE_TO_GPU = {inst: gpu for inst, (gpu, *_) in AWS_INSTANCES.items()}
+INSTANCE_TO_GPU = {spec.instance_type: spec.gpu_name for spec in AWS_INSTANCE_CATALOG.list_instances(cloud="aws")}
 
 # instance_type -> vcpus
-INSTANCE_VCPUS = {inst: vals[2] for inst, vals in AWS_INSTANCES.items()}
+INSTANCE_VCPUS = {spec.instance_type: spec.vcpus for spec in AWS_INSTANCE_CATALOG.list_instances(cloud="aws")}
 
 # instance_type -> vram_per_gpu_gb
-INSTANCE_VRAM = {inst: vals[3] for inst, vals in AWS_INSTANCES.items()}
+INSTANCE_VRAM = {spec.instance_type: spec.vram_gb for spec in AWS_INSTANCE_CATALOG.list_instances(cloud="aws")}
 
 # instance_type -> (gpu_name, gpu_count)  [used by roofline solver]
-AWS_INSTANCE_TO_GPU = {inst: (gpu, count) for inst, (gpu, count, *_) in AWS_INSTANCES.items()}
+AWS_INSTANCE_TO_GPU = {
+    spec.instance_type: (spec.gpu_name, spec.gpu_count) for spec in AWS_INSTANCE_CATALOG.list_instances(cloud="aws")
+}
 
 # GPUs with compute capability < 8.0 — vLLM V1 engine is not supported
 _V1_UNSUPPORTED_GPUS = {"V100", "T4"}
@@ -127,5 +138,7 @@ _V1_UNSUPPORTED_GPUS = {"V100", "T4"}
 
 def supports_vllm_v1(instance_type: str) -> bool:
     """Check if an instance type's GPU supports vLLM V1 engine (CC >= 8.0)."""
-    gpu = INSTANCE_TO_GPU.get(instance_type, "")
-    return gpu not in _V1_UNSUPPORTED_GPUS
+    try:
+        return AWS_INSTANCE_CATALOG.get_instance("aws", instance_type).supports_vllm_v1
+    except KeyError:
+        return "" not in _V1_UNSUPPORTED_GPUS

--- a/placement/roofline/gpu_specs.py
+++ b/placement/roofline/gpu_specs.py
@@ -190,6 +190,7 @@ AWS_INSTANCE_GPU_MAP: dict[str, dict[str, Any]] = {
     "g6e.4xlarge": {"gpu_model": "L40S", "num_gpus": 1},
     "g6e.8xlarge": {"gpu_model": "L40S", "num_gpus": 1},
     "g6e.12xlarge": {"gpu_model": "L40S", "num_gpus": 4},
+    "g6e.16xlarge": {"gpu_model": "L40S", "num_gpus": 1},
     "g6e.24xlarge": {"gpu_model": "L40S", "num_gpus": 4},
     "g6e.48xlarge": {"gpu_model": "L40S", "num_gpus": 8},
     # G6 instances (L4)
@@ -197,7 +198,8 @@ AWS_INSTANCE_GPU_MAP: dict[str, dict[str, Any]] = {
     "g6.2xlarge": {"gpu_model": "L4", "num_gpus": 1},
     "g6.4xlarge": {"gpu_model": "L4", "num_gpus": 1},
     "g6.8xlarge": {"gpu_model": "L4", "num_gpus": 1},
-    "g6.12xlarge": {"gpu_model": "L4", "num_gpus": 2},
+    "g6.12xlarge": {"gpu_model": "L4", "num_gpus": 4},
+    "g6.16xlarge": {"gpu_model": "L4", "num_gpus": 1},
     "g6.24xlarge": {"gpu_model": "L4", "num_gpus": 4},
     "g6.48xlarge": {"gpu_model": "L4", "num_gpus": 8},
     # G5 instances (A10G)
@@ -206,6 +208,7 @@ AWS_INSTANCE_GPU_MAP: dict[str, dict[str, Any]] = {
     "g5.4xlarge": {"gpu_model": "A10G", "num_gpus": 1},
     "g5.8xlarge": {"gpu_model": "A10G", "num_gpus": 1},
     "g5.12xlarge": {"gpu_model": "A10G", "num_gpus": 4},
+    "g5.16xlarge": {"gpu_model": "A10G", "num_gpus": 1},
     "g5.24xlarge": {"gpu_model": "A10G", "num_gpus": 4},
     "g5.48xlarge": {"gpu_model": "A10G", "num_gpus": 8},
 }

--- a/placement/roofline_magic.py
+++ b/placement/roofline_magic.py
@@ -23,6 +23,7 @@ import pandas as pd
 
 from models.requests import BatchedRequest, OnlineServingRequest
 from models.resources import MagicOutput
+from orca_server.cloud.models import PlacementCandidate
 from orca_server.config import AWS_INSTANCE_TO_GPU
 from orca_server.utils import make_job_id as _make_job_id
 from placement.magic import VPCMagic
@@ -83,6 +84,30 @@ def resolve_gpu_type_to_instance(gpu_type: str, min_gpus: int) -> tuple:
     max_count = instances[-1][1]
     raise ValueError(
         f"No AWS instance with >= {min_gpus} {gpu_type} GPUs. Max available: {max_count} GPUs on {instances[-1][0]}"
+    )
+
+
+def _aws_placement_candidate(
+    *,
+    instance_type: str,
+    tp_size: int,
+    pp_size: int,
+    num_nodes: int,
+    market: str | None = None,
+    estimated_cost_per_hour: float | None = None,
+) -> PlacementCandidate:
+    gpu_model, gpus_per_node = AWS_INSTANCE_TO_GPU[instance_type]
+    return PlacementCandidate(
+        cloud="aws",
+        region=None,
+        instance_type=instance_type,
+        gpu_type=gpu_model,
+        gpus_per_node=gpus_per_node,
+        num_nodes=num_nodes,
+        tp_size=tp_size,
+        pp_size=pp_size,
+        market=market,
+        estimated_cost_per_hour=estimated_cost_per_hour,
     )
 
 
@@ -483,6 +508,14 @@ class RooflineAWSAllocation(VPCMagic):
             cost_per_million_tokens=result.cost_per_million_tokens,
             estimated_runtime_hours=result.estimated_runtime_hours or None,
             meets_slo=result.meets_slo,
+            placement_candidate=_aws_placement_candidate(
+                instance_type=result.instance_family,
+                tp_size=result.tp_degree,
+                pp_size=result.pp_stages,
+                num_nodes=result.num_instances,
+                market=req.planned_market or req.preferred_market,
+                estimated_cost_per_hour=result.cost_per_hour,
+            ),
         )
 
     def _fallback_config(self, req: BatchedRequest) -> MagicOutput:
@@ -504,6 +537,12 @@ class RooflineAWSAllocation(VPCMagic):
             pp_size=1,
             max_model_len=8192,
             is_fallback=True,
+            placement_candidate=_aws_placement_candidate(
+                instance_type="g6e.12xlarge",
+                tp_size=4,
+                pp_size=1,
+                num_nodes=1,
+            ),
         )
 
     def _default_online_config(self, req: OnlineServingRequest) -> MagicOutput:
@@ -524,6 +563,12 @@ class RooflineAWSAllocation(VPCMagic):
             tp_size=4,
             pp_size=1,
             max_model_len=8192,  # Conservative default
+            placement_candidate=_aws_placement_candidate(
+                instance_type="g6e.12xlarge",
+                tp_size=4,
+                pp_size=1,
+                num_nodes=1,
+            ),
         )
 
     def process_batch_multi(
@@ -622,6 +667,14 @@ class RooflineAWSAllocation(VPCMagic):
                 cost_per_million_tokens=result.cost_per_million_tokens,
                 estimated_runtime_hours=result.estimated_runtime_hours or None,
                 meets_slo=result.meets_slo,
+                placement_candidate=_aws_placement_candidate(
+                    instance_type=result.instance_family,
+                    tp_size=result.tp_degree,
+                    pp_size=result.pp_stages,
+                    num_nodes=result.num_instances,
+                    market=req.planned_market or req.preferred_market,
+                    estimated_cost_per_hour=result.cost_per_hour,
+                ),
             )
             outputs.append(output)
             logger.info(

--- a/profiling/roofline/vllm/automatic_benchmark_1.py
+++ b/profiling/roofline/vllm/automatic_benchmark_1.py
@@ -22,19 +22,19 @@ Usage:
     python automatic_benchmark_1.py --gpu A10G --csv-only
 """
 
+import argparse
 import csv
 import sys
-import argparse
-from pathlib import Path
-from itertools import product
 from datetime import datetime
+from itertools import product
+from pathlib import Path
 
 from automatic_launch_1 import (
     GPU_CONFIGS,
-    load_experiments,
-    group_by_cluster_then_io,
-    run_cluster_benchmarks,
     check_orphaned_cluster,
+    group_by_cluster_then_io,
+    load_experiments,
+    run_cluster_benchmarks,
     save_results_csv,
 )
 
@@ -49,18 +49,22 @@ MODELS = [
 
 TP_PP_CONFIGS = [
     (2, 4),
-    (4, 2), (4, 3), (4, 4),
-    (8, 1), (8, 2), (8, 3),
+    (4, 2),
+    (4, 3),
+    (4, 4),
+    (8, 1),
+    (8, 2),
+    (8, 3),
 ]
 
 IO_LENGTHS = [
-    (128, 128),      # ratio 1.0  — baseline, max concurrency
-    (128, 2048),     # ratio 0.06 — extreme decode (chatbot-like)
-    (512, 1024),     # ratio 0.5  — medium decode-heavy
-    (1024, 512),     # ratio 2.0  — medium balanced
-    (4096, 1024),    # ratio 4.0  — long context, prefill-leaning
-    (8192, 256),     # ratio 32.0 — extreme prefill (RAG/summarization)
-    (16384, 2048),   # ratio 8.0  — maximum context stress test
+    (128, 128),  # ratio 1.0  — baseline, max concurrency
+    (128, 2048),  # ratio 0.06 — extreme decode (chatbot-like)
+    (512, 1024),  # ratio 0.5  — medium decode-heavy
+    (1024, 512),  # ratio 2.0  — medium balanced
+    (4096, 1024),  # ratio 4.0  — long context, prefill-leaning
+    (8192, 256),  # ratio 32.0 — extreme prefill (RAG/summarization)
+    (16384, 2048),  # ratio 8.0  — maximum context stress test
 ]
 
 GPU_TYPES = ["A10G", "L40S", "L4", "A100_40gb", "A100_80gb", "H100"]
@@ -79,13 +83,15 @@ def generate_experiment_csv(output_path, models, tp_pp_configs, io_lengths):
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         for model, (tp, pp), (in_len, out_len) in product(models, tp_pp_configs, io_lengths):
-            writer.writerow({
-                "model": model,
-                "tensor_degree": tp,
-                "pipeline_degree": pp,
-                "max_input_length": in_len,
-                "max_output_length": out_len,
-            })
+            writer.writerow(
+                {
+                    "model": model,
+                    "tensor_degree": tp,
+                    "pipeline_degree": pp,
+                    "max_input_length": in_len,
+                    "max_output_length": out_len,
+                }
+            )
             count += 1
     return count
 
@@ -93,6 +99,7 @@ def generate_experiment_csv(output_path, models, tp_pp_configs, io_lengths):
 def get_cluster_info(tp, pp, gpu_type):
     """Get cluster sizing for a TP/PP config (uses same logic as automatic_launch_1)."""
     from automatic_launch_1 import get_cluster_config
+
     gpu_config = GPU_CONFIGS[gpu_type]
     gpus_per_node, num_nodes = get_cluster_config(tp, pp, gpu_type)
     total_gpus = gpus_per_node * num_nodes
@@ -140,7 +147,9 @@ def render_sweep_plan(models, tp_pp_configs, io_lengths, gpu_types, cloud="aws")
     print(f"\n  GPU types ({len(gpu_types)}):")
     for gpu_type in gpu_types:
         gpu_config = GPU_CONFIGS[gpu_type]
-        print(f"\n    {gpu_type} ({gpu_config['gpu_generation']}, {gpu_config['gpu_mem_gb']}GB, {gpu_config['interconnect']}):")
+        print(
+            f"\n    {gpu_type} ({gpu_config['gpu_generation']}, {gpu_config['gpu_mem_gb']}GB, {gpu_config['interconnect']}):"
+        )
 
         # Group experiments by cluster config to show how many clusters are needed
         clusters = {}
@@ -159,8 +168,7 @@ def render_sweep_plan(models, tp_pp_configs, io_lengths, gpu_types, cloud="aws")
             est_hours = n_exp * 5 / 60
             est_cost = price * est_hours
             total_cost_estimate += est_cost
-            print(f"      {desc:>25s}  ({gpus} GPU/node × {nodes} node)  "
-                  f"{n_exp:>3} experiments  ~${est_cost:.0f} est.")
+            print(f"      {desc:>25s}  ({gpus} GPU/node × {nodes} node)  {n_exp:>3} experiments  ~${est_cost:.0f} est.")
 
         print(f"      {'':>25s}  Total: ~${total_cost_estimate:.0f} estimated cost")
 
@@ -179,7 +187,7 @@ def render_sweep_plan(models, tp_pp_configs, io_lengths, gpu_types, cloud="aws")
 
     print(f"\n  {'=' * 60}")
     print(f"  GRAND TOTAL: ~${grand_total:.0f} estimated cost (all GPU types)")
-    print(f"  (Assumes ~5 min per experiment — actual time depends on model size)")
+    print("  (Assumes ~5 min per experiment — actual time depends on model size)")
     print("=" * 80 + "\n")
 
 
@@ -197,46 +205,64 @@ Examples:
         """,
     )
     parser.add_argument(
-        "--gpu", "--gpu-type", dest="gpu_types",
-        nargs="+", choices=GPU_TYPES, default=None,
+        "--gpu",
+        "--gpu-type",
+        dest="gpu_types",
+        nargs="+",
+        choices=GPU_TYPES,
+        default=None,
         help=f"GPU type(s) to run. Default: all ({', '.join(GPU_TYPES)})",
     )
     parser.add_argument(
-        "--run", action="store_true",
+        "--run",
+        action="store_true",
         help="Actually launch clusters (default: dry-run plan only)",
     )
     parser.add_argument(
-        "--csv-only", action="store_true",
+        "--csv-only",
+        action="store_true",
         help="Generate experiment CSV(s) and exit without launching",
     )
     parser.add_argument(
-        "--s3-models", action="store_true", default=False,
+        "--s3-models",
+        action="store_true",
+        default=False,
         help="Load models from S3 instead of HuggingFace",
     )
     parser.add_argument(
-        "--hf-models", action="store_true", default=False,
+        "--hf-models",
+        action="store_true",
+        default=False,
         help="Load models from HuggingFace Hub (default when --s3-models not set)",
     )
     parser.add_argument(
-        "--models", nargs="+", default=None,
+        "--models",
+        nargs="+",
+        default=None,
         help=f"Override model list (default: {', '.join(MODELS)})",
     )
     parser.add_argument(
-        "--tp-pp", nargs="+", default=None,
+        "--tp-pp",
+        nargs="+",
+        default=None,
         help="Override TP/PP configs as 'TP,PP' pairs (e.g., --tp-pp 4,2 8,1)",
     )
     parser.add_argument(
-        "--io", nargs="+", default=None,
+        "--io",
+        nargs="+",
+        default=None,
         help="Override IO lengths as 'IN,OUT' pairs (e.g., --io 512,128 2048,512)",
     )
     parser.add_argument(
-        "--cloud", dest="cloud",
+        "--cloud",
+        dest="cloud",
         choices=["aws", "gcp", "azure"],
         default="aws",
         help="Cloud provider to launch on (default: aws). Ensures all instances stay on one cloud.",
     )
     parser.add_argument(
-        "--spot", action="store_true",
+        "--spot",
+        action="store_true",
         help="Use spot/preemptible instances (cheaper but may be interrupted)",
     )
 
@@ -295,7 +321,8 @@ Examples:
                 parent_dir = "results"
                 cluster_config = (gpus, nodes)
                 results = run_cluster_benchmarks(
-                    cluster_config, exps,
+                    cluster_config,
+                    exps,
                     parent_dir=parent_dir,
                     dry_run=False,
                     gpu_type=gpu_type,
@@ -308,6 +335,7 @@ Examples:
         except Exception as e:
             print(f"\n❌ Error during {gpu_type} sweep: {e}")
             import traceback
+
             traceback.print_exc()
 
     if all_results:

--- a/profiling/roofline/vllm/automatic_launch_1.py
+++ b/profiling/roofline/vllm/automatic_launch_1.py
@@ -1,19 +1,20 @@
+import argparse
+import atexit
 import csv
 import json
-import os
-import time
-import select
-from dataclasses import dataclass
-import subprocess
-from collections import defaultdict
-import sys
-import argparse
-from pathlib import Path
-import requests
-import signal
-import atexit
 import logging
+import os
+import select
+import signal
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
+
+import requests
 
 # GPU type configurations
 # Each GPU type maps to: available GPU counts per instance, instance family, and pricing
@@ -128,6 +129,7 @@ VM_SELECTION_STRATEGIES = {
 # Global logger instance
 logger = logging.getLogger("benchmark")
 
+
 def setup_logger(log_file_path: Path):
     """Set up logger to write to both console and file."""
     logger.setLevel(logging.DEBUG)
@@ -138,13 +140,13 @@ def setup_logger(log_file_path: Path):
     # Console handler - prints to stdout
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(logging.INFO)
-    console_format = logging.Formatter('%(message)s')
+    console_format = logging.Formatter("%(message)s")
     console_handler.setFormatter(console_format)
 
     # File handler - writes to log file
-    file_handler = logging.FileHandler(log_file_path, mode='w')
+    file_handler = logging.FileHandler(log_file_path, mode="w")
     file_handler.setLevel(logging.DEBUG)
-    file_format = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    file_format = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
     file_handler.setFormatter(file_format)
 
     logger.addHandler(console_handler)
@@ -152,12 +154,14 @@ def setup_logger(log_file_path: Path):
 
     return logger
 
+
 # Track active cluster for cleanup on unexpected exit
 # Uses PID-based files so parallel processes don't stomp each other
 _active_cluster = None
 _active_cluster_dir = Path("/tmp/.benchmark_clusters")
 _active_cluster_dir.mkdir(exist_ok=True)
 _active_cluster_file = _active_cluster_dir / f"cluster_pid{os.getpid()}"
+
 
 def set_active_cluster(cluster_name):
     """Set active cluster and persist to PID-specific file for crash recovery."""
@@ -168,6 +172,7 @@ def set_active_cluster(cluster_name):
     elif _active_cluster_file.exists():
         _active_cluster_file.unlink()
 
+
 def get_active_cluster():
     """Get active cluster from memory or file."""
     global _active_cluster
@@ -176,6 +181,7 @@ def get_active_cluster():
     if _active_cluster_file.exists():
         return _active_cluster_file.read_text().strip()
     return None
+
 
 def cleanup_on_exit():
     """Cleanup handler for unexpected exits."""
@@ -192,11 +198,13 @@ def cleanup_on_exit():
             if _active_cluster_file.exists():
                 _active_cluster_file.unlink()
 
+
 def signal_handler(signum, frame):
     """Handle Ctrl+C and other signals."""
     print(f"\n🛑 Received signal {signum}. Cleaning up...")
     cleanup_on_exit()
     sys.exit(1)
+
 
 def check_orphaned_cluster():
     """Check for orphaned clusters from crashed runs (dead PIDs only).
@@ -218,7 +226,7 @@ def check_orphaned_cluster():
             # Process is dead — this is truly orphaned
             cluster = f.read_text().strip()
             print(f"⚠️  Found orphaned cluster {cluster} (owner pid {pid} is dead)")
-            print(f"   Terminating...")
+            print("   Terminating...")
             try:
                 subprocess.run(["sky", "down", "-y", cluster], timeout=300)
                 print(f"   ✅ Terminated {cluster}")
@@ -229,10 +237,12 @@ def check_orphaned_cluster():
             # Bad file or permission issue — clean up
             f.unlink()
 
+
 # Register cleanup handlers
 atexit.register(cleanup_on_exit)
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
+
 
 def get_cluster_config(tp, pp, gpu_type=DEFAULT_GPU_TYPE, vm_strategy="prefer_single_node"):
     """
@@ -304,76 +314,80 @@ def load_experiments(csv_path):
     with open(csv_path) as f:
         reader = csv.DictReader(f)
         for row in reader:
-            experiments.append({
-                'tp': int(row['tensor_degree']),
-                'pp': int(row['pipeline_degree']),
-                'max_input_length': int(row['max_input_length']),
-                'max_output_length': int(row['max_output_length']),
-                'model': row['model']
-            })
+            experiments.append(
+                {
+                    "tp": int(row["tensor_degree"]),
+                    "pp": int(row["pipeline_degree"]),
+                    "max_input_length": int(row["max_input_length"]),
+                    "max_output_length": int(row["max_output_length"]),
+                    "model": row["model"],
+                }
+            )
     return experiments
+
 
 def group_by_cluster_then_io(experiments, gpu_type=DEFAULT_GPU_TYPE, vm_strategy="prefer_single_node"):
     """Group experiments: same cluster config runs multiple I/O shapes.
-    
+
     Groups by (gpus_per_node, num_nodes, tp, pp, model) so that a single
     server instance can serve all I/O shapes for the same model/parallelism config.
-    
+
     Returns: {(gpus_per_node, num_nodes, tp, pp, model): [experiments]}
     """
     groups = defaultdict(list)
     for exp in experiments:
-        gpus_per_node, num_nodes = get_cluster_config(exp['tp'], exp['pp'], gpu_type, vm_strategy=vm_strategy)
-        key = (gpus_per_node, num_nodes, exp['tp'], exp['pp'], exp['model'])
+        gpus_per_node, num_nodes = get_cluster_config(exp["tp"], exp["pp"], gpu_type, vm_strategy=vm_strategy)
+        key = (gpus_per_node, num_nodes, exp["tp"], exp["pp"], exp["model"])
         groups[key].append(exp)
     return dict(groups)
+
 
 def cleanup_old_benchmark_files(work_dir=None):
     """
     Remove old benchmark files that don't have GPU type in their names.
     These files are from the old naming scheme and are now obsolete.
-    
+
     Old naming pattern: roofline-tp{TP}-pp{PP}[-{input}in-{output}out].yaml
     New naming pattern: roofline-tp{TP}-pp{PP}-{input}in-{output}out-{GPU_TYPE}.yaml
-    
+
     This function identifies old files by checking if they don't end with any known GPU type.
     """
     if work_dir is None:
         work_dir = Path("roofline_benchmarks")
-    
+
     if not work_dir.exists():
         print("ℹ️  roofline_benchmarks directory doesn't exist")
         return 0
-    
+
     # List of known GPU types to check against
     known_gpu_types = list(GPU_CONFIGS.keys())
     gpu_type_suffixes = [gpu.replace("_", "-").replace("/", "-") for gpu in known_gpu_types]
-    
+
     removed_count = 0
     removed_files = []
-    
+
     # Check YAML files
     for file_path in work_dir.glob("roofline-*.yaml"):
         # Check if filename doesn't end with any GPU type suffix
         filename = file_path.stem  # without .yaml extension
         has_gpu_type = any(filename.endswith(f"-{suffix}") for suffix in gpu_type_suffixes)
-        
+
         if not has_gpu_type:
             removed_files.append(file_path.name)
             file_path.unlink()
             removed_count += 1
-    
+
     # Check Python benchmark scripts
     for file_path in work_dir.glob("benchmark_roofline-*.py"):
         # Check if filename doesn't end with any GPU type suffix
         filename = file_path.stem.replace("benchmark_roofline-", "")  # remove prefix
         has_gpu_type = any(filename.endswith(f"-{suffix}") for suffix in gpu_type_suffixes)
-        
+
         if not has_gpu_type:
             removed_files.append(file_path.name)
             file_path.unlink()
             removed_count += 1
-    
+
     if removed_count > 0:
         print(f"🗑️  Removed {removed_count} old benchmark files:")
         for fname in sorted(removed_files):
@@ -381,10 +395,20 @@ def cleanup_old_benchmark_files(work_dir=None):
         print(f"✅ Cleaned up {removed_count} old benchmark files")
     else:
         print("ℹ️  No old benchmark files to clean up")
-    
+
     return removed_count
 
-def generate_yaml(gpus_per_node, num_nodes, cluster_name, experiments, gpu_type=DEFAULT_GPU_TYPE, s3_models=False, cloud="aws", use_spot=False):
+
+def generate_yaml(
+    gpus_per_node,
+    num_nodes,
+    cluster_name,
+    experiments,
+    gpu_type=DEFAULT_GPU_TYPE,
+    s3_models=False,
+    cloud="aws",
+    use_spot=False,
+):
     # Determine if this GPU type uses EFA-capable instances (A100/H100 on AWS)
     is_efa_capable = gpu_type.upper().startswith("A100") or gpu_type.upper() == "H100"
 
@@ -412,7 +436,7 @@ def generate_yaml(gpus_per_node, num_nodes, cluster_name, experiments, gpu_type=
 """
 
     # Check if any experiment needs Ray (PP > 1)
-    needs_ray = any(exp['pp'] > 1 for exp in experiments)
+    needs_ray = any(exp["pp"] > 1 for exp in experiments)
 
     ray_run = f"""{env_exports}
   python roofline_benchmarks/benchmark_{cluster_name}.py
@@ -491,14 +515,16 @@ def generate_yaml(gpus_per_node, num_nodes, cluster_name, experiments, gpu_type=
     # Build file_mounts block for S3 model loading
     file_mounts_block = ""
     if s3_models:
-        unique_models = list(dict.fromkeys(exp['model'] for exp in experiments))
+        unique_models = list(dict.fromkeys(exp["model"] for exp in experiments))
         mounts = []
         for model_name in unique_models:
-            mounts.append(f"  /models/{model_name}:\n    source: s3://{DEFAULT_S3_BUCKET}/{DEFAULT_S3_PREFIX}/{model_name}\n    mode: COPY")
+            mounts.append(
+                f"  /models/{model_name}:\n    source: s3://{DEFAULT_S3_BUCKET}/{DEFAULT_S3_PREFIX}/{model_name}\n    mode: COPY"
+            )
         file_mounts_block = "\nfile_mounts:\n" + "\n".join(mounts) + "\n"
 
     # Scale disk for large models (MoE models like 235B need ~470GB for weights alone)
-    model_names = [exp['model'] for exp in experiments]
+    model_names = [exp["model"] for exp in experiments]
     disk_size_gb = 500
     for mn in model_names:
         mn_lower = mn.lower()
@@ -674,7 +700,9 @@ run: |
   echo "Cluster ready for benchmarking"
 """
 
+
 DISCORD_WEBHOOK = "https://discord.com/api/webhooks/1453154642706960485/iFXIAaDTLxNO7_GHKHhXnXwFFnXziniP4TUwLUDUnXHtT9kNo08eQBjGQ4CiBr6AazY6"
+
 
 def send_discord_message(message):
     try:
@@ -683,9 +711,12 @@ def send_discord_message(message):
     except Exception:
         pass
 
-def generate_benchmark_script(experiments, gpus_per_node, num_nodes, gpu_type=DEFAULT_GPU_TYPE, s3_models=False, cloud="aws"):
+
+def generate_benchmark_script(
+    experiments, gpus_per_node, num_nodes, gpu_type=DEFAULT_GPU_TYPE, s3_models=False, cloud="aws"
+):
     """Generate Python benchmark script for a set of experiments.
-    
+
     Generates a server-mode orchestrator that:
     1. Starts vLLM OpenAI-compatible server as subprocess
     2. Runs benchmark_client.py for each I/O shape
@@ -702,11 +733,11 @@ def generate_benchmark_script(experiments, gpus_per_node, num_nodes, gpu_type=DE
         cluster_instance_type = f"{num_nodes}x {instance_type}"
     else:
         cluster_instance_type = instance_type
-    
+
     # Model path expressions for the generated script
     if s3_models:
-        model_path_line = 'model_path = f"/models/" + exp[\'model\']'
-        global_model_path_line = 'MODEL_PATH = f"/models/" + EXPERIMENTS[0][\'model\']'
+        model_path_line = "model_path = f\"/models/\" + exp['model']"
+        global_model_path_line = "MODEL_PATH = f\"/models/\" + EXPERIMENTS[0]['model']"
     else:
         model_path_line = "model_path = exp['model']"
         global_model_path_line = "MODEL_PATH = EXPERIMENTS[0]['model']"
@@ -1965,12 +1996,22 @@ finally:
     print("✅ Server stopped")
 '''
 
-def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run=True, gpu_type=DEFAULT_GPU_TYPE, s3_models=False, cloud="aws", use_spot=False):
+
+def run_cluster_benchmarks(
+    cluster_config,
+    experiments,
+    parent_dir=None,
+    dry_run=True,
+    gpu_type=DEFAULT_GPU_TYPE,
+    s3_models=False,
+    cloud="aws",
+    use_spot=False,
+):
     gpus_per_node, num_nodes = cluster_config
     # Use TP/PP from the first experiment for naming (all experiments in a group have compatible TP/PP)
-    tp = experiments[0]['tp']
-    pp = experiments[0]['pp']
-    model = experiments[0]['model']
+    tp = experiments[0]["tp"]
+    pp = experiments[0]["pp"]
+    model = experiments[0]["model"]
     # Short model slug for cluster name (e.g., "Qwen/Qwen3-32B" → "qwen3-32b")
     model_slug = model.split("/")[-1].lower().replace("_", "-").replace(".", "-")[:20]
     # Normalize GPU type for use in filenames (replace special chars)
@@ -2013,32 +2054,36 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
                 with open(results_file) as f:
                     prior = json.load(f)
                 # Check model matches AND all experiment IDs are present
-                prior_models = {r.get('model') for r in prior if r.get('status') == 'success'}
+                prior_models = {r.get("model") for r in prior if r.get("status") == "success"}
                 if model in prior_models:
-                    prior_success = {r['exp_id'] for r in prior if r.get('status') == 'success' and r.get('model') == model}
-                    needed = {f"tp{e['tp']}_pp{e['pp']}_in{e['max_input_length']}_out{e['max_output_length']}" for e in experiments}
+                    prior_success = {
+                        r["exp_id"] for r in prior if r.get("status") == "success" and r.get("model") == model
+                    }
+                    needed = {
+                        f"tp{e['tp']}_pp{e['pp']}_in{e['max_input_length']}_out{e['max_output_length']}"
+                        for e in experiments
+                    }
                     if needed.issubset(prior_success):
                         print(f"\n⏭️  Skipping {cluster_name} — already completed in {latest.name}")
-                        return [r for r in prior if r.get('model') == model]
+                        return [r for r in prior if r.get("model") == model]
             except Exception:
                 pass  # corrupted results, re-run
 
     instance_path.mkdir(parents=True, exist_ok=True)
     result_dir = instance_path / subdir_name
 
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * 70}")
     print(f"Cluster: {cluster_name}")
     print(f"Config: {gpus_per_node} GPUs/node × {num_nodes} nodes")
     print(f"Experiments: {len(experiments)}")
-    print("="*70)
+    print("=" * 70)
 
     if dry_run:
         print("[DRY RUN] Would launch and run:")
         for exp in experiments:
-            print(f"  - TP={exp['tp']}, PP={exp['pp']}, "
-                  f"in={exp['max_input_length']}, out={exp['max_output_length']}")
+            print(f"  - TP={exp['tp']}, PP={exp['pp']}, in={exp['max_input_length']}, out={exp['max_output_length']}")
         if len(experiments) > 3:
-            print(f"  ... and {len(experiments)-3} more")
+            print(f"  ... and {len(experiments) - 3} more")
         return []
 
     # Create result directory and set up logging
@@ -2056,16 +2101,28 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
     work_dir.mkdir(exist_ok=True)
     yaml_path = work_dir / f"{cluster_name}.yaml"
     script_path = work_dir / f"benchmark_{cluster_name}.py"
-    
-    yaml_content = generate_yaml(gpus_per_node, num_nodes, cluster_name, experiments, gpu_type, s3_models=s3_models, cloud=cloud, use_spot=use_spot)
+
+    yaml_content = generate_yaml(
+        gpus_per_node,
+        num_nodes,
+        cluster_name,
+        experiments,
+        gpu_type,
+        s3_models=s3_models,
+        cloud=cloud,
+        use_spot=use_spot,
+    )
     yaml_path.write_text(yaml_content)
 
     # 2. Write benchmark script
-    script_content = generate_benchmark_script(experiments, gpus_per_node, num_nodes, gpu_type, s3_models=s3_models, cloud=cloud)
+    script_content = generate_benchmark_script(
+        experiments, gpus_per_node, num_nodes, gpu_type, s3_models=s3_models, cloud=cloud
+    )
     script_path.write_text(script_content)
 
     # 3. Copy static helper files into workdir (uploaded to cluster with sky launch)
     import shutil
+
     src_dir = Path(__file__).parent
     for helper_file in ["benchmark_client.py", "prometheus_parser.py"]:
         src = src_dir / helper_file
@@ -2091,7 +2148,7 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
-            bufsize=1
+            bufsize=1,
         )
 
         # Stream output with watchdog: kill if no output for 30 minutes
@@ -2124,29 +2181,28 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
             raise subprocess.CalledProcessError(process.returncode, "sky launch")
 
         # 5. Fetch results
-        logger.info(f"📥 Fetching results...")
-        subprocess.run([
-            "scp",
-            f"{cluster_name}:/tmp/benchmark_results.json",
-            str(local_results)
-        ], check=True)
+        logger.info("📥 Fetching results...")
+        subprocess.run(["scp", f"{cluster_name}:/tmp/benchmark_results.json", str(local_results)], check=True)
 
         # Fetch timeseries files directly into result directory
-        logger.info(f"📈 Fetching timeseries data...")
-        subprocess.run([
-            "scp",
-            f"{cluster_name}:/tmp/timeseries_*.json",
-            str(result_dir)  # Path object converts to string correctly
-        ], check=False)  # Don't fail if no timeseries files
+        logger.info("📈 Fetching timeseries data...")
+        subprocess.run(
+            [
+                "scp",
+                f"{cluster_name}:/tmp/timeseries_*.json",
+                str(result_dir),  # Path object converts to string correctly
+            ],
+            check=False,
+        )  # Don't fail if no timeseries files
 
         # Update results with local timeseries paths
         with open(local_results) as f:
             results = json.load(f)
 
         # Check if all experiments succeeded or any failed
-        all_succeeded = all(r.get('status') == 'success' for r in results)
-        status_suffix = 'success' if all_succeeded else 'fail'
-        
+        all_succeeded = all(r.get("status") == "success" for r in results)
+        status_suffix = "success" if all_succeeded else "fail"
+
         # Rename directory to include status suffix
         new_subdir_name = f"tp{tp}-pp{pp}-{instance_name_safe}-{timestamp}-{status_suffix}"
         new_result_dir = instance_path / new_subdir_name
@@ -2159,16 +2215,16 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
             local_results = result_dir / "results.json"
 
         for result in results:
-            if 'timeseries_file' in result and result.get('status') == 'success':
+            if "timeseries_file" in result and result.get("status") == "success":
                 # Update path to local location
-                remote_filename = Path(result['timeseries_file']).name
+                remote_filename = Path(result["timeseries_file"]).name
                 local_ts_path = result_dir / remote_filename
-                result['timeseries_file'] = str(local_ts_path)
+                result["timeseries_file"] = str(local_ts_path)
 
         # Save updated results
-        with open(local_results, 'w') as f:
+        with open(local_results, "w") as f:
             json.dump(results, f, indent=2)
-        
+
         # Save CSV in the same result directory with timestamp
         csv_filename = f"benchmark_results-{timestamp}.csv"
         csv_path = result_dir / csv_filename
@@ -2177,9 +2233,7 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
         # Automatically plot timeseries for successful experiments
         try:
             successful_ts_files = [
-                Path(r['timeseries_file'])
-                for r in results
-                if r.get('status') == 'success' and r.get('timeseries_file')
+                Path(r["timeseries_file"]) for r in results if r.get("status") == "success" and r.get("timeseries_file")
             ]
             if successful_ts_files:
                 logger.info(f"📈 Plotting timeseries for {len(successful_ts_files)} successful experiment(s)...")
@@ -2197,7 +2251,7 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
                 )
         except Exception as plot_err:
             logger.warning(f"⚠️  Failed to generate timeseries plots: {plot_err}")
-        
+
         logger.info(f"✅ Results saved to {result_dir}/")
         send_discord_message(f"✅ Results saved to {result_dir}")
         return results
@@ -2205,52 +2259,50 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
     except Exception as e:
         # Cluster error occurred, but benchmark might have completed successfully
         logger.error(f"❌ Cluster error: {e}")
-        logger.info(f"📥 Attempting to fetch results (benchmark may have completed)...")
-        
+        logger.info("📥 Attempting to fetch results (benchmark may have completed)...")
+
         fetched_results = None
         try:
-            logger.info(f"📥 Fetching results.json from cluster...")
-            subprocess.run([
-                "scp",
-                f"{cluster_name}:/tmp/benchmark_results.json",
-                str(local_results)
-            ], check=True)
-            
+            logger.info("📥 Fetching results.json from cluster...")
+            subprocess.run(["scp", f"{cluster_name}:/tmp/benchmark_results.json", str(local_results)], check=True)
+
             # Best-effort fetch of timeseries files even when sky launch failed
-            logger.info(f"📈 Attempting to fetch timeseries data from cluster (best-effort)...")
-            subprocess.run([
-                "scp",
-                f"{cluster_name}:/tmp/timeseries_*.json",
-                str(result_dir)
-            ], check=False)  # Don't fail the cleanup path if timeseries are missing
-            
+            logger.info("📈 Attempting to fetch timeseries data from cluster (best-effort)...")
+            subprocess.run(
+                ["scp", f"{cluster_name}:/tmp/timeseries_*.json", str(result_dir)], check=False
+            )  # Don't fail the cleanup path if timeseries are missing
+
             # Check if we successfully fetched valid results
             if local_results.exists():
                 with open(local_results) as f:
                     fetched_results = json.load(f)
                     # Check if any results have 'success' status
-                    has_success = any(r.get('status') == 'success' for r in fetched_results)
+                    has_success = any(r.get("status") == "success" for r in fetched_results)
                     if has_success:
-                        logger.info(f"✅ Found successful benchmark results despite cluster error!")
-                        logger.info(f"   This is likely a cleanup error, not a benchmark failure.")
-                        send_discord_message(f"✅ Cluster {cluster_name} completed benchmarks but had a cleanup error: {str(e)[:80]}")
+                        logger.info("✅ Found successful benchmark results despite cluster error!")
+                        logger.info("   This is likely a cleanup error, not a benchmark failure.")
+                        send_discord_message(
+                            f"✅ Cluster {cluster_name} completed benchmarks but had a cleanup error: {str(e)[:80]}"
+                        )
                     else:
                         send_discord_message(f"❌ Cluster {cluster_name} FAILED: {str(e)[:100]}")
         except Exception as fetch_error:
             logger.warning(f"⚠️  Could not fetch results: {fetch_error}")
-            send_discord_message(f"❌ Cluster {cluster_name} FAILED and results could not be fetched: {str(e)[:60]} | fetch error: {str(fetch_error)[:60]}")
-        
+            send_discord_message(
+                f"❌ Cluster {cluster_name} FAILED and results could not be fetched: {str(e)[:60]} | fetch error: {str(fetch_error)[:60]}"
+            )
+
         # Use fetched results if they contain successful benchmarks, otherwise mark as failed
-        if fetched_results and any(r.get('status') == 'success' for r in fetched_results):
+        if fetched_results and any(r.get("status") == "success" for r in fetched_results):
             results = fetched_results
             # Determine status suffix based on whether all succeeded
-            all_succeeded = all(r.get('status') == 'success' for r in results)
-            status_suffix = 'success' if all_succeeded else 'fail'
+            all_succeeded = all(r.get("status") == "success" for r in results)
+            status_suffix = "success" if all_succeeded else "fail"
         else:
             # No valid results fetched, mark all as failed
-            results = [{**exp, 'status': 'cluster_error', 'error': str(e)} for exp in experiments]
-            status_suffix = 'fail'
-        
+            results = [{**exp, "status": "cluster_error", "error": str(e)} for exp in experiments]
+            status_suffix = "fail"
+
         # Rename directory to include status suffix
         new_subdir_name = f"tp{tp}-pp{pp}-{instance_name_safe}-{timestamp}-{status_suffix}"
         new_result_dir = instance_path / new_subdir_name
@@ -2261,28 +2313,28 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
             result_dir = new_result_dir
             # Update local_results path
             local_results = result_dir / "results.json"
-        
+
         # If we have successful results and timeseries files, rewrite their paths
-        if results and any(r.get('status') == 'success' for r in results):
+        if results and any(r.get("status") == "success" for r in results):
             for result in results:
-                if 'timeseries_file' in result and result.get('status') == 'success':
-                    remote_filename = Path(result['timeseries_file']).name
+                if "timeseries_file" in result and result.get("status") == "success":
+                    remote_filename = Path(result["timeseries_file"]).name
                     local_ts_path = result_dir / remote_filename
-                    result['timeseries_file'] = str(local_ts_path)
-        
+                    result["timeseries_file"] = str(local_ts_path)
+
         # Save results (either fetched successful ones or failed markers)
-        with open(local_results, 'w') as f:
+        with open(local_results, "w") as f:
             json.dump(results, f, indent=2)
-        
+
         # Save CSV in the same result directory
         csv_filename = f"benchmark_results-{timestamp}.csv"
         csv_path = result_dir / csv_filename
         save_results_csv(results, str(csv_path))
 
         # If we have successful results, also attempt to plot timeseries
-        if results and any(r.get('status') == 'success' for r in results):
+        if results and any(r.get("status") == "success" for r in results):
             try:
-                logger.info(f"📈 Plotting timeseries for successful experiment(s) after cluster error...")
+                logger.info("📈 Plotting timeseries for successful experiment(s) after cluster error...")
                 subprocess.run(
                     [
                         "python",
@@ -2295,7 +2347,7 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
                 )
             except Exception as plot_err:
                 logger.warning(f"⚠️  Failed to generate timeseries plots after cluster error: {plot_err}")
-        
+
         return results
 
     finally:
@@ -2305,8 +2357,6 @@ def run_cluster_benchmarks(cluster_config, experiments, parent_dir=None, dry_run
 
         # Clear active cluster after successful teardown
         set_active_cluster(None)
-
-
 
 
 def save_results_csv(all_results, output_path="benchmark_results.csv"):
@@ -2319,7 +2369,7 @@ def save_results_csv(all_results, output_path="benchmark_results.csv"):
         for key in result.keys():
             if key not in fieldnames:
                 fieldnames.append(key)
-    with open(output_path, 'w', newline='') as f:
+    with open(output_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(all_results)
@@ -2332,51 +2382,69 @@ def main():
 
     # Parse arguments
     parser = argparse.ArgumentParser(
-        description='Run benchmark experiments on AWS GPU instances',
+        description="Run benchmark experiments on AWS GPU instances",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=f'''
-Available GPU types: {', '.join(GPU_CONFIGS.keys())}
+        epilog=f"""
+Available GPU types: {", ".join(GPU_CONFIGS.keys())}
 Default: {DEFAULT_GPU_TYPE}
 
 Examples:
   python automatic_launch_1.py --gpu L40S
   python automatic_launch_1.py experiment.csv --gpu A100 --run
   python automatic_launch_1.py --gpu H100 --run
-        '''
+        """,
     )
-    parser.add_argument('csv_file', nargs='?', default='experiment_L40_llama.csv',
-                       help='CSV file with experiment configurations (default: experiment_L40_llama.csv)')
-    parser.add_argument('--gpu', '--gpu-type', dest='gpu_type', 
-                       choices=list(GPU_CONFIGS.keys()),
-                       default=DEFAULT_GPU_TYPE,
-                       help=f'GPU type to use (default: {DEFAULT_GPU_TYPE})')
-    parser.add_argument('--vm-strategy', dest='vm_strategy',
-                       choices=list(VM_SELECTION_STRATEGIES.keys()),
-                       default='fit_tp_then_scale',
-                       help='VM selection strategy for TP/PP -> cluster sizing')
-    parser.add_argument('--run', action='store_true',
-                       help='Actually launch clusters (default: dry run)')
-    parser.add_argument('--s3-models', action='store_true',
-                       help='Load models from S3 instead of HuggingFace (faster, requires prior upload via upload_model_to_s3.py)')
-    parser.add_argument('--cloud', dest='cloud',
-                       choices=['aws', 'gcp', 'azure'],
-                       default='aws',
-                       help='Cloud provider to launch on (default: aws)')
-    parser.add_argument('--spot', action='store_true',
-                       help='Use spot/preemptible instances (cheaper but may be interrupted)')
-    parser.add_argument('--cleanup', action='store_true',
-                       help='Clean up old benchmark files without GPU type in their names')
-    
+    parser.add_argument(
+        "csv_file",
+        nargs="?",
+        default="experiment_L40_llama.csv",
+        help="CSV file with experiment configurations (default: experiment_L40_llama.csv)",
+    )
+    parser.add_argument(
+        "--gpu",
+        "--gpu-type",
+        dest="gpu_type",
+        choices=list(GPU_CONFIGS.keys()),
+        default=DEFAULT_GPU_TYPE,
+        help=f"GPU type to use (default: {DEFAULT_GPU_TYPE})",
+    )
+    parser.add_argument(
+        "--vm-strategy",
+        dest="vm_strategy",
+        choices=list(VM_SELECTION_STRATEGIES.keys()),
+        default="fit_tp_then_scale",
+        help="VM selection strategy for TP/PP -> cluster sizing",
+    )
+    parser.add_argument("--run", action="store_true", help="Actually launch clusters (default: dry run)")
+    parser.add_argument(
+        "--s3-models",
+        action="store_true",
+        help="Load models from S3 instead of HuggingFace (faster, requires prior upload via upload_model_to_s3.py)",
+    )
+    parser.add_argument(
+        "--cloud",
+        dest="cloud",
+        choices=["aws", "gcp", "azure"],
+        default="aws",
+        help="Cloud provider to launch on (default: aws)",
+    )
+    parser.add_argument(
+        "--spot", action="store_true", help="Use spot/preemptible instances (cheaper but may be interrupted)"
+    )
+    parser.add_argument(
+        "--cleanup", action="store_true", help="Clean up old benchmark files without GPU type in their names"
+    )
+
     args = parser.parse_args()
-    
+
     # Handle cleanup option
     if args.cleanup:
         print("🧹 Cleaning up old benchmark files...")
         cleanup_old_benchmark_files()
-        if not args.run and args.csv_file == parser.get_default('csv_file'):
+        if not args.run and args.csv_file == parser.get_default("csv_file"):
             # If only cleanup was requested (no other args), exit after cleanup
             return
-    
+
     csv_path = args.csv_file
     gpu_type = args.gpu_type
     vm_strategy = args.vm_strategy
@@ -2391,10 +2459,12 @@ Examples:
     cluster_groups = group_by_cluster_then_io(experiments, gpu_type, vm_strategy=vm_strategy)
 
     print(f"📊 Loaded {len(experiments)} experiments")
-    print(f"📦 Grouped by cluster config (server reuse across I/O shapes):")
+    print("📦 Grouped by cluster config (server reuse across I/O shapes):")
     for (gpus, nodes, tp, pp, model), exps in sorted(cluster_groups.items()):
-        io_shapes = set((e['max_input_length'], e['max_output_length']) for e in exps)
-        print(f"   TP={tp}, PP={pp}, {gpus} GPU/node × {nodes} nodes: {len(exps)} experiments ({len(io_shapes)} I/O shapes)")
+        io_shapes = set((e["max_input_length"], e["max_output_length"]) for e in exps)
+        print(
+            f"   TP={tp}, PP={pp}, {gpus} GPU/node × {nodes} nodes: {len(exps)} experiments ({len(io_shapes)} I/O shapes)"
+        )
         for il, ol in sorted(io_shapes):
             print(f"      {il}in/{ol}out")
 
@@ -2408,12 +2478,16 @@ Examples:
         for (gpus, nodes, tp, pp, model), exps in sorted(cluster_groups.items()):
             # Parent directory: use results/ with all I/O shapes in one cluster
             parent_dir = "results"
-            
+
             cluster_config = (gpus, nodes)
             results = run_cluster_benchmarks(
-                cluster_config, exps, parent_dir=parent_dir,
-                dry_run=dry_run, gpu_type=gpu_type,
-                s3_models=args.s3_models, cloud=args.cloud,
+                cluster_config,
+                exps,
+                parent_dir=parent_dir,
+                dry_run=dry_run,
+                gpu_type=gpu_type,
+                s3_models=args.s3_models,
+                cloud=args.cloud,
                 use_spot=args.spot,
             )
             if results:

--- a/profiling/roofline/vllm/benchmark_client.py
+++ b/profiling/roofline/vllm/benchmark_client.py
@@ -74,8 +74,7 @@ def load_prompts(dataset_name, model_name, input_len, num_prompts):
             break
 
     if len(prompts) < num_prompts:
-        print(f"⚠️  Only found {len(prompts)} prompts with >= {input_len} tokens, "
-              f"recycling to reach {num_prompts}")
+        print(f"⚠️  Only found {len(prompts)} prompts with >= {input_len} tokens, recycling to reach {num_prompts}")
         while len(prompts) < num_prompts:
             prompts.append(prompts[len(prompts) % max(1, len(prompts) - num_prompts + len(prompts))])
 
@@ -151,7 +150,7 @@ async def send_request(session, semaphore, base_url, model, prompt, output_len, 
                 "output_tokens": output_tokens,
             }
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return {"request_id": request_id, "status": "error", "error": "timeout"}
         except Exception as e:
             return {"request_id": request_id, "status": "error", "error": str(e)}
@@ -170,9 +169,16 @@ async def run_benchmark(args, prompts):
         if args.warmup_requests > 0:
             print(f"Running {args.warmup_requests} warmup requests...")
             warmup_tasks = [
-                send_request(session, semaphore, args.base_url, args.model,
-                             prompts[i % len(prompts)], args.output_len, f"warmup_{i}",
-                             args.request_timeout)
+                send_request(
+                    session,
+                    semaphore,
+                    args.base_url,
+                    args.model,
+                    prompts[i % len(prompts)],
+                    args.output_len,
+                    f"warmup_{i}",
+                    args.request_timeout,
+                )
                 for i in range(args.warmup_requests)
             ]
             await asyncio.gather(*warmup_tasks, return_exceptions=True)
@@ -183,19 +189,24 @@ async def run_benchmark(args, prompts):
         t_start = time.perf_counter()
 
         tasks = [
-            send_request(session, semaphore, args.base_url, args.model,
-                         prompts[i % len(prompts)], args.output_len, i,
-                         args.request_timeout)
+            send_request(
+                session,
+                semaphore,
+                args.base_url,
+                args.model,
+                prompts[i % len(prompts)],
+                args.output_len,
+                i,
+                args.request_timeout,
+            )
             for i in range(args.num_requests)
         ]
 
         # Track progress so long-running benchmarks don't trigger watchdog
-        completed = 0
         results = []
-        for coro in asyncio.as_completed(tasks):
+        for completed, coro in enumerate(asyncio.as_completed(tasks), start=1):
             result = await coro
             results.append(result)
-            completed += 1
             if completed % max(1, args.num_requests // 10) == 0 or completed == args.num_requests:
                 elapsed = time.perf_counter() - t_start
                 print(f"  Progress: {completed}/{args.num_requests} ({elapsed:.0f}s elapsed)")
@@ -263,8 +274,7 @@ def main(argv=None):
     args = parse_args(argv)
 
     # Load prompts
-    prompts = load_prompts(args.dataset, args.model, args.input_len,
-                           args.num_requests + args.warmup_requests)
+    prompts = load_prompts(args.dataset, args.model, args.input_len, args.num_requests + args.warmup_requests)
 
     # Run benchmark
     results, wall_clock = asyncio.run(run_benchmark(args, prompts))
@@ -275,7 +285,7 @@ def main(argv=None):
     with open(args.output, "w") as f:
         json.dump(output, f, indent=2)
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Benchmark complete: {output['num_successful']}/{args.num_requests} successful")
     print(f"Wall clock: {wall_clock:.1f}s")
     print(f"Results saved to: {args.output}")

--- a/profiling/roofline/vllm/plot_benchmark_results.py
+++ b/profiling/roofline/vllm/plot_benchmark_results.py
@@ -4,73 +4,84 @@ Professional plotting script for benchmark results analysis.
 Creates bar charts showing performance metrics across different TP/PP combinations.
 """
 
-import sys
 import os
-import pandas as pd
-import matplotlib.pyplot as plt
-from matplotlib.ticker import MaxNLocator
-import numpy as np
-import seaborn as sns
+import sys
 from pathlib import Path
 
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from matplotlib.ticker import MaxNLocator
+
 # Set professional style
-plt.style.use('seaborn-v0_8-whitegrid')
+plt.style.use("seaborn-v0_8-whitegrid")
 sns.set_palette("husl")
 
 # Custom color scheme - professional and pleasing
 COLORS = {
-    'requests_per_sec': '#2E86AB',      # Deep blue
-    'input_tokens_per_sec': '#A23B72',  # Burgundy
-    'output_tokens_per_sec': '#F18F01', # Orange
-    'total_tokens_per_sec': '#C73E1D'   # Red
+    "requests_per_sec": "#2E86AB",  # Deep blue
+    "input_tokens_per_sec": "#A23B72",  # Burgundy
+    "output_tokens_per_sec": "#F18F01",  # Orange
+    "total_tokens_per_sec": "#C73E1D",  # Red
 }
+
 
 def load_and_process_data(csv_path):
     """Load CSV and process successful experiments."""
     df = pd.read_csv(csv_path)
 
     # Filter successful experiments only
-    successful = df[df['status'] == 'success'].copy()
+    successful = df[df["status"] == "success"].copy()
 
     # Ensure numeric columns are properly typed
-    numeric_cols = ['requests_per_sec', 'input_tokens_per_sec',
-                   'output_tokens_per_sec', 'total_tokens_per_sec', 'tokens_per_dollar', 'cost_for_run_usd',
-                   'avg_sm_util_pct', 'avg_mem_bw_util_pct', 'elapsed_time']
+    numeric_cols = [
+        "requests_per_sec",
+        "input_tokens_per_sec",
+        "output_tokens_per_sec",
+        "total_tokens_per_sec",
+        "tokens_per_dollar",
+        "cost_for_run_usd",
+        "avg_sm_util_pct",
+        "avg_mem_bw_util_pct",
+        "elapsed_time",
+    ]
     for col in numeric_cols:
         if col in successful.columns:
-            successful[col] = pd.to_numeric(successful[col], errors='coerce')
+            successful[col] = pd.to_numeric(successful[col], errors="coerce")
 
     # Sort by tp, then pp
-    successful = successful.sort_values(['tp', 'pp'])
+    successful = successful.sort_values(["tp", "pp"])
 
     # Create labels for x-axis
-    successful['config'] = successful.apply(lambda x: f'TP{x["tp"]}, PP{x["pp"]}', axis=1)
+    successful["config"] = successful.apply(lambda x: f"TP{x['tp']}, PP{x['pp']}", axis=1)
 
     return successful
+
 
 def create_performance_plot(df, save_path=None):
     """Create professional bar chart for performance metrics."""
 
     # Set up professional style
-    plt.rcParams['font.family'] = 'DejaVu Sans'
-    plt.rcParams['font.weight'] = 'normal'
-    plt.rcParams['axes.titleweight'] = 'bold'
-    plt.rcParams['axes.labelweight'] = 'bold'
+    plt.rcParams["font.family"] = "DejaVu Sans"
+    plt.rcParams["font.weight"] = "normal"
+    plt.rcParams["axes.titleweight"] = "bold"
+    plt.rcParams["axes.labelweight"] = "bold"
 
     # Metrics to plot
-    metrics = ['requests_per_sec', 'input_tokens_per_sec', 'output_tokens_per_sec', 'total_tokens_per_sec']
-    metric_labels = ['Requests/sec', 'Input tokens/sec', 'Output tokens/sec', 'Total tokens/sec']
+    metrics = ["requests_per_sec", "input_tokens_per_sec", "output_tokens_per_sec", "total_tokens_per_sec"]
+    metric_labels = ["Requests/sec", "Input tokens/sec", "Output tokens/sec", "Total tokens/sec"]
 
     # Enhanced color scheme - more professional and distinct
     COLORS_ENHANCED = {
-        'requests_per_sec': '#1F4E79',      # Dark blue
-        'input_tokens_per_sec': '#8B4513',  # Dark brown
-        'output_tokens_per_sec': '#FF6B35', # Bright orange (not pink)
-        'total_tokens_per_sec': '#DC143C'   # Crimson red
+        "requests_per_sec": "#1F4E79",  # Dark blue
+        "input_tokens_per_sec": "#8B4513",  # Dark brown
+        "output_tokens_per_sec": "#FF6B35",  # Bright orange (not pink)
+        "total_tokens_per_sec": "#DC143C",  # Crimson red
     }
 
     # Set up the plot with better proportions (3 subplots now, wider for instance names)
-    fig = plt.figure(figsize=(24, 16), facecolor='white')
+    fig = plt.figure(figsize=(24, 16), facecolor="white")
 
     # Main performance plot with more space
     ax1 = plt.subplot(3, 1, 1)
@@ -89,13 +100,13 @@ def create_performance_plot(df, save_path=None):
     max_value = 0
     for i, (metric, label) in enumerate(zip(metrics, metric_labels)):
         # Position for this metric's bars
-        x_positions = group_centers - (group_width/2) + (i * bar_width) + (bar_width/2)
+        x_positions = group_centers - (group_width / 2) + (i * bar_width) + (bar_width / 2)
 
         # Get mean values for bar heights
-        mean_col = f'{metric}_mean'
-        min_col = f'{metric}_min'
-        max_col = f'{metric}_max'
-        
+        mean_col = f"{metric}_mean"
+        min_col = f"{metric}_min"
+        max_col = f"{metric}_max"
+
         if mean_col not in df.columns:
             # Fallback to original column if aggregation didn't happen
             values = df[metric].fillna(0).values
@@ -114,7 +125,7 @@ def create_performance_plot(df, save_path=None):
                 errors = np.array([errors_lower, errors_upper])
             else:
                 errors = None
-        
+
         # Filter out NaN values and ensure numeric
         values = values[~np.isnan(values)]
         if len(values) > 0:
@@ -122,43 +133,64 @@ def create_performance_plot(df, save_path=None):
 
         # Create bars with enhanced styling and error bars
         if errors is not None:
-            bars = ax1.bar(x_positions, values, bar_width,
-                          yerr=errors, capsize=3,
-                          label=label, color=COLORS_ENHANCED[metric],
-                          alpha=0.9, edgecolor='white', linewidth=1.5,
-                          error_kw={'elinewidth': 1.5, 'ecolor': '#333333', 'alpha': 0.7, 'capthick': 1.5},
-                          zorder=3)
+            bars = ax1.bar(
+                x_positions,
+                values,
+                bar_width,
+                yerr=errors,
+                capsize=3,
+                label=label,
+                color=COLORS_ENHANCED[metric],
+                alpha=0.9,
+                edgecolor="white",
+                linewidth=1.5,
+                error_kw={"elinewidth": 1.5, "ecolor": "#333333", "alpha": 0.7, "capthick": 1.5},
+                zorder=3,
+            )
         else:
-            bars = ax1.bar(x_positions, values, bar_width,
-                          label=label, color=COLORS_ENHANCED[metric],
-                          alpha=0.9, edgecolor='white', linewidth=1.5,
-                          zorder=3)
+            bars = ax1.bar(
+                x_positions,
+                values,
+                bar_width,
+                label=label,
+                color=COLORS_ENHANCED[metric],
+                alpha=0.9,
+                edgecolor="white",
+                linewidth=1.5,
+                zorder=3,
+            )
 
         # Add value labels on bars for throughput metrics
-        if metric in ['total_tokens_per_sec', 'input_tokens_per_sec', 'output_tokens_per_sec']:
+        if metric in ["total_tokens_per_sec", "input_tokens_per_sec", "output_tokens_per_sec"]:
             for bar, value in zip(bars, values):
                 height = bar.get_height()
                 # Format throughput metrics with 0 decimal places
-                label_text = f'{value:.0f}'
+                label_text = f"{value:.0f}"
 
-                ax1.text(bar.get_x() + bar.get_width()/2., height + max_value*0.03,
-                        label_text, ha='center', va='bottom',
-                        fontsize=9, fontweight='bold', color='#1a1a1a',
-                        rotation=90,  # Rotate 45 degrees as requested
-                        bbox=dict(boxstyle="round,pad=0.2", facecolor='white',
-                                edgecolor='none', alpha=0.9))
+                ax1.text(
+                    bar.get_x() + bar.get_width() / 2.0,
+                    height + max_value * 0.03,
+                    label_text,
+                    ha="center",
+                    va="bottom",
+                    fontsize=9,
+                    fontweight="bold",
+                    color="#1a1a1a",
+                    rotation=90,  # Rotate 45 degrees as requested
+                    bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor="none", alpha=0.9),
+                )
 
     # Create secondary y-axis for cost (total price)
     ax1_right = ax1.twinx()
-    
+
     # Get cost values (use mean if aggregated)
-    cost_col = 'cost_for_run_usd_mean' if 'cost_for_run_usd_mean' in df.columns else 'cost_for_run_usd'
+    cost_col = "cost_for_run_usd_mean" if "cost_for_run_usd_mean" in df.columns else "cost_for_run_usd"
     cost_values = df[cost_col].fillna(0).values
     max_cost = max(cost_values) if len(cost_values) > 0 and max(cost_values) > 0 else 1
-    
+
     # Get cost error bars if available
-    cost_min_col = 'cost_for_run_usd_min' if 'cost_for_run_usd_min' in df.columns else None
-    cost_max_col = 'cost_for_run_usd_max' if 'cost_for_run_usd_max' in df.columns else None
+    cost_min_col = "cost_for_run_usd_min" if "cost_for_run_usd_min" in df.columns else None
+    cost_max_col = "cost_for_run_usd_max" if "cost_for_run_usd_max" in df.columns else None
     cost_errors = None
     if cost_min_col and cost_max_col:
         cost_means = df[cost_col].fillna(0).values
@@ -167,49 +199,70 @@ def create_performance_plot(df, save_path=None):
         cost_errors_lower = np.maximum(0, cost_means - cost_mins)
         cost_errors_upper = np.maximum(0, cost_maxs - cost_means)
         cost_errors = np.array([cost_errors_lower, cost_errors_upper])
-    
+
     # Position for cost bars (fifth bar, after the four performance metrics)
-    cost_x_positions = group_centers - (group_width/2) + (4 * bar_width) + (bar_width/2)
-    
+    cost_x_positions = group_centers - (group_width / 2) + (4 * bar_width) + (bar_width / 2)
+
     # Create cost bars on right y-axis with error bars
     if cost_errors is not None:
-        bars_cost = ax1_right.bar(cost_x_positions, cost_values, bar_width,
-                                 yerr=cost_errors, capsize=3,
-                                 label='Total Cost ($)', color='#8B008B',  # Dark magenta/purple
-                                 alpha=0.9, edgecolor='white', linewidth=1.5,
-                                 error_kw={'elinewidth': 1.5, 'ecolor': '#333333', 'alpha': 0.7, 'capthick': 1.5},
-                                 zorder=3)
+        bars_cost = ax1_right.bar(
+            cost_x_positions,
+            cost_values,
+            bar_width,
+            yerr=cost_errors,
+            capsize=3,
+            label="Total Cost ($)",
+            color="#8B008B",  # Dark magenta/purple
+            alpha=0.9,
+            edgecolor="white",
+            linewidth=1.5,
+            error_kw={"elinewidth": 1.5, "ecolor": "#333333", "alpha": 0.7, "capthick": 1.5},
+            zorder=3,
+        )
     else:
-        bars_cost = ax1_right.bar(cost_x_positions, cost_values, bar_width,
-                                 label='Total Cost ($)', color='#8B008B',  # Dark magenta/purple
-                                 alpha=0.9, edgecolor='white', linewidth=1.5,
-                                 zorder=3)
-    
+        bars_cost = ax1_right.bar(
+            cost_x_positions,
+            cost_values,
+            bar_width,
+            label="Total Cost ($)",
+            color="#8B008B",  # Dark magenta/purple
+            alpha=0.9,
+            edgecolor="white",
+            linewidth=1.5,
+            zorder=3,
+        )
+
     # Add cost value labels
     for bar, cost in zip(bars_cost, cost_values):
         if cost > 0:  # Only label if value exists
             height = bar.get_height()
-            label_text = f'${cost:.2f}'
-            ax1_right.text(bar.get_x() + bar.get_width()/2., height + max_cost*0.03,
-                         label_text, ha='center', va='bottom',
-                         fontsize=9, fontweight='bold', color='#1a1a1a',
-                         rotation=90,
-                         bbox=dict(boxstyle="round,pad=0.2", facecolor='white',
-                                 edgecolor='none', alpha=0.9))
+            label_text = f"${cost:.2f}"
+            ax1_right.text(
+                bar.get_x() + bar.get_width() / 2.0,
+                height + max_cost * 0.03,
+                label_text,
+                ha="center",
+                va="bottom",
+                fontsize=9,
+                fontweight="bold",
+                color="#1a1a1a",
+                rotation=90,
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor="none", alpha=0.9),
+            )
 
     # Create tertiary y-axis for elapsed time (total time)
     ax1_right_time = ax1.twinx()
     # Offset the time axis to the right of the cost axis
-    ax1_right_time.spines['right'].set_position(('outward', 60))
-    
+    ax1_right_time.spines["right"].set_position(("outward", 60))
+
     # Get elapsed time values (in seconds) - use mean if aggregated
-    time_col = 'elapsed_time_mean' if 'elapsed_time_mean' in df.columns else 'elapsed_time'
+    time_col = "elapsed_time_mean" if "elapsed_time_mean" in df.columns else "elapsed_time"
     time_values = df[time_col].fillna(0).values
     max_time = max(time_values) if len(time_values) > 0 and max(time_values) > 0 else 1
-    
+
     # Get time error bars if available
-    time_min_col = 'elapsed_time_min' if 'elapsed_time_min' in df.columns else None
-    time_max_col = 'elapsed_time_max' if 'elapsed_time_max' in df.columns else None
+    time_min_col = "elapsed_time_min" if "elapsed_time_min" in df.columns else None
+    time_max_col = "elapsed_time_max" if "elapsed_time_max" in df.columns else None
     time_errors = None
     if time_min_col and time_max_col:
         time_means = df[time_col].fillna(0).values
@@ -218,24 +271,39 @@ def create_performance_plot(df, save_path=None):
         time_errors_lower = np.maximum(0, time_means - time_mins)
         time_errors_upper = np.maximum(0, time_maxs - time_means)
         time_errors = np.array([time_errors_lower, time_errors_upper])
-    
+
     # Position for time bars (sixth bar, after cost)
-    time_x_positions = group_centers - (group_width/2) + (5 * bar_width) + (bar_width/2)
-    
+    time_x_positions = group_centers - (group_width / 2) + (5 * bar_width) + (bar_width / 2)
+
     # Create time bars on tertiary y-axis with error bars
     if time_errors is not None:
-        bars_time = ax1_right_time.bar(time_x_positions, time_values, bar_width,
-                                       yerr=time_errors, capsize=3,
-                                       label='Total Time (s)', color='#FF1493',  # Deep pink
-                                       alpha=0.9, edgecolor='white', linewidth=1.5,
-                                       error_kw={'elinewidth': 1.5, 'ecolor': '#333333', 'alpha': 0.7, 'capthick': 1.5},
-                                       zorder=3)
+        bars_time = ax1_right_time.bar(
+            time_x_positions,
+            time_values,
+            bar_width,
+            yerr=time_errors,
+            capsize=3,
+            label="Total Time (s)",
+            color="#FF1493",  # Deep pink
+            alpha=0.9,
+            edgecolor="white",
+            linewidth=1.5,
+            error_kw={"elinewidth": 1.5, "ecolor": "#333333", "alpha": 0.7, "capthick": 1.5},
+            zorder=3,
+        )
     else:
-        bars_time = ax1_right_time.bar(time_x_positions, time_values, bar_width,
-                                       label='Total Time (s)', color='#FF1493',  # Deep pink
-                                       alpha=0.9, edgecolor='white', linewidth=1.5,
-                                       zorder=3)
-    
+        bars_time = ax1_right_time.bar(
+            time_x_positions,
+            time_values,
+            bar_width,
+            label="Total Time (s)",
+            color="#FF1493",  # Deep pink
+            alpha=0.9,
+            edgecolor="white",
+            linewidth=1.5,
+            zorder=3,
+        )
+
     # Add time value labels
     for bar, time_val in zip(bars_time, time_values):
         if time_val > 0:  # Only label if value exists
@@ -244,122 +312,142 @@ def create_performance_plot(df, save_path=None):
             if time_val >= 60:
                 minutes = int(time_val // 60)
                 seconds = time_val % 60
-                label_text = f'{minutes}m{seconds:.0f}s'
+                label_text = f"{minutes}m{seconds:.0f}s"
             else:
-                label_text = f'{time_val:.1f}s'
-            ax1_right_time.text(bar.get_x() + bar.get_width()/2., height + max_time*0.03,
-                              label_text, ha='center', va='bottom',
-                              fontsize=9, fontweight='bold', color='#1a1a1a',
-                              rotation=90,
-                              bbox=dict(boxstyle="round,pad=0.2", facecolor='white',
-                                      edgecolor='none', alpha=0.9))
+                label_text = f"{time_val:.1f}s"
+            ax1_right_time.text(
+                bar.get_x() + bar.get_width() / 2.0,
+                height + max_time * 0.03,
+                label_text,
+                ha="center",
+                va="bottom",
+                fontsize=9,
+                fontweight="bold",
+                color="#1a1a1a",
+                rotation=90,
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor="none", alpha=0.9),
+            )
 
     # Customize the main plot with better typography
-    ax1.set_ylabel('Performance Metrics', fontsize=14, fontweight='bold', labelpad=20)
-    
+    ax1.set_ylabel("Performance Metrics", fontsize=14, fontweight="bold", labelpad=20)
+
     # Get input/output length (use first value or aggregated column)
-    input_len_col = 'max_input_length_first' if 'max_input_length_first' in df.columns else 'max_input_length'
-    output_len_col = 'max_output_length_first' if 'max_output_length_first' in df.columns else 'max_output_length'
-    input_len = df[input_len_col].values[0] if len(df) > 0 and input_len_col in df.columns else 'N/A'
-    output_len = df[output_len_col].values[0] if len(df) > 0 and output_len_col in df.columns else 'N/A'
-    
-    ax1.set_title('DeepSeek-R1-Distill-Llama-70B Performance Analysis\n' +
-                 f'TP/PP Parallelism Configurations (Input: {input_len} tokens, Output: {output_len} tokens)',
-                 fontsize=18, fontweight='bold', pad=30, color='#1a1a1a')
+    input_len_col = "max_input_length_first" if "max_input_length_first" in df.columns else "max_input_length"
+    output_len_col = "max_output_length_first" if "max_output_length_first" in df.columns else "max_output_length"
+    input_len = df[input_len_col].values[0] if len(df) > 0 and input_len_col in df.columns else "N/A"
+    output_len = df[output_len_col].values[0] if len(df) > 0 and output_len_col in df.columns else "N/A"
+
+    ax1.set_title(
+        "DeepSeek-R1-Distill-Llama-70B Performance Analysis\n"
+        + f"TP/PP Parallelism Configurations (Input: {input_len} tokens, Output: {output_len} tokens)",
+        fontsize=18,
+        fontweight="bold",
+        pad=30,
+        color="#1a1a1a",
+    )
 
     # Set x-axis ticks and labels - NOW WITH LABELS!
     ax1.set_xticks(group_centers)
-    ax1.set_xticklabels(df['config'].values, fontsize=12, fontweight='bold',
-                       rotation=45, ha='center')
+    ax1.set_xticklabels(df["config"].values, fontsize=12, fontweight="bold", rotation=45, ha="center")
 
     # Make y-axis tick labels larger
-    ax1.tick_params(axis='y', labelsize=12)
+    ax1.tick_params(axis="y", labelsize=12)
 
     # Customize right y-axis (cost)
-    ax1_right.set_ylabel('Total Cost ($)', fontsize=14, fontweight='bold', 
-                         labelpad=20, color='#8B008B')
-    ax1_right.tick_params(axis='y', labelsize=12, labelcolor='#8B008B')
+    ax1_right.set_ylabel("Total Cost ($)", fontsize=14, fontweight="bold", labelpad=20, color="#8B008B")
+    ax1_right.tick_params(axis="y", labelsize=12, labelcolor="#8B008B")
 
     # Customize tertiary y-axis (time)
-    ax1_right_time.set_ylabel('Total Time (s)', fontsize=14, fontweight='bold',
-                              labelpad=20, color='#FF1493')
-    ax1_right_time.tick_params(axis='y', labelsize=12, labelcolor='#FF1493')
-    
+    ax1_right_time.set_ylabel("Total Time (s)", fontsize=14, fontweight="bold", labelpad=20, color="#FF1493")
+    ax1_right_time.tick_params(axis="y", labelsize=12, labelcolor="#FF1493")
+
     # Align all three y-axes to have the same number of ticks and intervals
     # Calculate max values for normalization (use mean columns if aggregated)
-    req_col = 'requests_per_sec_mean' if 'requests_per_sec_mean' in df.columns else 'requests_per_sec'
-    input_col = 'input_tokens_per_sec_mean' if 'input_tokens_per_sec_mean' in df.columns else 'input_tokens_per_sec'
-    output_col = 'output_tokens_per_sec_mean' if 'output_tokens_per_sec_mean' in df.columns else 'output_tokens_per_sec'
-    total_col = 'total_tokens_per_sec_mean' if 'total_tokens_per_sec_mean' in df.columns else 'total_tokens_per_sec'
-    
+    req_col = "requests_per_sec_mean" if "requests_per_sec_mean" in df.columns else "requests_per_sec"
+    input_col = "input_tokens_per_sec_mean" if "input_tokens_per_sec_mean" in df.columns else "input_tokens_per_sec"
+    output_col = "output_tokens_per_sec_mean" if "output_tokens_per_sec_mean" in df.columns else "output_tokens_per_sec"
+    total_col = "total_tokens_per_sec_mean" if "total_tokens_per_sec_mean" in df.columns else "total_tokens_per_sec"
+
     requests_per_sec_vals = df[req_col].fillna(0).values
     input_tokens_per_sec_vals = df[input_col].fillna(0).values
     output_tokens_per_sec_vals = df[output_col].fillna(0).values
     total_tokens_per_sec_vals = df[total_col].fillna(0).values
-    
-    max_perf = max(max(requests_per_sec_vals), max(input_tokens_per_sec_vals), 
-                   max(output_tokens_per_sec_vals), max(total_tokens_per_sec_vals))
+
+    max_perf = max(
+        max(requests_per_sec_vals),
+        max(input_tokens_per_sec_vals),
+        max(output_tokens_per_sec_vals),
+        max(total_tokens_per_sec_vals),
+    )
     max_perf = max_perf if max_perf > 0 else 1
     max_cost = max(cost_values) if len(cost_values) > 0 and max(cost_values) > 0 else 1
     max_time = max(time_values) if len(time_values) > 0 and max(time_values) > 0 else 1
-    
+
     # Use 5 ticks for all axes
     num_ticks = 5
-    
+
     # Set y-limits and ticks for performance axis (left)
     ax1.set_ylim([0, max_perf * 1.1])
     ax1.yaxis.set_major_locator(MaxNLocator(nbins=num_ticks))
-    
+
     # Set y-limits and ticks for cost axis (right inner)
     ax1_right.set_ylim([0, max_cost * 1.1])
     ax1_right.yaxis.set_major_locator(MaxNLocator(nbins=num_ticks))
-    
+
     # Set y-limits and ticks for time axis (right outer)
     ax1_right_time.set_ylim([0, max_time * 1.1])
     ax1_right_time.yaxis.set_major_locator(MaxNLocator(nbins=num_ticks))
 
     # Enhanced grid (only horizontal lines, no vertical grid)
-    ax1.grid(axis='y', alpha=0.3, linestyle=':', color='#666666', zorder=1)
-    ax1.grid(axis='x', visible=False)  # Explicitly disable vertical grid
+    ax1.grid(axis="y", alpha=0.3, linestyle=":", color="#666666", zorder=1)
+    ax1.grid(axis="x", visible=False)  # Explicitly disable vertical grid
     ax1.set_axisbelow(True)
     # Disable grid on time axis
     ax1_right_time.grid(False)
-    
+
     # Add vertical separator lines between parallelism configurations
     # Place separators at the boundaries between groups (not in the middle)
     for i in range(n_configs - 1):
         # Calculate the position between this group and the next
-        separator_x = group_centers[i] + group_width/2 + group_spacing/2
-        ax1.axvline(x=separator_x, color='#999999', linestyle='-', linewidth=1.5, 
-                   alpha=0.5, zorder=2)
+        separator_x = group_centers[i] + group_width / 2 + group_spacing / 2
+        ax1.axvline(x=separator_x, color="#999999", linestyle="-", linewidth=1.5, alpha=0.5, zorder=2)
 
     # Add subtle background pattern
-    ax1.set_facecolor('#fafafa')
+    ax1.set_facecolor("#fafafa")
 
     # Enhanced legend with better positioning - combine all axes
     lines1, labels1 = ax1.get_legend_handles_labels()
     lines2, labels2 = ax1_right.get_legend_handles_labels()
     lines3, labels3 = ax1_right_time.get_legend_handles_labels()
-    legend = ax1.legend(lines1 + lines2 + lines3, labels1 + labels2 + labels3, 
-                       title='Performance Metrics, Cost & Time', title_fontsize=13, fontsize=11,
-                       bbox_to_anchor=(1.1, 0.98), loc='upper left',
-                       frameon=True, fancybox=True, shadow=True, borderpad=1.5,
-                       labelspacing=1.2)
+    legend = ax1.legend(
+        lines1 + lines2 + lines3,
+        labels1 + labels2 + labels3,
+        title="Performance Metrics, Cost & Time",
+        title_fontsize=13,
+        fontsize=11,
+        bbox_to_anchor=(1.1, 0.98),
+        loc="upper left",
+        frameon=True,
+        fancybox=True,
+        shadow=True,
+        borderpad=1.5,
+        labelspacing=1.2,
+    )
     legend.get_frame().set_alpha(0.95)
-    legend.get_frame().set_edgecolor('#cccccc')
+    legend.get_frame().set_edgecolor("#cccccc")
 
     # Second subplot for efficiency analysis and cost efficiency
     ax2 = plt.subplot(3, 1, 2)
 
     # Calculate efficiency metrics (scaling efficiency relative to baseline)
     # Find the configuration with minimum GPUs as baseline
-    total_gpus = df['tp'] * df['pp']
+    total_gpus = df["tp"] * df["pp"]
     min_gpus_idx = total_gpus.idxmin()
     baseline_gpus = total_gpus.loc[min_gpus_idx]
     # Use mean column if aggregated
-    perf_col = 'total_tokens_per_sec_mean' if 'total_tokens_per_sec_mean' in df.columns else 'total_tokens_per_sec'
+    perf_col = "total_tokens_per_sec_mean" if "total_tokens_per_sec_mean" in df.columns else "total_tokens_per_sec"
     baseline_perf = df.loc[min_gpus_idx, perf_col]
-    
+
     # Calculate PERFORMANCE scaling efficiency: (per-GPU performance) / (baseline per-GPU performance) * 100
     per_gpu_perf = df[perf_col] / total_gpus
     baseline_per_gpu = baseline_perf / baseline_gpus
@@ -367,74 +455,98 @@ def create_performance_plot(df, save_path=None):
 
     # Calculate COST efficiency (tokens per dollar efficiency relative to baseline)
     # Use mean column if aggregated
-    tpd_col = 'tokens_per_dollar_mean' if 'tokens_per_dollar_mean' in df.columns else 'tokens_per_dollar'
+    tpd_col = "tokens_per_dollar_mean" if "tokens_per_dollar_mean" in df.columns else "tokens_per_dollar"
     tokens_per_dollar = df[tpd_col].fillna(0)
     baseline_tokens_per_dollar = tokens_per_dollar.loc[min_gpus_idx]
-    
+
     # Cost efficiency: (tokens_per_dollar / baseline_tokens_per_dollar) * 100
     # This shows how cost efficiency scales compared to baseline
     if baseline_tokens_per_dollar > 0:
         cost_efficiency = (tokens_per_dollar / baseline_tokens_per_dollar) * 100
     else:
         cost_efficiency = pd.Series([0] * len(df), index=df.index)
-    
+
     # Ensure values are in the same order as the dataframe (which matches group_centers)
     performance_efficiency_values = performance_efficiency.loc[df.index].values
     cost_efficiency_values = cost_efficiency.loc[df.index].values
 
     # Create performance efficiency bars on left y-axis
     bar_width_eff = group_width * 0.35
-    bars_perf_eff = ax2.bar(group_centers - bar_width_eff/2, performance_efficiency_values, 
-                      width=bar_width_eff, color='#2E8B57', alpha=0.85, 
-                      edgecolor='white', linewidth=1.5, zorder=3, label='Performance Scaling Efficiency (%)')
+    bars_perf_eff = ax2.bar(
+        group_centers - bar_width_eff / 2,
+        performance_efficiency_values,
+        width=bar_width_eff,
+        color="#2E8B57",
+        alpha=0.85,
+        edgecolor="white",
+        linewidth=1.5,
+        zorder=3,
+        label="Performance Scaling Efficiency (%)",
+    )
 
     # Add performance efficiency value labels
     for bar, eff in zip(bars_perf_eff, performance_efficiency_values):
         height = bar.get_height()
-        ax2.text(bar.get_x() + bar.get_width()/2., height + 2,
-                f'{eff:.1f}%', ha='center', va='bottom',
-                fontsize=9, fontweight='bold', color='#1a1a1a',
-                rotation=90,
-                bbox=dict(boxstyle="round,pad=0.2", facecolor='white',
-                         edgecolor='none', alpha=0.8))
+        ax2.text(
+            bar.get_x() + bar.get_width() / 2.0,
+            height + 2,
+            f"{eff:.1f}%",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+            fontweight="bold",
+            color="#1a1a1a",
+            rotation=90,
+            bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor="none", alpha=0.8),
+        )
 
     # Create secondary y-axis for cost efficiency
     ax2_right = ax2.twinx()
 
     # Create cost efficiency bars on right y-axis
-    bars_cost_eff = ax2_right.bar(group_centers + bar_width_eff/2, cost_efficiency_values,
-                              width=bar_width_eff, color='#4169E1', alpha=0.85,
-                              edgecolor='white', linewidth=1.5, zorder=3, 
-                              label='Cost Efficiency (%)')
+    bars_cost_eff = ax2_right.bar(
+        group_centers + bar_width_eff / 2,
+        cost_efficiency_values,
+        width=bar_width_eff,
+        color="#4169E1",
+        alpha=0.85,
+        edgecolor="white",
+        linewidth=1.5,
+        zorder=3,
+        label="Cost Efficiency (%)",
+    )
 
     # Add cost efficiency value labels
     for bar, ceff in zip(bars_cost_eff, cost_efficiency_values):
         if ceff > 0:  # Only label if value exists
             height = bar.get_height()
-            ax2_right.text(bar.get_x() + bar.get_width()/2., height + 2,
-                          f'{ceff:.1f}%', ha='center', va='bottom',
-                          fontsize=9, fontweight='bold', color='#1a1a1a',
-                          rotation=90,
-                          bbox=dict(boxstyle="round,pad=0.2", facecolor='white',
-                                   edgecolor='none', alpha=0.8))
+            ax2_right.text(
+                bar.get_x() + bar.get_width() / 2.0,
+                height + 2,
+                f"{ceff:.1f}%",
+                ha="center",
+                va="bottom",
+                fontsize=9,
+                fontweight="bold",
+                color="#1a1a1a",
+                rotation=90,
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor="none", alpha=0.8),
+            )
 
     # Customize left y-axis (performance efficiency)
     # ax2.set_xlabel('Parallelism Configuration (TP/PP)', fontsize=14, fontweight='bold', labelpad=20)
-    ax2.set_ylabel('Performance Scaling Efficiency (%)', fontsize=14, fontweight='bold', labelpad=20, color='#2E8B57')
-    ax2.set_title('Performance Scaling Efficiency & Cost Efficiency Analysis', 
-                 fontsize=16, fontweight='bold', pad=20)
+    ax2.set_ylabel("Performance Scaling Efficiency (%)", fontsize=14, fontweight="bold", labelpad=20, color="#2E8B57")
+    ax2.set_title("Performance Scaling Efficiency & Cost Efficiency Analysis", fontsize=16, fontweight="bold", pad=20)
 
     ax2.set_xticks(group_centers)
-    ax2.set_xticklabels(df['config'].values, fontsize=12, fontweight='bold',
-                       rotation=45, ha='center')
+    ax2.set_xticklabels(df["config"].values, fontsize=12, fontweight="bold", rotation=45, ha="center")
 
     # Make y-axis tick labels larger
-    ax2.tick_params(axis='y', labelsize=12, labelcolor='#2E8B57')
+    ax2.tick_params(axis="y", labelsize=12, labelcolor="#2E8B57")
 
     # Customize right y-axis (cost efficiency)
-    ax2_right.set_ylabel('Cost Efficiency (%)', fontsize=14, fontweight='bold', 
-                        labelpad=20, color='#4169E1')
-    ax2_right.tick_params(axis='y', labelsize=12, labelcolor='#4169E1')
+    ax2_right.set_ylabel("Cost Efficiency (%)", fontsize=14, fontweight="bold", labelpad=20, color="#4169E1")
+    ax2_right.tick_params(axis="y", labelsize=12, labelcolor="#4169E1")
 
     # Calculate max values for both efficiency metrics to align y-axes
     max_perf_eff = max(performance_efficiency_values) if len(performance_efficiency_values) > 0 else 100
@@ -443,47 +555,58 @@ def create_performance_plot(df, save_path=None):
     max_value = max(max_perf_eff, max_cost_eff, 100)
     y_max = max_value * 1.1 if max_value > 0 else 120
     y_min = 0
-    
+
     # Set both axes to the same limits so 100% aligns at the same visual height
     ax2.set_ylim([y_min, y_max])
     ax2_right.set_ylim([y_min, y_max])
 
     # Add efficiency grid and reference lines at 100%
-    ax2.grid(axis='y', alpha=0.3, linestyle=':', color='#666666', zorder=1)
-    ax2.axhline(y=100, color='#DC143C', linestyle='--', alpha=0.8, linewidth=2.5,
-                label='Perfect Performance Scaling', zorder=2)
+    ax2.grid(axis="y", alpha=0.3, linestyle=":", color="#666666", zorder=1)
+    ax2.axhline(
+        y=100, color="#DC143C", linestyle="--", alpha=0.8, linewidth=2.5, label="Perfect Performance Scaling", zorder=2
+    )
     # Add reference line for cost efficiency on right axis (will align with left axis 100% line)
-    ax2_right.axhline(y=100, color='#8B008B', linestyle='--', alpha=0.8, linewidth=2.5,
-                     label='Perfect Cost Efficiency', zorder=2)
+    ax2_right.axhline(
+        y=100, color="#8B008B", linestyle="--", alpha=0.8, linewidth=2.5, label="Perfect Cost Efficiency", zorder=2
+    )
     ax2.set_axisbelow(True)
-    ax2.set_facecolor('#fafafa')
+    ax2.set_facecolor("#fafafa")
 
     # Combine legends from both axes and position outside on the right (further right to avoid y-axis overlap)
     lines1, labels1 = ax2.get_legend_handles_labels()
     lines2, labels2 = ax2_right.get_legend_handles_labels()
-    legend2 = ax2.legend(lines1 + lines2, labels1 + labels2, 
-                       bbox_to_anchor=(1.1, 0.98), loc='upper left',
-                       frameon=True, fancybox=True, shadow=True, fontsize=11, 
-                       borderpad=1.5, labelspacing=1.2, title='Efficiency Metrics (%)', 
-                       title_fontsize=13)
+    legend2 = ax2.legend(
+        lines1 + lines2,
+        labels1 + labels2,
+        bbox_to_anchor=(1.1, 0.98),
+        loc="upper left",
+        frameon=True,
+        fancybox=True,
+        shadow=True,
+        fontsize=11,
+        borderpad=1.5,
+        labelspacing=1.2,
+        title="Efficiency Metrics (%)",
+        title_fontsize=13,
+    )
     legend2.get_frame().set_alpha(0.95)
-    legend2.get_frame().set_edgecolor('#cccccc')
+    legend2.get_frame().set_edgecolor("#cccccc")
 
     # Third subplot for GPU utilization metrics
     ax3 = plt.subplot(3, 1, 3)
-    
+
     # Get GPU utilization metrics (use mean if aggregated)
-    sm_col = 'avg_sm_util_pct_mean' if 'avg_sm_util_pct_mean' in df.columns else 'avg_sm_util_pct'
-    membw_col = 'avg_mem_bw_util_pct_mean' if 'avg_mem_bw_util_pct_mean' in df.columns else 'avg_mem_bw_util_pct'
+    sm_col = "avg_sm_util_pct_mean" if "avg_sm_util_pct_mean" in df.columns else "avg_sm_util_pct"
+    membw_col = "avg_mem_bw_util_pct_mean" if "avg_mem_bw_util_pct_mean" in df.columns else "avg_mem_bw_util_pct"
     avg_sm_util = df[sm_col].fillna(0)
     avg_mem_bw_util = df[membw_col].fillna(0)
-    
+
     # Get error bars for GPU utilization if available
-    sm_min_col = 'avg_sm_util_pct_min' if 'avg_sm_util_pct_min' in df.columns else None
-    sm_max_col = 'avg_sm_util_pct_max' if 'avg_sm_util_pct_max' in df.columns else None
-    membw_min_col = 'avg_mem_bw_util_pct_min' if 'avg_mem_bw_util_pct_min' in df.columns else None
-    membw_max_col = 'avg_mem_bw_util_pct_max' if 'avg_mem_bw_util_pct_max' in df.columns else None
-    
+    sm_min_col = "avg_sm_util_pct_min" if "avg_sm_util_pct_min" in df.columns else None
+    sm_max_col = "avg_sm_util_pct_max" if "avg_sm_util_pct_max" in df.columns else None
+    membw_min_col = "avg_mem_bw_util_pct_min" if "avg_mem_bw_util_pct_min" in df.columns else None
+    membw_max_col = "avg_mem_bw_util_pct_max" if "avg_mem_bw_util_pct_max" in df.columns else None
+
     sm_errors = None
     membw_errors = None
     if sm_min_col and sm_max_col:
@@ -493,7 +616,7 @@ def create_performance_plot(df, save_path=None):
         sm_errors_lower = np.maximum(0, sm_means - sm_mins)
         sm_errors_upper = np.maximum(0, sm_maxs - sm_means)
         sm_errors = np.array([sm_errors_lower, sm_errors_upper])
-    
+
     if membw_min_col and membw_max_col:
         membw_means = df[membw_col].fillna(0).values
         membw_mins = df[membw_min_col].fillna(0).values
@@ -501,127 +624,173 @@ def create_performance_plot(df, save_path=None):
         membw_errors_lower = np.maximum(0, membw_means - membw_mins)
         membw_errors_upper = np.maximum(0, membw_maxs - membw_means)
         membw_errors = np.array([membw_errors_lower, membw_errors_upper])
-    
+
     # Ensure values are aligned with group_centers
     avg_sm_values = avg_sm_util.loc[df.index].values
     avg_mem_bw_values = avg_mem_bw_util.loc[df.index].values
-    
+
     # Create bars for GPU utilization with error bars
     bar_width_util = group_width * 0.35
     if sm_errors is not None:
-        bars_sm = ax3.bar(group_centers - bar_width_util/2, avg_sm_values,
-                          width=bar_width_util, yerr=sm_errors, capsize=3,
-                          color='#FF6B35', alpha=0.85,
-                          edgecolor='white', linewidth=1.5, zorder=3,
-                          error_kw={'elinewidth': 1.5, 'ecolor': '#333333', 'alpha': 0.7, 'capthick': 1.5},
-                          label='Avg SM Utilization (%)')
+        bars_sm = ax3.bar(
+            group_centers - bar_width_util / 2,
+            avg_sm_values,
+            width=bar_width_util,
+            yerr=sm_errors,
+            capsize=3,
+            color="#FF6B35",
+            alpha=0.85,
+            edgecolor="white",
+            linewidth=1.5,
+            zorder=3,
+            error_kw={"elinewidth": 1.5, "ecolor": "#333333", "alpha": 0.7, "capthick": 1.5},
+            label="Avg SM Utilization (%)",
+        )
     else:
-        bars_sm = ax3.bar(group_centers - bar_width_util/2, avg_sm_values,
-                          width=bar_width_util, color='#FF6B35', alpha=0.85,
-                          edgecolor='white', linewidth=1.5, zorder=3, 
-                          label='Avg SM Utilization (%)')
-    
+        bars_sm = ax3.bar(
+            group_centers - bar_width_util / 2,
+            avg_sm_values,
+            width=bar_width_util,
+            color="#FF6B35",
+            alpha=0.85,
+            edgecolor="white",
+            linewidth=1.5,
+            zorder=3,
+            label="Avg SM Utilization (%)",
+        )
+
     # Add SM utilization value labels
     for bar, sm_val in zip(bars_sm, avg_sm_values):
         if sm_val > 0:  # Only label if value exists
             height = bar.get_height()
-            ax3.text(bar.get_x() + bar.get_width()/2., height + 2,
-                    f'{sm_val:.1f}%', ha='center', va='bottom',
-                    fontsize=9, fontweight='bold', color='#1a1a1a',
-                    rotation=90,
-                    bbox=dict(boxstyle="round,pad=0.2", facecolor='white',
-                             edgecolor='none', alpha=0.8))
-    
+            ax3.text(
+                bar.get_x() + bar.get_width() / 2.0,
+                height + 2,
+                f"{sm_val:.1f}%",
+                ha="center",
+                va="bottom",
+                fontsize=9,
+                fontweight="bold",
+                color="#1a1a1a",
+                rotation=90,
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor="none", alpha=0.8),
+            )
+
     # Create secondary y-axis for memory bandwidth (though both are percentages, using same scale)
     ax3_right = ax3.twinx()
-    
+
     # Create memory bandwidth bars with error bars
     if membw_errors is not None:
-        bars_membw = ax3_right.bar(group_centers + bar_width_util/2, avg_mem_bw_values,
-                                   width=bar_width_util, yerr=membw_errors, capsize=3,
-                                   color='#4ECDC4', alpha=0.85,
-                                   edgecolor='white', linewidth=1.5, zorder=3,
-                                   error_kw={'elinewidth': 1.5, 'ecolor': '#333333', 'alpha': 0.7, 'capthick': 1.5},
-                                   label='Avg Memory BW Utilization (%)')
+        bars_membw = ax3_right.bar(
+            group_centers + bar_width_util / 2,
+            avg_mem_bw_values,
+            width=bar_width_util,
+            yerr=membw_errors,
+            capsize=3,
+            color="#4ECDC4",
+            alpha=0.85,
+            edgecolor="white",
+            linewidth=1.5,
+            zorder=3,
+            error_kw={"elinewidth": 1.5, "ecolor": "#333333", "alpha": 0.7, "capthick": 1.5},
+            label="Avg Memory BW Utilization (%)",
+        )
     else:
-        bars_membw = ax3_right.bar(group_centers + bar_width_util/2, avg_mem_bw_values,
-                                   width=bar_width_util, color='#4ECDC4', alpha=0.85,
-                                   edgecolor='white', linewidth=1.5, zorder=3,
-                                   label='Avg Memory BW Utilization (%)')
-    
+        bars_membw = ax3_right.bar(
+            group_centers + bar_width_util / 2,
+            avg_mem_bw_values,
+            width=bar_width_util,
+            color="#4ECDC4",
+            alpha=0.85,
+            edgecolor="white",
+            linewidth=1.5,
+            zorder=3,
+            label="Avg Memory BW Utilization (%)",
+        )
+
     # Add memory bandwidth value labels
     for bar, membw_val in zip(bars_membw, avg_mem_bw_values):
         if membw_val > 0:  # Only label if value exists
             height = bar.get_height()
-            ax3_right.text(bar.get_x() + bar.get_width()/2., height + 2,
-                          f'{membw_val:.1f}%', ha='center', va='bottom',
-                          fontsize=9, fontweight='bold', color='#1a1a1a',
-                          rotation=90,
-                          bbox=dict(boxstyle="round,pad=0.2", facecolor='white',
-                                   edgecolor='none', alpha=0.8))
-    
+            ax3_right.text(
+                bar.get_x() + bar.get_width() / 2.0,
+                height + 2,
+                f"{membw_val:.1f}%",
+                ha="center",
+                va="bottom",
+                fontsize=9,
+                fontweight="bold",
+                color="#1a1a1a",
+                rotation=90,
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white", edgecolor="none", alpha=0.8),
+            )
+
     # Customize left y-axis (SM utilization)
     # ax3.set_xlabel('Parallelism Configuration (TP/PP)', fontsize=14, fontweight='bold', labelpad=20)
-    ax3.set_ylabel('Avg SM Utilization (%)', fontsize=14, fontweight='bold', 
-                   labelpad=20, color='#FF6B35')
-    ax3.set_title('GPU Utilization Analysis', 
-                 fontsize=16, fontweight='bold', pad=20)
-    
+    ax3.set_ylabel("Avg SM Utilization (%)", fontsize=14, fontweight="bold", labelpad=20, color="#FF6B35")
+    ax3.set_title("GPU Utilization Analysis", fontsize=16, fontweight="bold", pad=20)
+
     ax3.set_xticks(group_centers)
-    ax3.set_xticklabels(df['config'].values, fontsize=12, fontweight='bold',
-                       rotation=45, ha='center')
-    
+    ax3.set_xticklabels(df["config"].values, fontsize=12, fontweight="bold", rotation=45, ha="center")
+
     # Make y-axis tick labels larger
-    ax3.tick_params(axis='y', labelsize=12, labelcolor='#FF6B35')
+    ax3.tick_params(axis="y", labelsize=12, labelcolor="#FF6B35")
     ax3.set_ylim([0, 105])  # 0-100% range with some padding
-    
+
     # Customize right y-axis (memory bandwidth)
-    ax3_right.set_ylabel('Avg Memory BW Utilization (%)', fontsize=14, fontweight='bold',
-                        labelpad=20, color='#4ECDC4')
-    ax3_right.tick_params(axis='y', labelsize=12, labelcolor='#4ECDC4')
+    ax3_right.set_ylabel("Avg Memory BW Utilization (%)", fontsize=14, fontweight="bold", labelpad=20, color="#4ECDC4")
+    ax3_right.tick_params(axis="y", labelsize=12, labelcolor="#4ECDC4")
     ax3_right.set_ylim([0, 105])  # 0-100% range with some padding
-    
+
     # Add grid and reference lines
-    ax3.grid(axis='y', alpha=0.3, linestyle=':', color='#666666', zorder=1)
-    ax3.axhline(y=100, color='#DC143C', linestyle='--', alpha=0.5, linewidth=1.5,
-                zorder=2, label='100% Utilization')
+    ax3.grid(axis="y", alpha=0.3, linestyle=":", color="#666666", zorder=1)
+    ax3.axhline(y=100, color="#DC143C", linestyle="--", alpha=0.5, linewidth=1.5, zorder=2, label="100% Utilization")
     ax3.set_axisbelow(True)
-    ax3.set_facecolor('#fafafa')
-    
+    ax3.set_facecolor("#fafafa")
+
     # Combine legends from both axes
     lines3, labels3 = ax3.get_legend_handles_labels()
     lines4, labels4 = ax3_right.get_legend_handles_labels()
-    legend3 = ax3.legend(lines3 + lines4, labels3 + labels4,
-                       bbox_to_anchor=(1.1, 0.98), loc='upper left',
-                       frameon=True, fancybox=True, shadow=True, fontsize=11,
-                       borderpad=1.5, labelspacing=1.2, title='GPU Utilization Metrics',
-                       title_fontsize=13)
+    legend3 = ax3.legend(
+        lines3 + lines4,
+        labels3 + labels4,
+        bbox_to_anchor=(1.1, 0.98),
+        loc="upper left",
+        frameon=True,
+        fancybox=True,
+        shadow=True,
+        fontsize=11,
+        borderpad=1.5,
+        labelspacing=1.2,
+        title="GPU Utilization Metrics",
+        title_fontsize=13,
+    )
     legend3.get_frame().set_alpha(0.95)
-    legend3.get_frame().set_edgecolor('#cccccc')
+    legend3.get_frame().set_edgecolor("#cccccc")
 
     # Adjust layout for better spacing (3 subplots now, increased right margin for third y-axis, increased bottom margin for rotated labels, increased vertical spacing)
     plt.subplots_adjust(hspace=0.7, top=0.95, bottom=0.15, left=0.08, right=0.90)
 
     # Save or show
     if save_path:
-        plt.savefig(save_path, bbox_inches='tight',
-                   facecolor='white', edgecolor='none')
+        plt.savefig(save_path, bbox_inches="tight", facecolor="white", edgecolor="none")
         print(f"Professional plot saved to: {save_path}")
     else:
         plt.show()
 
     return fig, (ax1, ax2, ax3)
 
+
 def create_summary_table(df):
     """Create a summary table of key metrics."""
     # Use aggregated column names if available, otherwise use original
-    req_col = 'requests_per_sec_mean' if 'requests_per_sec_mean' in df.columns else 'requests_per_sec'
-    input_col = 'input_tokens_per_sec_mean' if 'input_tokens_per_sec_mean' in df.columns else 'input_tokens_per_sec'
-    output_col = 'output_tokens_per_sec_mean' if 'output_tokens_per_sec_mean' in df.columns else 'output_tokens_per_sec'
-    total_col = 'total_tokens_per_sec_mean' if 'total_tokens_per_sec_mean' in df.columns else 'total_tokens_per_sec'
-    
-    summary_cols = ['config', 'instance', 'tp', 'pp', req_col, input_col, output_col, total_col]
-    
+    req_col = "requests_per_sec_mean" if "requests_per_sec_mean" in df.columns else "requests_per_sec"
+    input_col = "input_tokens_per_sec_mean" if "input_tokens_per_sec_mean" in df.columns else "input_tokens_per_sec"
+    output_col = "output_tokens_per_sec_mean" if "output_tokens_per_sec_mean" in df.columns else "output_tokens_per_sec"
+    total_col = "total_tokens_per_sec_mean" if "total_tokens_per_sec_mean" in df.columns else "total_tokens_per_sec"
+
+    summary_cols = ["config", "instance", "tp", "pp", req_col, input_col, output_col, total_col]
+
     # Only include columns that exist
     available_cols = [col for col in summary_cols if col in df.columns]
     summary = df[available_cols].copy()
@@ -634,22 +803,23 @@ def create_summary_table(df):
 
     return summary
 
+
 def find_and_merge_csvs(directory):
     """Find all benchmark_results*.csv files in subdirectories and merge them."""
     directory = Path(directory)
     if not directory.exists():
         raise FileNotFoundError(f"Directory not found: {directory}")
-    
+
     # Find all benchmark_results*.csv files recursively, but skip merged files
     csv_files = [f for f in directory.rglob("benchmark_results*.csv") if "merged" not in f.name]
-    
+
     if not csv_files:
         raise FileNotFoundError(f"No benchmark_results*.csv files found in {directory}")
-    
+
     print(f"Found {len(csv_files)} CSV files:")
     for csv_file in csv_files:
         print(f"  - {csv_file.relative_to(directory)}")
-    
+
     # Load and merge all CSVs
     dfs = []
     for csv_file in csv_files:
@@ -657,9 +827,9 @@ def find_and_merge_csvs(directory):
             df = pd.read_csv(csv_file)
             if len(df) > 0:
                 # Extract instance name from the 'instance_type' column
-                if 'instance_type' in df.columns:
+                if "instance_type" in df.columns:
                     # Get the first non-null instance_type value
-                    instance_type_values = df['instance_type'].dropna()
+                    instance_type_values = df["instance_type"].dropna()
                     if len(instance_type_values) > 0:
                         instance_name = instance_type_values.iloc[0]
                     else:
@@ -670,98 +840,100 @@ def find_and_merge_csvs(directory):
                     continue
 
                 # Add instance column
-                df['instance'] = instance_name
+                df["instance"] = instance_name
                 dfs.append(df)
                 print(f"  ✓ Loaded {len(df)} rows from {csv_file.name} (instance: {instance_name})")
         except Exception as e:
             print(f"  ⚠️  Skipped {csv_file.name}: {e}")
-    
+
     if not dfs:
         raise ValueError("No valid data found in any CSV files")
-    
+
     # Merge all dataframes
     merged_df = pd.concat(dfs, ignore_index=True)
     print(f"\nMerged {len(merged_df)} total rows from {len(dfs)} CSV files")
-    
+
     # Save merged CSV in the input directory
     merged_csv_path = directory / "benchmark_results_merged.csv"
     merged_df.to_csv(merged_csv_path, index=False)
     print(f"Saved merged CSV to: {merged_csv_path}")
-    
+
     return merged_df, merged_csv_path
+
 
 def create_concise_merged_csv(merged_df, output_dir):
     """Create a concise merged CSV with key metrics and cost efficiency."""
     df = merged_df.copy()
 
     # Map model name to requested column
-    if 'model' in df.columns and 'model_name' not in df.columns:
-        df['model_name'] = df['model']
+    if "model" in df.columns and "model_name" not in df.columns:
+        df["model_name"] = df["model"]
 
     # Map device type to requested column
-    if 'device_type' not in df.columns:
-        if 'instance_type' in df.columns:
-            df['device_type'] = df['instance_type']
-        elif 'instance' in df.columns:
-            df['device_type'] = df['instance']
+    if "device_type" not in df.columns:
+        if "instance_type" in df.columns:
+            df["device_type"] = df["instance_type"]
+        elif "instance" in df.columns:
+            df["device_type"] = df["instance"]
 
     # Map total cost to requested column
-    if 'total_cost' not in df.columns:
-        if 'cost_for_run_usd' in df.columns:
-            df['total_cost'] = df['cost_for_run_usd']
+    if "total_cost" not in df.columns:
+        if "cost_for_run_usd" in df.columns:
+            df["total_cost"] = df["cost_for_run_usd"]
 
     # Compute dollar per million tokens
     dollar_per_million = None
-    if 'tokens_per_dollar' in df.columns:
-        tpd = pd.to_numeric(df['tokens_per_dollar'], errors='coerce')
+    if "tokens_per_dollar" in df.columns:
+        tpd = pd.to_numeric(df["tokens_per_dollar"], errors="coerce")
         dollar_per_million = 1_000_000 / tpd.replace(0, np.nan)
-    elif {'cost_for_run_usd', 'total_tokens_per_sec', 'elapsed_time'}.issubset(df.columns):
-        cost = pd.to_numeric(df['cost_for_run_usd'], errors='coerce')
-        tps = pd.to_numeric(df['total_tokens_per_sec'], errors='coerce')
-        elapsed = pd.to_numeric(df['elapsed_time'], errors='coerce')
+    elif {"cost_for_run_usd", "total_tokens_per_sec", "elapsed_time"}.issubset(df.columns):
+        cost = pd.to_numeric(df["cost_for_run_usd"], errors="coerce")
+        tps = pd.to_numeric(df["total_tokens_per_sec"], errors="coerce")
+        elapsed = pd.to_numeric(df["elapsed_time"], errors="coerce")
         total_tokens = tps * elapsed
         dollar_per_million = (cost / total_tokens.replace(0, np.nan)) * 1_000_000
 
     if dollar_per_million is not None:
-        df['dollar_per_million_token'] = dollar_per_million
+        df["dollar_per_million_token"] = dollar_per_million
 
     # Build concise dataframe with requested columns
     requested_cols = [
-        'model_name',
-        'max_input_length',
-        'max_output_length',
-        'total_tokens_per_sec',
-        'input_tokens_per_sec',
-        'output_tokens_per_sec',
-        'device_type',
-        'tp',
-        'pp',
-        'mem_per_gpu_gb',
-        'total_cost',
-        'dollar_per_million_token',
+        "model_name",
+        "max_input_length",
+        "max_output_length",
+        "total_tokens_per_sec",
+        "input_tokens_per_sec",
+        "output_tokens_per_sec",
+        "device_type",
+        "tp",
+        "pp",
+        "mem_per_gpu_gb",
+        "total_cost",
+        "dollar_per_million_token",
     ]
 
     concise_df = df.reindex(columns=requested_cols)
     # Drop rows that are missing core metrics/cost; keep mem_per_gpu_gb optional
-    concise_df = concise_df.replace('', np.nan)
+    concise_df = concise_df.replace("", np.nan)
     required_cols = [
-        'model_name',
-        'max_input_length',
-        'max_output_length',
-        'total_tokens_per_sec',
-        'input_tokens_per_sec',
-        'output_tokens_per_sec',
-        'device_type',
-        'tp',
-        'pp',
-        'total_cost',
-        'dollar_per_million_token',
+        "model_name",
+        "max_input_length",
+        "max_output_length",
+        "total_tokens_per_sec",
+        "input_tokens_per_sec",
+        "output_tokens_per_sec",
+        "device_type",
+        "tp",
+        "pp",
+        "total_cost",
+        "dollar_per_million_token",
     ]
-    concise_df = concise_df.dropna(subset=required_cols, how='any')
+    concise_df = concise_df.dropna(subset=required_cols, how="any")
     concise_csv_path = Path(output_dir) / "benchmark_results_merged_concise.csv"
     concise_df.to_csv(concise_csv_path, index=False)
     print(f"Saved concise merged CSV to: {concise_csv_path}")
     return concise_df, concise_csv_path
+
 
 def main():
     """Main function to run the analysis."""
@@ -771,11 +943,11 @@ def main():
         print("Usage: python plot_benchmark_results.py <directory_path>")
         print("Example: python plot_benchmark_results.py result-16384in_2048out/aws-g6e-L40S")
         return
-    
+
     input_dir = Path(sys.argv[1])
-    
+
     print(f"Input directory: {input_dir}")
-    output_plot = input_dir / 'benchmark_performance_analysis.pdf'
+    output_plot = input_dir / "benchmark_performance_analysis.pdf"
     print(f"Output plot: {output_plot}")
 
     # Check if directory exists
@@ -797,63 +969,73 @@ def main():
     # Process merged data (filter successful experiments and prepare for plotting)
     print("\nProcessing merged data...")
     # Filter successful experiments only
-    successful = merged_df[merged_df['status'] == 'success'].copy()
+    successful = merged_df[merged_df["status"] == "success"].copy()
 
     # Ensure numeric columns are properly typed
-    numeric_cols = ['requests_per_sec', 'input_tokens_per_sec',
-                   'output_tokens_per_sec', 'total_tokens_per_sec', 'tokens_per_dollar', 'cost_for_run_usd',
-                   'avg_sm_util_pct', 'avg_mem_bw_util_pct', 'elapsed_time']
+    numeric_cols = [
+        "requests_per_sec",
+        "input_tokens_per_sec",
+        "output_tokens_per_sec",
+        "total_tokens_per_sec",
+        "tokens_per_dollar",
+        "cost_for_run_usd",
+        "avg_sm_util_pct",
+        "avg_mem_bw_util_pct",
+        "elapsed_time",
+    ]
     for col in numeric_cols:
         if col in successful.columns:
-            successful[col] = pd.to_numeric(successful[col], errors='coerce')
+            successful[col] = pd.to_numeric(successful[col], errors="coerce")
 
     # Group by instance, TP and PP to aggregate multiple runs
     print("\nGrouping by instance/TP/PP configuration...")
-    grouped = successful.groupby(['instance', 'tp', 'pp'], as_index=False)
-    
+    grouped = successful.groupby(["instance", "tp", "pp"], as_index=False)
+
     # Calculate statistics for each metric
     agg_dict = {}
     for col in numeric_cols:
         if col in successful.columns:
-            agg_dict[col] = ['mean', 'min', 'max', 'std']
-    
+            agg_dict[col] = ["mean", "min", "max", "std"]
+
     # Also keep first value for non-numeric columns we need
-    for col in ['max_input_length', 'max_output_length', 'model', 'instance']:
+    for col in ["max_input_length", "max_output_length", "model", "instance"]:
         if col in successful.columns:
-            agg_dict[col] = 'first'
-    
+            agg_dict[col] = "first"
+
     df_agg = grouped.agg(agg_dict)
 
     # Flatten column names (e.g., 'requests_per_sec_mean', 'requests_per_sec_min', etc.)
     def flatten_col(col):
         name, agg_func = col
-        if agg_func == 'first':
+        if agg_func == "first":
             # For 'first' aggregations, just use the column name
             return name
         elif agg_func:
             # For other aggregations, join with underscore
-            return f'{name}_{agg_func}'
+            return f"{name}_{agg_func}"
         else:
             # For grouping columns
             return name
 
     df_agg.columns = [flatten_col(col) for col in df_agg.columns.values]
-    
+
     # Rename tp, pp, and instance columns
-    df_agg = df_agg.rename(columns={'tp_': 'tp', 'pp_': 'pp', 'instance_': 'instance'})
+    df_agg = df_agg.rename(columns={"tp_": "tp", "pp_": "pp", "instance_": "instance"})
 
     # Sort by tp, then pp, then instance (TP from lower to higher, PP from lower to higher)
-    df_agg = df_agg.sort_values(['tp', 'pp', 'instance'])
+    df_agg = df_agg.sort_values(["tp", "pp", "instance"])
 
     # Create labels for x-axis (include instance name)
-    df_agg['config'] = df_agg.apply(lambda x: f'{x["instance"]}\nTP{x["tp"]}, PP{x["pp"]}', axis=1)
-    
+    df_agg["config"] = df_agg.apply(lambda x: f"{x['instance']}\nTP{x['tp']}, PP{x['pp']}", axis=1)
+
     print(f"Aggregated to {len(df_agg)} unique instance/TP/PP configurations")
     for _, row in df_agg.iterrows():
-        instance, tp, pp = row['instance'], row['tp'], row['pp']
-        count = len(successful[(successful['instance'] == instance) & (successful['tp'] == tp) & (successful['pp'] == pp)])
+        instance, tp, pp = row["instance"], row["tp"], row["pp"]
+        count = len(
+            successful[(successful["instance"] == instance) & (successful["tp"] == tp) & (successful["pp"] == pp)]
+        )
         print(f"  {instance}/TP{tp}/PP{pp}: {count} run(s)")
-    
+
     df = df_agg
 
     if len(df) == 0:
@@ -861,8 +1043,8 @@ def main():
         return
 
     # Validate that all configurations have the same input/output lengths
-    input_lengths = df['max_input_length'].unique()
-    output_lengths = df['max_output_length'].unique()
+    input_lengths = df["max_input_length"].unique()
+    output_lengths = df["max_output_length"].unique()
 
     if len(input_lengths) > 1:
         print(f"ERROR: Multiple input lengths found in the data: {sorted(input_lengths)}")
@@ -882,9 +1064,9 @@ def main():
 
     print(f"Found {len(df)} unique instance/TP/PP configurations:")
     # Use aggregated column names if available, otherwise use original
-    req_col = 'requests_per_sec_mean' if 'requests_per_sec_mean' in df.columns else 'requests_per_sec'
-    total_col = 'total_tokens_per_sec_mean' if 'total_tokens_per_sec_mean' in df.columns else 'total_tokens_per_sec'
-    print(df[['instance', 'tp', 'pp', req_col, total_col]].to_string(index=False))
+    req_col = "requests_per_sec_mean" if "requests_per_sec_mean" in df.columns else "requests_per_sec"
+    total_col = "total_tokens_per_sec_mean" if "total_tokens_per_sec_mean" in df.columns else "total_tokens_per_sec"
+    print(df[["instance", "tp", "pp", req_col, total_col]].to_string(index=False))
 
     # Create summary table
     summary = create_summary_table(df)
@@ -898,13 +1080,14 @@ def main():
     # Also show plot if running interactively
     try:
         plt.show()
-    except:
+    except Exception:
         pass  # In case we're not in an interactive environment
 
     print(f"file saved in {merged_csv_path}")
     print(f"file saved in {concise_csv_path}")
     print(f"file saved in {output_plot}")
     print("Analysis complete!")
+
 
 if __name__ == "__main__":
     main()

--- a/profiling/roofline/vllm/plot_timeseries.py
+++ b/profiling/roofline/vllm/plot_timeseries.py
@@ -9,53 +9,56 @@ Usage:
 
 import argparse
 import json
+from collections import defaultdict
 from pathlib import Path
+
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import numpy as np
-from collections import defaultdict
 from scipy import interpolate
 
 # Publication-quality settings
-plt.rcParams.update({
-    'font.family': 'serif',
-    'font.serif': ['Times New Roman', 'DejaVu Serif', 'serif'],
-    'font.size': 10,
-    'axes.titlesize': 11,
-    'axes.labelsize': 10,
-    'xtick.labelsize': 9,
-    'ytick.labelsize': 9,
-    'legend.fontsize': 8,
-    'figure.titlesize': 12,
-    'axes.linewidth': 0.8,
-    'grid.linewidth': 0.5,
-    'lines.linewidth': 1.2,
-    'axes.spines.top': False,
-    'axes.spines.right': False,
-    'figure.dpi': 150,
-    'savefig.dpi': 300,
-    'savefig.bbox': 'tight',
-    'savefig.pad_inches': 0.1,
-})
+plt.rcParams.update(
+    {
+        "font.family": "serif",
+        "font.serif": ["Times New Roman", "DejaVu Serif", "serif"],
+        "font.size": 10,
+        "axes.titlesize": 11,
+        "axes.labelsize": 10,
+        "xtick.labelsize": 9,
+        "ytick.labelsize": 9,
+        "legend.fontsize": 8,
+        "figure.titlesize": 12,
+        "axes.linewidth": 0.8,
+        "grid.linewidth": 0.5,
+        "lines.linewidth": 1.2,
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+        "figure.dpi": 150,
+        "savefig.dpi": 300,
+        "savefig.bbox": "tight",
+        "savefig.pad_inches": 0.1,
+    }
+)
 
 # Color palette (colorblind-friendly)
 COLORS = {
-    'gpu0': '#0072B2',  # Blue
-    'gpu1': '#D55E00',  # Orange
-    'gpu2': '#009E73',  # Green
-    'gpu3': '#CC79A7',  # Pink
-    'gpu4': '#F0E442',  # Yellow
-    'gpu5': '#56B4E9',  # Light blue
-    'gpu6': '#E69F00',  # Amber
-    'gpu7': '#8B4513',  # Brown/SaddleBrown
-    'avg': '#333333',   # Dark gray for averages
-    'running': '#0072B2',
-    'waiting': '#D55E00',
-    'swapped': '#009E73',
+    "gpu0": "#0072B2",  # Blue
+    "gpu1": "#D55E00",  # Orange
+    "gpu2": "#009E73",  # Green
+    "gpu3": "#CC79A7",  # Pink
+    "gpu4": "#F0E442",  # Yellow
+    "gpu5": "#56B4E9",  # Light blue
+    "gpu6": "#E69F00",  # Amber
+    "gpu7": "#8B4513",  # Brown/SaddleBrown
+    "avg": "#333333",  # Dark gray for averages
+    "running": "#0072B2",
+    "waiting": "#D55E00",
+    "swapped": "#009E73",
 }
 
 # Markers for different nodes
-MARKERS = ['o', 's', '^', 'D', 'v', '<', '>', 'p', '*', 'h', 'H', 'X']
+MARKERS = ["o", "s", "^", "D", "v", "<", ">", "p", "*", "h", "H", "X"]
 
 
 def load_timeseries(path: Path) -> list[dict]:
@@ -66,7 +69,7 @@ def load_timeseries(path: Path) -> list[dict]:
         with open(path) as f:
             experiments.append(json.load(f))
     elif path.is_dir():
-        for json_file in sorted(path.glob('timeseries_*.json')):
+        for json_file in sorted(path.glob("timeseries_*.json")):
             with open(json_file) as f:
                 experiments.append(json.load(f))
 
@@ -76,7 +79,7 @@ def load_timeseries(path: Path) -> list[dict]:
 def extract_gpu_data(gpu_timeseries: list[dict]) -> dict:
     """
     Extract GPU metrics into arrays for plotting.
-    
+
     Handles the case where different GPUs are sampled at different times.
     Each GPU metric gets its own time series (only times when that GPU was sampled).
     """
@@ -87,9 +90,9 @@ def extract_gpu_data(gpu_timeseries: list[dict]) -> dict:
     all_keys = set()
     for sample in gpu_timeseries:
         for key in sample.keys():
-            if key != 't':
+            if key != "t":
                 all_keys.add(key)
-    
+
     # Second pass: extract data per metric (each metric has its own time series)
     data = {}
     for key in all_keys:
@@ -97,18 +100,15 @@ def extract_gpu_data(gpu_timeseries: list[dict]) -> dict:
         values = []
         for sample in gpu_timeseries:
             if key in sample:
-                times.append(sample['t'])
+                times.append(sample["t"])
                 values.append(sample[key])
         if times:  # Only add if we have data
-            data[key] = {
-                'time': np.array(times),
-                'value': np.array(values)
-            }
-    
+            data[key] = {"time": np.array(times), "value": np.array(values)}
+
     # Also create a unified time array for backward compatibility (all unique times)
-    all_times = sorted(set(sample['t'] for sample in gpu_timeseries))
-    data['_all_times'] = np.array(all_times)
-    
+    all_times = sorted(set(sample["t"] for sample in gpu_timeseries))
+    data["_all_times"] = np.array(all_times)
+
     return data
 
 
@@ -120,9 +120,9 @@ def extract_scheduler_data(scheduler_timeseries: list[dict]) -> dict:
     data = defaultdict(list)
 
     for sample in scheduler_timeseries:
-        data['time'].append(sample['t'])
+        data["time"].append(sample["t"])
         for key, value in sample.items():
-            if key != 't':
+            if key != "t":
                 data[key].append(value)
 
     return {k: np.array(v) for k, v in data.items()}
@@ -140,28 +140,28 @@ def get_gpu_identifiers(gpu_data: dict) -> list[str]:
     """
     gpu_ids = set()
     for key in gpu_data.keys():
-        if key == '_all_times' or key == 'time':
+        if key == "_all_times" or key == "time":
             continue
         # Check for node-prefixed format: node0_gpu0_metric
-        if key.startswith('node') and '_gpu' in key:
-            parts = key.split('_')
+        if key.startswith("node") and "_gpu" in key:
+            parts = key.split("_")
             if len(parts) >= 3:
                 gpu_id = f"{parts[0]}_{parts[1]}"  # e.g., "node0_gpu0"
                 gpu_ids.add(gpu_id)
         # Check for old format: gpu0_metric
-        elif key.startswith('gpu') and '_' in key:
-            gpu_id = key.split('_')[0]  # e.g., "gpu0"
+        elif key.startswith("gpu") and "_" in key:
+            gpu_id = key.split("_")[0]  # e.g., "gpu0"
             gpu_ids.add(gpu_id)
 
     # Sort: by node first (if present), then by GPU number
     def sort_key(gpu_id):
-        if gpu_id.startswith('node'):
-            parts = gpu_id.split('_')
+        if gpu_id.startswith("node"):
+            parts = gpu_id.split("_")
             node_num = int(parts[0][4:])  # Extract number from "node0"
-            gpu_num = int(parts[1][3:])   # Extract number from "gpu0"
+            gpu_num = int(parts[1][3:])  # Extract number from "gpu0"
             return (node_num, gpu_num)
         else:
-            return (0, int(gpu_id[3:]))   # Single node: sort by GPU number
+            return (0, int(gpu_id[3:]))  # Single node: sort by GPU number
 
     return sorted(gpu_ids, key=sort_key)
 
@@ -174,20 +174,20 @@ def get_num_gpus(gpu_data: dict) -> int:
 def plot_experiment(exp_data: dict, output_path: Path):
     """Create a multi-panel figure for one experiment."""
 
-    gpu_data = extract_gpu_data(exp_data.get('gpu_timeseries', []))
-    scheduler_data = extract_scheduler_data(exp_data.get('scheduler_timeseries', []))
+    gpu_data = extract_gpu_data(exp_data.get("gpu_timeseries", []))
+    scheduler_data = extract_scheduler_data(exp_data.get("scheduler_timeseries", []))
 
-    config = exp_data.get('config', {})
-    exp_id = exp_data.get('exp_id', 'unknown')
-    elapsed = exp_data.get('elapsed_time', 0)
-    
+    config = exp_data.get("config", {})
+    exp_id = exp_data.get("exp_id", "unknown")
+    elapsed = exp_data.get("elapsed_time", 0)
+
     # Get instance_type and gpu_type from results.json in the same directory
     instance_type = None
     gpu_type = None
     try:
-        results_json_path = output_path.parent / 'results.json'
+        results_json_path = output_path.parent / "results.json"
         if results_json_path.exists():
-            with open(results_json_path, 'r') as f:
+            with open(results_json_path) as f:
                 results_data = json.load(f)
                 if isinstance(results_data, list) and len(results_data) > 0:
                     exp_data = results_data[0]
@@ -195,32 +195,32 @@ def plot_experiment(exp_data: dict, output_path: Path):
                     exp_data = results_data
                 else:
                     exp_data = {}
-                
-                instance_type = exp_data.get('instance_type')
-                gpu_type = exp_data.get('gpu_type')  # Check if gpu_type is directly stored
-                
+
+                instance_type = exp_data.get("instance_type")
+                gpu_type = exp_data.get("gpu_type")  # Check if gpu_type is directly stored
+
                 # If gpu_type not found, infer from instance_type
                 if not gpu_type and instance_type:
                     # Map instance family to GPU type
                     instance_str = instance_type.lower()
-                    if 'g6e' in instance_str:
-                        gpu_type = 'L40S'
-                    elif 'g6' in instance_str and 'g6e' not in instance_str:
-                        gpu_type = 'L4'
-                    elif 'g5' in instance_str:
-                        gpu_type = 'A10G'
-                    elif 'p4d' in instance_str:
-                        gpu_type = 'A100_40gb'  # Could be 40gb or 80gb, default to 40gb
-                    elif 'p4de' in instance_str:
-                        gpu_type = 'A100_80gb'
+                    if "g6e" in instance_str:
+                        gpu_type = "L40S"
+                    elif "g6" in instance_str and "g6e" not in instance_str:
+                        gpu_type = "L4"
+                    elif "g5" in instance_str:
+                        gpu_type = "A10G"
+                    elif "p4d" in instance_str:
+                        gpu_type = "A100_40gb"  # Could be 40gb or 80gb, default to 40gb
+                    elif "p4de" in instance_str:
+                        gpu_type = "A100_80gb"
     except Exception as e:
         pass
 
     # Determine what to plot
     has_gpu = bool(gpu_data)
     has_scheduler = bool(scheduler_data)
-    has_kv_cache = 'kv_cache_util_pct' in scheduler_data if scheduler_data else False
-    has_queues = any(k in scheduler_data for k in ['running', 'waiting', 'swapped']) if scheduler_data else False
+    has_kv_cache = "kv_cache_util_pct" in scheduler_data if scheduler_data else False
+    has_queues = any(k in scheduler_data for k in ["running", "waiting", "swapped"]) if scheduler_data else False
     gpu_ids = get_gpu_identifiers(gpu_data) if has_gpu else []
     num_gpus = len(gpu_ids)
 
@@ -245,51 +245,53 @@ def plot_experiment(exp_data: dict, output_path: Path):
         axes = [axes]
 
     # Get all times to determine time unit and calculate GPU time
-    all_times = gpu_data.get('_all_times', np.array([]))
+    all_times = gpu_data.get("_all_times", np.array([]))
     if len(all_times) == 0 and gpu_data:
         # Fallback: get times from first available metric
         for key, value in gpu_data.items():
-            if isinstance(value, dict) and 'time' in value:
-                all_times = value['time']
+            if isinstance(value, dict) and "time" in value:
+                all_times = value["time"]
                 break
-    
+
     # Calculate GPU monitoring time span
     gpu_time = 0.0
     if len(all_times) > 0:
         gpu_time = all_times[-1] - all_times[0] if len(all_times) > 1 else 0.0
 
     # Title with experiment configuration
-    model_name = config.get('model', 'Unknown').split('/')[-1]
+    model_name = config.get("model", "Unknown").split("/")[-1]
     title_parts = [model_name]
-    title_parts.append(f"TP={config.get('tp', '?')}, PP={config.get('pp', '?')}, Input={config.get('max_input_length', '?')}, Output={config.get('max_output_length', '?')}")
+    title_parts.append(
+        f"TP={config.get('tp', '?')}, PP={config.get('pp', '?')}, Input={config.get('max_input_length', '?')}, Output={config.get('max_output_length', '?')}"
+    )
     title_parts.append(f"Instance={instance_type}, GPU={gpu_type}")
     title_parts.append(f"Elapsed={elapsed:.1f}s, GPU Time={gpu_time:.1f}s")
     title = "\n".join(title_parts)
     fig.suptitle(title, y=0.995)
 
     ax_idx = 0
-    
+
     # Convert time to minutes if > 120 seconds
-    time_unit = 's'
+    time_unit = "s"
     time_divisor = 1
     if len(all_times) > 0 and all_times[-1] > 120:
-        time_unit = 'min'
+        time_unit = "min"
         time_divisor = 60
 
     # --- Plot 1: SM Utilization ---
     ax = axes[ax_idx]
     for idx, gpu_id in enumerate(gpu_ids):
-        key = f'{gpu_id}_sm_pct'
+        key = f"{gpu_id}_sm_pct"
         if key in gpu_data and isinstance(gpu_data[key], dict):
             metric_data = gpu_data[key]
-            time_arr = metric_data['time']
-            values = metric_data['value']
+            time_arr = metric_data["time"]
+            values = metric_data["value"]
             time_plot = time_arr / time_divisor
-            
+
             # Create readable label: "Node0:GPU0" for node0_gpu0, or "GPU 0" for gpu0
             # Get marker based on node number
-            if gpu_id.startswith('node'):
-                parts = gpu_id.split('_')
+            if gpu_id.startswith("node"):
+                parts = gpu_id.split("_")
                 node_num = int(parts[0][4:])
                 gpu_num = int(parts[1][3:])
                 label = f"Node{node_num}:GPU{gpu_num}"
@@ -297,30 +299,37 @@ def plot_experiment(exp_data: dict, output_path: Path):
             else:
                 label = f"GPU {gpu_id[3:]}"
                 marker = MARKERS[0]  # Default marker for single-node
-            
-            ax.plot(time_plot, values,
-                   color=COLORS.get(f'gpu{idx % 8}', f'C{idx}'),
-                   label=label, alpha=0.8, marker=marker, markersize=3, markevery=max(1, len(time_plot)//50))
 
-    ax.set_ylabel('SM Utilization (%)')
+            ax.plot(
+                time_plot,
+                values,
+                color=COLORS.get(f"gpu{idx % 8}", f"C{idx}"),
+                label=label,
+                alpha=0.8,
+                marker=marker,
+                markersize=3,
+                markevery=max(1, len(time_plot) // 50),
+            )
+
+    ax.set_ylabel("SM Utilization (%)")
     ax.set_ylim(-5, 105)
     ax.yaxis.set_major_locator(ticker.MultipleLocator(25))
     ax.grid(True, alpha=0.3)
-    ax.legend(loc='upper center', bbox_to_anchor=(0.5, 1.35), ncol=4, framealpha=0.9)
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.35), ncol=4, framealpha=0.9)
     ax_idx += 1
 
     # --- Plot 2: Memory Bandwidth Utilization ---
     ax = axes[ax_idx]
     for idx, gpu_id in enumerate(gpu_ids):
-        key = f'{gpu_id}_membw_pct'
+        key = f"{gpu_id}_membw_pct"
         if key in gpu_data and isinstance(gpu_data[key], dict):
             metric_data = gpu_data[key]
-            time_arr = metric_data['time']
-            values = metric_data['value']
+            time_arr = metric_data["time"]
+            values = metric_data["value"]
             time_plot = time_arr / time_divisor
-            
-            if gpu_id.startswith('node'):
-                parts = gpu_id.split('_')
+
+            if gpu_id.startswith("node"):
+                parts = gpu_id.split("_")
                 node_num = int(parts[0][4:])
                 gpu_num = int(parts[1][3:])
                 label = f"Node{node_num}:GPU{gpu_num}"
@@ -328,32 +337,39 @@ def plot_experiment(exp_data: dict, output_path: Path):
             else:
                 label = f"GPU {gpu_id[3:]}"
                 marker = MARKERS[0]  # Default marker for single-node
-            
-            ax.plot(time_plot, values,
-                   color=COLORS.get(f'gpu{idx % 8}', f'C{idx}'),
-                   label=label, alpha=0.8, marker=marker, markersize=3, markevery=max(1, len(time_plot)//50))
 
-    ax.set_ylabel('Memory BW Util. (%)')
+            ax.plot(
+                time_plot,
+                values,
+                color=COLORS.get(f"gpu{idx % 8}", f"C{idx}"),
+                label=label,
+                alpha=0.8,
+                marker=marker,
+                markersize=3,
+                markevery=max(1, len(time_plot) // 50),
+            )
+
+    ax.set_ylabel("Memory BW Util. (%)")
     ax.set_ylim(-5, 105)
     ax.yaxis.set_major_locator(ticker.MultipleLocator(25))
     ax.grid(True, alpha=0.3)
-    ax.legend(loc='upper center', bbox_to_anchor=(0.5, 1.35), ncol=4, framealpha=0.9)
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.35), ncol=4, framealpha=0.9)
     ax_idx += 1
 
     # --- Plot 3: Memory Usage (GB) ---
     ax = axes[ax_idx]
     all_mem = []
     for idx, gpu_id in enumerate(gpu_ids):
-        key = f'{gpu_id}_mem_gb'
+        key = f"{gpu_id}_mem_gb"
         if key in gpu_data and isinstance(gpu_data[key], dict):
             metric_data = gpu_data[key]
-            time_arr = metric_data['time']
-            values = metric_data['value']
+            time_arr = metric_data["time"]
+            values = metric_data["value"]
             time_plot = time_arr / time_divisor
             all_mem.extend(values)
-            
-            if gpu_id.startswith('node'):
-                parts = gpu_id.split('_')
+
+            if gpu_id.startswith("node"):
+                parts = gpu_id.split("_")
                 node_num = int(parts[0][4:])
                 gpu_num = int(parts[1][3:])
                 label = f"Node{node_num}:GPU{gpu_num}"
@@ -361,14 +377,21 @@ def plot_experiment(exp_data: dict, output_path: Path):
             else:
                 label = f"GPU {gpu_id[3:]}"
                 marker = MARKERS[0]  # Default marker for single-node
-            
-            ax.plot(time_plot, values,
-                   color=COLORS.get(f'gpu{idx % 8}', f'C{idx}'),
-                   label=label, alpha=0.8, marker=marker, markersize=3, markevery=max(1, len(time_plot)//50))
 
-    ax.set_ylabel('Memory Usage (GB)')
+            ax.plot(
+                time_plot,
+                values,
+                color=COLORS.get(f"gpu{idx % 8}", f"C{idx}"),
+                label=label,
+                alpha=0.8,
+                marker=marker,
+                markersize=3,
+                markevery=max(1, len(time_plot) // 50),
+            )
+
+    ax.set_ylabel("Memory Usage (GB)")
     ax.grid(True, alpha=0.3)
-    ax.legend(loc='upper center', bbox_to_anchor=(0.5, 1.35), ncol=4, framealpha=0.9)
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, 1.35), ncol=4, framealpha=0.9)
 
     # Set reasonable y-limits for memory
     if all_mem:
@@ -378,51 +401,48 @@ def plot_experiment(exp_data: dict, output_path: Path):
     # --- Plot 4: KV Cache Utilization (if available) ---
     if has_kv_cache:
         ax = axes[ax_idx]
-        sched_time = scheduler_data.get('time', np.array([]))
+        sched_time = scheduler_data.get("time", np.array([]))
         sched_time_plot = sched_time / time_divisor
 
-        ax.plot(sched_time_plot, scheduler_data['kv_cache_util_pct'],
-               color='#E69F00', linewidth=1.5, label='KV Cache Util.')
-        ax.fill_between(sched_time_plot, 0, scheduler_data['kv_cache_util_pct'],
-                       alpha=0.3, color='#E69F00')
+        ax.plot(
+            sched_time_plot, scheduler_data["kv_cache_util_pct"], color="#E69F00", linewidth=1.5, label="KV Cache Util."
+        )
+        ax.fill_between(sched_time_plot, 0, scheduler_data["kv_cache_util_pct"], alpha=0.3, color="#E69F00")
 
-        ax.set_ylabel('KV Cache Util. (%)')
+        ax.set_ylabel("KV Cache Util. (%)")
         ax.set_ylim(-5, 105)
         ax.yaxis.set_major_locator(ticker.MultipleLocator(25))
         ax.grid(True, alpha=0.3)
-        ax.legend(loc='lower right', framealpha=0.9)
+        ax.legend(loc="lower right", framealpha=0.9)
         ax_idx += 1
 
     # --- Plot 5: Scheduler Queues (if available) ---
     if has_queues:
         ax = axes[ax_idx]
-        sched_time = scheduler_data.get('time', np.array([]))
+        sched_time = scheduler_data.get("time", np.array([]))
         sched_time_plot = sched_time / time_divisor
 
-        if 'running' in scheduler_data:
-            ax.plot(sched_time_plot, scheduler_data['running'],
-                   color=COLORS['running'], label='Running', linewidth=1.5)
-        if 'waiting' in scheduler_data:
-            ax.plot(sched_time_plot, scheduler_data['waiting'],
-                   color=COLORS['waiting'], label='Waiting', linewidth=1.5)
-        if 'swapped' in scheduler_data:
-            ax.plot(sched_time_plot, scheduler_data['swapped'],
-                   color=COLORS['swapped'], label='Swapped', linewidth=1.5)
+        if "running" in scheduler_data:
+            ax.plot(sched_time_plot, scheduler_data["running"], color=COLORS["running"], label="Running", linewidth=1.5)
+        if "waiting" in scheduler_data:
+            ax.plot(sched_time_plot, scheduler_data["waiting"], color=COLORS["waiting"], label="Waiting", linewidth=1.5)
+        if "swapped" in scheduler_data:
+            ax.plot(sched_time_plot, scheduler_data["swapped"], color=COLORS["swapped"], label="Swapped", linewidth=1.5)
 
-        ax.set_ylabel('Queue Depth')
+        ax.set_ylabel("Queue Depth")
         ax.grid(True, alpha=0.3)
-        ax.legend(loc='upper right', framealpha=0.9)
+        ax.legend(loc="upper right", framealpha=0.9)
         ax_idx += 1
 
     # Set x-axis label on bottom plot
-    axes[-1].set_xlabel(f'Time ({time_unit})')
+    axes[-1].set_xlabel(f"Time ({time_unit})")
 
     # Adjust layout - increase spacing between subplots to accommodate legends on top
     plt.tight_layout()
     plt.subplots_adjust(top=0.82, hspace=0.55)
 
     # Save figure
-    fig.savefig(output_path, format='pdf', bbox_inches='tight')
+    fig.savefig(output_path, format="pdf", bbox_inches="tight")
     plt.close(fig)
     print(f"Saved: {output_path}")
 
@@ -439,7 +459,7 @@ def plot_all_experiments(experiments: list[dict], output_path: Path):
     base_name = output_path.stem
 
     for exp in experiments:
-        exp_id = exp.get('exp_id', 'unknown')
+        exp_id = exp.get("exp_id", "unknown")
         exp_output = output_dir / f"{base_name}_{exp_id}.pdf"
         plot_experiment(exp, exp_output)
 
@@ -447,12 +467,11 @@ def plot_all_experiments(experiments: list[dict], output_path: Path):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='Plot GPU and scheduler time-series from vLLM benchmarks')
-    parser.add_argument('input', type=Path,
-                       help='Timeseries JSON file or directory containing timeseries files')
-    parser.add_argument('--output', '-o', type=Path, default=None,
-                       help='Output PDF path (default: timeseries_plot.pdf)')
+    parser = argparse.ArgumentParser(description="Plot GPU and scheduler time-series from vLLM benchmarks")
+    parser.add_argument("input", type=Path, help="Timeseries JSON file or directory containing timeseries files")
+    parser.add_argument(
+        "--output", "-o", type=Path, default=None, help="Output PDF path (default: timeseries_plot.pdf)"
+    )
 
     args = parser.parse_args()
 
@@ -463,9 +482,9 @@ def main():
     # Default output path
     if args.output is None:
         if args.input.is_file():
-            args.output = args.input.with_suffix('.pdf')
+            args.output = args.input.with_suffix(".pdf")
         else:
-            args.output = args.input / 'timeseries_plot.pdf'
+            args.output = args.input / "timeseries_plot.pdf"
 
     # Load data
     experiments = load_timeseries(args.input)
@@ -482,5 +501,5 @@ def main():
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     exit(main())

--- a/profiling/roofline/vllm/prometheus_parser.py
+++ b/profiling/roofline/vllm/prometheus_parser.py
@@ -43,7 +43,7 @@ def parse_prometheus_text(text):
 
         # Parse: name{labels} value [timestamp]
         # Handle _bucket{le="..."}, _sum, _count suffixes for histograms
-        m = re.match(r'^(\S+?)\s+([\d.eE+\-NnAaIiFf]+)', line)
+        m = re.match(r"^(\S+?)\s+([\d.eE+\-NnAaIiFf]+)", line)
         if not m:
             continue
         full_name = m.group(1)
@@ -61,7 +61,7 @@ def parse_prometheus_text(text):
         if bucket_match:
             base = bucket_match.group(1)
             le_str = bucket_match.group(2)
-            le_val = float('inf') if le_str == '+Inf' else float(le_str)
+            le_val = float("inf") if le_str == "+Inf" else float(le_str)
             hist_buckets[base].append((le_val, value))
             # Ensure histogram entry exists
             if base not in result["histograms"]:
@@ -69,7 +69,7 @@ def parse_prometheus_text(text):
             continue
 
         # Check histogram _sum / _count
-        sum_match = re.match(r'^(.+)_sum(?:\{.*\})?$', full_name)
+        sum_match = re.match(r"^(.+)_sum(?:\{.*\})?$", full_name)
         if sum_match:
             base = sum_match.group(1)
             if base in types and types[base] == "histogram" or base in hist_buckets:
@@ -78,7 +78,7 @@ def parse_prometheus_text(text):
                 result["histograms"][base]["sum"] = value
                 continue
 
-        count_match = re.match(r'^(.+)_count(?:\{.*\})?$', full_name)
+        count_match = re.match(r"^(.+)_count(?:\{.*\})?$", full_name)
         if count_match:
             base = count_match.group(1)
             if base in types and types[base] == "histogram" or base in hist_buckets:
@@ -88,21 +88,21 @@ def parse_prometheus_text(text):
                 continue
 
         # Strip labels for plain metrics
-        plain_name = re.sub(r'\{[^}]*\}', '', full_name)
+        plain_name = re.sub(r"\{[^}]*\}", "", full_name)
 
         # Determine type
         mtype = types.get(plain_name, "untyped")
         if mtype == "counter":
             # Use full_name to distinguish label variants, but for simplicity use plain_name
             # If there are labels, use full_name; otherwise plain_name
-            key = full_name if '{' in full_name else plain_name
+            key = full_name if "{" in full_name else plain_name
             result["counters"][key] = value
         elif mtype == "gauge":
-            key = full_name if '{' in full_name else plain_name
+            key = full_name if "{" in full_name else plain_name
             result["gauges"][key] = value
         else:
             # Untyped or summary — treat as gauge
-            key = full_name if '{' in full_name else plain_name
+            key = full_name if "{" in full_name else plain_name
             result["gauges"][key] = value
 
     # Attach sorted buckets to histograms
@@ -135,7 +135,7 @@ def histogram_quantile(buckets, quantile):
     prev_bound = 0.0
     prev_count = 0.0
     for bound, count in buckets:
-        if bound == float('inf'):
+        if bound == float("inf"):
             if count >= target and prev_count < target:
                 return prev_bound
             continue
@@ -194,8 +194,8 @@ def compute_deltas(warmup_parsed, final_parsed):
 
 def _find_metric(deltas, base_name, default=0.0):
     """Find a metric value by base name, ignoring label suffixes.
-    
-    Handles both 'vllm:prompt_tokens_total' and 
+
+    Handles both 'vllm:prompt_tokens_total' and
     'vllm:prompt_tokens_total{model_name="..."}' style keys.
     """
     # Exact match first

--- a/profiling/roofline/vllm/scripts/build_perfdb.py
+++ b/profiling/roofline/vllm/scripts/build_perfdb.py
@@ -68,7 +68,7 @@ def load_results(results_dir: Path) -> pd.DataFrame:
         try:
             with open(rfile) as f:
                 entries = json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+        except (OSError, json.JSONDecodeError) as e:
             print(f"  WARN: skipping {rfile}: {e}")
             continue
 
@@ -117,8 +117,9 @@ def deduplicate(df: pd.DataFrame) -> pd.DataFrame:
 
 def sort_output(df: pd.DataFrame) -> pd.DataFrame:
     """Sort by model, gpu_model, tp, pp, max_input_length, max_output_length."""
-    sort_cols = [c for c in ["model", "gpu_model", "tp", "pp", "max_input_length", "max_output_length"]
-                 if c in df.columns]
+    sort_cols = [
+        c for c in ["model", "gpu_model", "tp", "pp", "max_input_length", "max_output_length"] if c in df.columns
+    ]
     return df.sort_values(sort_cols, ascending=True).reset_index(drop=True)
 
 
@@ -206,12 +207,11 @@ def build_perfdb(results_dir: Path, output_path: Path, dry_run: bool = False):
 
 def main():
     parser = argparse.ArgumentParser(description="Build unified performance database CSV")
-    parser.add_argument("--results-dir", default="results/",
-                        help="Root directory containing result subdirectories (default: results/)")
-    parser.add_argument("--output", default="perfdb_all.csv",
-                        help="Output CSV path (default: perfdb_all.csv)")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Preview what would be written without actually writing")
+    parser.add_argument(
+        "--results-dir", default="results/", help="Root directory containing result subdirectories (default: results/)"
+    )
+    parser.add_argument("--output", default="perfdb_all.csv", help="Output CSV path (default: perfdb_all.csv)")
+    parser.add_argument("--dry-run", action="store_true", help="Preview what would be written without actually writing")
     args = parser.parse_args()
 
     # Resolve paths relative to the script's parent directory (roofline/vllm/)

--- a/profiling/roofline/vllm/test_prometheus_parser.py
+++ b/profiling/roofline/vllm/test_prometheus_parser.py
@@ -2,11 +2,11 @@
 """Tests for prometheus_parser.py"""
 
 from prometheus_parser import (
-    parse_prometheus_text,
-    histogram_quantile,
     compute_deltas,
-    extract_throughput_metrics,
     extract_latency_percentiles,
+    extract_throughput_metrics,
+    histogram_quantile,
+    parse_prometheus_text,
 )
 
 SAMPLE_METRICS = """\
@@ -106,41 +106,41 @@ vllm:time_per_output_token_seconds_count 5
 
 def test_parse():
     parsed = parse_prometheus_text(SAMPLE_METRICS)
-    
+
     assert parsed["counters"]["vllm:prompt_tokens_total"] == 50000.0, f"Got {parsed['counters']}"
     assert parsed["counters"]["vllm:generation_tokens_total"] == 12000.0
     assert parsed["counters"]["vllm:num_preemptions_total"] == 3.0
-    
+
     assert parsed["gauges"]["vllm:gpu_cache_usage_perc"] == 0.45
     assert parsed["gauges"]["vllm:num_requests_running"] == 10.0
-    
+
     e2e = parsed["histograms"]["vllm:e2e_request_latency_seconds"]
     assert e2e["sum"] == 42.5
     assert e2e["count"] == 30
     assert len(e2e["buckets"]) == 5
     assert e2e["buckets"][0] == (0.5, 5)
-    assert e2e["buckets"][-1] == (float('inf'), 30)
-    
+    assert e2e["buckets"][-1] == (float("inf"), 30)
+
     print("✅ parse_prometheus_text OK")
 
 
 def test_histogram_quantile():
     # Simple: 10 items in [0,1], 20 items in [1,2]
-    buckets = [(1.0, 10), (2.0, 30), (float('inf'), 30)]
-    
+    buckets = [(1.0, 10), (2.0, 30), (float("inf"), 30)]
+
     p50 = histogram_quantile(buckets, 0.5)
     # target = 15, falls in bucket (1.0, 2.0), count 10->30, fraction=(15-10)/20=0.25
     # result = 1.0 + 0.25 * 1.0 = 1.25
     assert abs(p50 - 1.25) < 0.001, f"p50={p50}, expected 1.25"
-    
+
     p90 = histogram_quantile(buckets, 0.9)
     # target = 27, bucket (1,2), fraction=(27-10)/20=0.85, result=1.0+0.85=1.85
     assert abs(p90 - 1.85) < 0.001, f"p90={p90}"
-    
+
     # Empty
     assert histogram_quantile([], 0.5) is None
-    assert histogram_quantile([(1.0, 0), (float('inf'), 0)], 0.5) is None
-    
+    assert histogram_quantile([(1.0, 0), (float("inf"), 0)], 0.5) is None
+
     print("✅ histogram_quantile OK")
 
 
@@ -148,11 +148,11 @@ def test_compute_deltas():
     warmup = parse_prometheus_text(WARMUP_METRICS)
     final = parse_prometheus_text(SAMPLE_METRICS)
     deltas = compute_deltas(warmup, final)
-    
+
     assert deltas["vllm:prompt_tokens_total"] == 49000.0
     assert deltas["vllm:generation_tokens_total"] == 11800.0
     assert deltas["vllm:num_preemptions_total"] == 3.0
-    
+
     e2e = deltas["vllm:e2e_request_latency_seconds"]
     assert e2e["count"] == 25
     assert abs(e2e["sum"] - 39.3) < 0.01
@@ -161,9 +161,9 @@ def test_compute_deltas():
     assert bd[0.5] == 3
     assert bd[1.0] == 11
     assert bd[2.0] == 20
-    
+
     assert deltas["gauges"]["vllm:gpu_cache_usage_perc"] == 0.45
-    
+
     print("✅ compute_deltas OK")
 
 
@@ -171,14 +171,14 @@ def test_throughput():
     warmup = parse_prometheus_text(WARMUP_METRICS)
     final = parse_prometheus_text(SAMPLE_METRICS)
     deltas = compute_deltas(warmup, final)
-    
+
     tp = extract_throughput_metrics(deltas, wall_clock_elapsed=100.0)
     assert tp["total_prompt_tokens"] == 49000.0
     assert tp["total_generation_tokens"] == 11800.0
     assert abs(tp["tokens_per_sec_total"] - 608.0) < 0.1
     assert abs(tp["tokens_per_sec_prefill"] - 490.0) < 0.1
     assert abs(tp["tokens_per_sec_decode"] - 118.0) < 0.1
-    
+
     print("✅ extract_throughput_metrics OK")
 
 
@@ -186,22 +186,30 @@ def test_latency_percentiles():
     warmup = parse_prometheus_text(WARMUP_METRICS)
     final = parse_prometheus_text(SAMPLE_METRICS)
     deltas = compute_deltas(warmup, final)
-    
+
     lat = extract_latency_percentiles(deltas)
-    
+
     # Check that percentiles are populated and reasonable
-    for key in ["ttft_ms_p50", "ttft_ms_p95", "ttft_ms_p99",
-                "tpot_ms_p50", "tpot_ms_p95", "tpot_ms_p99",
-                "e2e_ms_p50", "e2e_ms_p95", "e2e_ms_p99"]:
+    for key in [
+        "ttft_ms_p50",
+        "ttft_ms_p95",
+        "ttft_ms_p99",
+        "tpot_ms_p50",
+        "tpot_ms_p95",
+        "tpot_ms_p99",
+        "e2e_ms_p50",
+        "e2e_ms_p95",
+        "e2e_ms_p99",
+    ]:
         assert lat[key] is not None, f"{key} is None"
         assert lat[key] > 0, f"{key} = {lat[key]}"
-    
+
     # TTFT p50 should be < 500ms (most in 0-0.5s range)
     assert lat["ttft_ms_p50"] < 500, f"ttft_ms_p50={lat['ttft_ms_p50']}"
     # E2E p50 should be around 0.5-1.0s range
     assert 200 < lat["e2e_ms_p50"] < 2000, f"e2e_ms_p50={lat['e2e_ms_p50']}"
-    
-    print(f"✅ extract_latency_percentiles OK")
+
+    print("✅ extract_latency_percentiles OK")
     for k, v in sorted(lat.items()):
         print(f"   {k}: {v}")
 

--- a/profiling/roofline/vllm/upload_model_to_s3.py
+++ b/profiling/roofline/vllm/upload_model_to_s3.py
@@ -19,6 +19,7 @@ Usage:
     # Custom disk size (for very large models)
     python upload_model_to_s3.py --disk-size 500 --run
 """
+
 import argparse
 import subprocess
 import sys
@@ -157,31 +158,39 @@ def main():
         """),
     )
     parser.add_argument(
-        "--model", default=DEFAULT_MODEL,
+        "--model",
+        default=DEFAULT_MODEL,
         help=f"HuggingFace model ID (default: {DEFAULT_MODEL})",
     )
     parser.add_argument(
-        "--bucket", default=DEFAULT_BUCKET,
+        "--bucket",
+        default=DEFAULT_BUCKET,
         help=f"S3 bucket name (default: {DEFAULT_BUCKET})",
     )
     parser.add_argument(
-        "--s3-prefix", default=DEFAULT_S3_PREFIX,
+        "--s3-prefix",
+        default=DEFAULT_S3_PREFIX,
         help=f"S3 key prefix within the bucket (default: {DEFAULT_S3_PREFIX})",
     )
     parser.add_argument(
-        "--disk-size", type=int, default=DEFAULT_DISK_SIZE,
+        "--disk-size",
+        type=int,
+        default=DEFAULT_DISK_SIZE,
         help=f"Disk size in GB for the worker instance (default: {DEFAULT_DISK_SIZE})",
     )
     parser.add_argument(
-        "--region", default=DEFAULT_REGION,
+        "--region",
+        default=DEFAULT_REGION,
         help=f"AWS region (should match your benchmark region) (default: {DEFAULT_REGION})",
     )
     parser.add_argument(
-        "--hf-token", default="",
+        "--hf-token",
+        default="",
         help="HuggingFace token for authenticated downloads (faster speeds, required for gated models)",
     )
     parser.add_argument(
-        "--run", action="store_true",
+        "--run",
+        action="store_true",
         help="Actually launch the instance (default: dry run)",
     )
 
@@ -193,7 +202,7 @@ def main():
     print(f"S3 path:    {s3_path}")
     print(f"Region:     {args.region}")
     print(f"Disk size:  {args.disk_size} GB")
-    print(f"Instance:   spot (cheapest with 8+ CPUs, 32+ GB RAM)")
+    print("Instance:   spot (cheapest with 8+ CPUs, 32+ GB RAM)")
     print()
 
     # Generate YAML

--- a/quota/region_selector.py
+++ b/quota/region_selector.py
@@ -16,6 +16,13 @@ import logging
 import subprocess
 from dataclasses import dataclass
 
+from orca_server.cloud.models import (
+    QuotaRequest,
+)
+from orca_server.cloud.models import (
+    RegionCandidate as CloudRegionCandidate,
+)
+from orca_server.cloud.quota import QuotaProvider
 from orca_server.config import INSTANCE_VCPUS, VLLM_PORT
 
 logger = logging.getLogger(__name__)
@@ -260,6 +267,28 @@ def build_skypilot_any_of(
         any_of.append(c.to_skypilot_resources(instance_type, disk_size, ports))
 
     return any_of
+
+
+class AWSQuotaProvider(QuotaProvider):
+    """AWS quota adapter backed by the existing region selector implementation."""
+
+    def get_region_candidates(self, request: QuotaRequest) -> list[CloudRegionCandidate]:
+        if request.cloud.lower() != "aws":
+            return []
+        candidates = get_ordered_regions(
+            instance_type=request.instance_type,
+            num_nodes=request.num_nodes,
+            prefer_spot=request.prefer_spot,
+            target_market=request.target_market,
+        )
+        return [
+            CloudRegionCandidate(
+                region=c.region,
+                market="spot" if c.use_spot else "on_demand",
+                available_quota=c.available_quota,
+            )
+            for c in candidates
+        ]
 
 
 # Cache for quota queries (refresh every 5 minutes)

--- a/server.py
+++ b/server.py
@@ -32,6 +32,7 @@ from orca_server.config import (
     PLACEMENT_SOLVER,
     S3_UPLOAD_BUCKET,
     S3_UPLOAD_PREFIX,
+    TD_STORAGE_UPLOAD_SCHEME,
 )
 from orca_server.input_parser import parse_input_file_stats
 from orca_server.job_manager import (
@@ -60,6 +61,7 @@ from quota.region_selector import (
 )
 from quota.tracker import VPCQuotaTracker
 from storage.storage_factory import get_storage_backend
+from storage.uri import is_storage_uri
 
 # ---------------------------------------------------------------------------
 # Replica log forwarding
@@ -2522,9 +2524,9 @@ async def upload_file_to_storage(
     try:
         if not remote_path:
             filename = file.filename or f"upload_{int(time.time())}"
-            remote_path = f"s3://{S3_UPLOAD_BUCKET}/{S3_UPLOAD_PREFIX}/{user}/{int(time.time())}_{filename}"
-        elif not remote_path.startswith("s3://"):
-            remote_path = f"s3://{S3_UPLOAD_BUCKET}/{S3_UPLOAD_PREFIX}/{user}/{remote_path}"
+            remote_path = f"{TD_STORAGE_UPLOAD_SCHEME}://{S3_UPLOAD_BUCKET}/{S3_UPLOAD_PREFIX}/{user}/{int(time.time())}_{filename}"
+        elif not is_storage_uri(remote_path):
+            remote_path = f"{TD_STORAGE_UPLOAD_SCHEME}://{S3_UPLOAD_BUCKET}/{S3_UPLOAD_PREFIX}/{user}/{remote_path}"
         logger.info(f"[Storage] Uploading file for user {user} to {remote_path}")
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             chunk_size = CHUNK_SIZE_BYTES
@@ -2611,6 +2613,29 @@ async def download_s3_file(path: str, user: str = "default"):
         raise HTTPException(status_code=500, detail=f"Error downloading file: {str(e)}")
 
 
+@app.get("/storage/download")
+async def download_storage_file(path: str, user: str = "default"):
+    """Download a file by full storage URI."""
+    if not is_storage_uri(path):
+        raise HTTPException(status_code=400, detail="path must be a full storage URI")
+    try:
+        logger.info(f"[Storage] download path={path} user={user}")
+        filename = path.split("/")[-1] or "download"
+
+        async def file_stream_iterator():
+            async for chunk in storage_backend.stream_file(path, user):
+                yield chunk
+
+        return StreamingResponse(
+            file_stream_iterator(),
+            media_type="application/octet-stream",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    except Exception as e:
+        logger.error(f"[Storage] Error downloading storage file: {e}")
+        raise HTTPException(status_code=500, detail=f"Error downloading file: {str(e)}")
+
+
 @app.delete("/storage/delete/{user}/{file_path:path}")
 async def delete_file_from_storage(user: str, file_path: str):
     """Delete a file from storage backend."""
@@ -2649,6 +2674,24 @@ async def delete_s3_file(path: str, user: str = "default"):
         raise
     except Exception as e:
         logger.error(f"[Storage] Error deleting S3 file: {e}")
+        raise HTTPException(status_code=500, detail=f"Error deleting file: {str(e)}")
+
+
+@app.delete("/storage/delete")
+async def delete_storage_file(path: str, user: str = "default"):
+    """Delete a file by full storage URI."""
+    if not is_storage_uri(path):
+        raise HTTPException(status_code=400, detail="path must be a full storage URI")
+    try:
+        logger.info(f"[Storage] delete path={path} user={user}")
+        success = await storage_backend.delete_file(path, user)
+        if success:
+            return {"status": "success", "path": path}
+        raise HTTPException(status_code=500, detail=f"Failed to delete {path}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"[Storage] Error deleting storage file: {e}")
         raise HTTPException(status_code=500, detail=f"Error deleting file: {str(e)}")
 
 

--- a/storage/backends/s3_big.py
+++ b/storage/backends/s3_big.py
@@ -8,7 +8,7 @@ from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-from utils.utils import split_uri
+from storage.uri import parse_storage_uri
 
 from .base import StorageBackend
 
@@ -21,18 +21,26 @@ DEFAULT_MAX_CONCURRENCY = 16
 DEFAULT_STREAM_CHUNK_MB = 8
 
 
-class S3BigStorageBackend(StorageBackend):
+class S3CompatibleStorageBackend(StorageBackend):
     """
     Optimized S3 backend for large objects (multi-GB) and high concurrency.
     Uses boto3 TransferConfig to take advantage of multipart uploads/downloads
     and threaded concurrency without requiring changes to the FastAPI layer.
     """
 
+    allowed_schemes = {"s3", "minio"}
+
     def __init__(self):
         self.aws_region = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
         boto_config = Config(signature_version="s3v4")
+        endpoint_url = os.getenv("TD_STORAGE_ENDPOINT_URL") or os.getenv("S3_ENDPOINT_URL")
         # print("running in region: ", self.aws_region)
-        self.s3_client = boto3.client("s3", region_name=self.aws_region, config=boto_config)
+        self.s3_client = boto3.client(
+            "s3",
+            region_name=self.aws_region,
+            config=boto_config,
+            endpoint_url=endpoint_url,
+        )
 
         multipart_threshold = int(os.getenv("S3_MULTIPART_THRESHOLD_MB", DEFAULT_MULTIPART_THRESHOLD_MB)) * 1024 * 1024
         multipart_chunksize = int(os.getenv("S3_MULTIPART_CHUNK_MB", DEFAULT_MULTIPART_CHUNK_MB)) * 1024 * 1024
@@ -47,22 +55,20 @@ class S3BigStorageBackend(StorageBackend):
 
         self.stream_chunk_size = int(os.getenv("S3_STREAM_CHUNK_MB", DEFAULT_STREAM_CHUNK_MB)) * 1024 * 1024
 
+    def _parse_remote_path(self, remote_path: str):
+        return parse_storage_uri(remote_path, allowed_schemes=self.allowed_schemes)
+
     def _get_bucket_and_key(self, remote_path: str) -> tuple[str, str]:
         """
         Extract bucket name and key from remote_path.
-        If remote_path is a full S3 URI (s3://bucket/key), extract both.
-        Otherwise, use the user prefix and remote_path as the key.
+        If remote_path is a full S3-compatible URI, extract both.
         Returns: (bucket_name, key)
         """
-        if remote_path.startswith("s3://"):
-            uri_bucket, key = split_uri(remote_path)
-            bucket_name = uri_bucket.split("://")[1]
-            return bucket_name, key
-        # For non-URI paths, we need a bucket name - this should come from remote_path
-        # If it's not a full URI, we can't determine the bucket, so raise an error
-        raise ValueError(
-            f"remote_path must be a full S3 URI (s3://bucket/key) or include bucket information. Got: {remote_path}"
-        )
+        uri = self._parse_remote_path(remote_path)
+        return uri.bucket, uri.key
+
+    def _remote_uri(self, remote_path: str) -> str:
+        return self._parse_remote_path(remote_path).uri
 
     def _get_key(self, remote_path: str, user: str) -> str:
         """Deprecated: Use _get_bucket_and_key instead. Kept for backward compatibility."""
@@ -79,7 +85,7 @@ class S3BigStorageBackend(StorageBackend):
                 key,
                 Config=self.transfer_config,
             )
-            s3_uri = f"s3://{bucket_name}/{key}"
+            s3_uri = self._remote_uri(remote_path)
             logger.info(f"Uploaded {local_path} to {s3_uri}")
             return s3_uri
         except ClientError as e:
@@ -115,7 +121,7 @@ class S3BigStorageBackend(StorageBackend):
                 Key=key,
                 Body=data,
             )
-            s3_uri = f"s3://{bucket_name}/{key}"
+            s3_uri = self._remote_uri(remote_path)
             logger.info(f"Uploaded data to {s3_uri}")
             return s3_uri
         except ClientError as e:
@@ -225,7 +231,8 @@ class S3BigStorageBackend(StorageBackend):
                 "method": "put",
                 "headers": {"Content-Type": "application/octet-stream"},
                 "key": key,
-                "s3_uri": f"s3://{bucket_name}/{key}",
+                "s3_uri": self._remote_uri(remote_path),
+                "storage_uri": self._remote_uri(remote_path),
             }
         except ClientError as e:
             logger.error(f"Error generating presigned upload URL: {e}")
@@ -265,7 +272,8 @@ class S3BigStorageBackend(StorageBackend):
             "upload_id": response["UploadId"],
             "key": key,
             "bucket": bucket_name,
-            "s3_uri": f"s3://{bucket_name}/{key}",
+            "s3_uri": self._remote_uri(remote_path),
+            "storage_uri": self._remote_uri(remote_path),
         }
 
     async def multipart_sign_part(
@@ -323,6 +331,12 @@ class S3BigStorageBackend(StorageBackend):
             UploadId=upload_id,
         )
         return True
+
+
+class S3BigStorageBackend(S3CompatibleStorageBackend):
+    """Backward-compatible name for the S3-compatible large object backend."""
+
+    pass
 
 
 async def _paginate_async(page_iterator):

--- a/storage/storage_factory.py
+++ b/storage/storage_factory.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from storage.backends.base import StorageBackend
-from storage.backends.s3_big import S3BigStorageBackend
+from storage.backends.s3_big import S3BigStorageBackend, S3CompatibleStorageBackend
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +13,10 @@ def get_storage_backend() -> StorageBackend:
     """
     storage_type = os.getenv("TD_STORAGE_BACKEND", "s3_big").lower()
 
-    if storage_type == "s3_big":
+    if storage_type in {"s3_big", "s3", "s3_compatible", "minio"}:
         # logger.info("Initializing S3 Big storage backend")
-        return S3BigStorageBackend()
+        if storage_type == "s3_big":
+            return S3BigStorageBackend()
+        return S3CompatibleStorageBackend()
     else:
         raise ValueError(f"Unknown storage backend type: {storage_type}")

--- a/storage/uri.py
+++ b/storage/uri.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class StorageUri:
+    scheme: str
+    bucket: str
+    key: str
+
+    @property
+    def uri(self) -> str:
+        return f"{self.scheme}://{self.bucket}/{self.key}" if self.key else f"{self.scheme}://{self.bucket}"
+
+
+def parse_storage_uri(uri: str, allowed_schemes: set[str] | None = None) -> StorageUri:
+    parsed = urlparse(uri)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"storage URI must include scheme and bucket/container: {uri}")
+    if allowed_schemes is not None and parsed.scheme not in allowed_schemes:
+        allowed = ", ".join(sorted(allowed_schemes))
+        raise ValueError(f"storage URI scheme must be one of {allowed}. Got: {uri}")
+    return StorageUri(
+        scheme=parsed.scheme,
+        bucket=parsed.netloc,
+        key=parsed.path.lstrip("/"),
+    )
+
+
+def is_storage_uri(value: str) -> bool:
+    parsed = urlparse(value)
+    return bool(parsed.scheme and parsed.netloc)

--- a/templates/vllm_batch_runner_chunked.py
+++ b/templates/vllm_batch_runner_chunked.py
@@ -1253,13 +1253,13 @@ def report_chunk_complete(chunk_id: str) -> dict:
         return {}
 
 
-def download_chunk(s3_input_path: str, local_path: str) -> bool:
-    """Download a chunk via the control plane's S3 download endpoint (with retries)."""
+def download_chunk(input_uri: str, local_path: str) -> bool:
+    """Download a chunk via the control plane's storage endpoint (with retries)."""
 
     def _download():
         resp = requests.get(
-            f"{ORCA_URL}/storage/download_s3",
-            params={"path": s3_input_path, "user": "chunk-runner"},
+            f"{ORCA_URL}/storage/download",
+            params={"path": input_uri, "user": "chunk-runner"},
             timeout=120,
             stream=True,
         )
@@ -1269,13 +1269,13 @@ def download_chunk(s3_input_path: str, local_path: str) -> bool:
                 f.write(data)
 
     try:
-        _retry(_download, f"Download {s3_input_path}", max_attempts=3, base_delay=3.0)
+        _retry(_download, f"Download {input_uri}", max_attempts=3, base_delay=3.0)
         return True
     except RuntimeError:
         return False
 
 
-def upload_chunk_output(local_path: str, s3_output_path: str) -> bool:
+def upload_chunk_output(local_path: str, output_uri: str) -> bool:
     """Upload chunk output via the control plane's storage endpoint (with retries)."""
 
     def _upload():
@@ -1283,13 +1283,13 @@ def upload_chunk_output(local_path: str, s3_output_path: str) -> bool:
             resp = requests.post(
                 f"{ORCA_URL}/storage/upload",
                 files={"file": (os.path.basename(local_path), f)},
-                data={"user": "chunk-runner", "remote_path": s3_output_path},
+                data={"user": "chunk-runner", "remote_path": output_uri},
                 timeout=120,
             )
         resp.raise_for_status()
 
     try:
-        _retry(_upload, f"Upload {s3_output_path}", max_attempts=3, base_delay=3.0)
+        _retry(_upload, f"Upload {output_uri}", max_attempts=3, base_delay=3.0)
         return True
     except RuntimeError:
         return False
@@ -1372,11 +1372,11 @@ def pull_and_download_chunk() -> tuple:
     renewal_thread.start()
     renewal_ctx = (renewal_stop, lease_stolen, renewal_thread)
 
-    s3_path = chunk_info.get("s3_input_path", "")
+    input_uri = chunk_info.get("input_uri") or chunk_info.get("s3_input_path", "")
     local_path = f"/tmp/chunk_{JOB_ID}_{cid}.jsonl"
 
-    print(f"[Runner] Downloading chunk {cid} from {s3_path}")
-    if not download_chunk(s3_path, local_path):
+    print(f"[Runner] Downloading chunk {cid} from {input_uri}")
+    if not download_chunk(input_uri, local_path):
         print(f"[Runner] Failed to download chunk {cid} after retries")
         return chunk_info, [], renewal_ctx
 
@@ -1735,12 +1735,12 @@ def main():
                 _signaled_idle = False
                 _idle_since = None
             cid = chunk_info.get("chunk_id", "unknown")
-            s3_output_path = chunk_info.get("s3_output_path", "")
+            output_uri = chunk_info.get("output_uri") or chunk_info.get("s3_output_path", "")
 
-            # Extract s3_output_base from first chunk's output path
-            if not s3_output_base and s3_output_path:
+            # Extract output base from first chunk's output path
+            if not s3_output_base and output_uri:
                 # e.g. "s3://bucket/prefix/chunks/c0001.jsonl" → "s3://bucket/prefix"
-                parts = s3_output_path.rsplit("/chunks/", 1)
+                parts = output_uri.rsplit("/chunks/", 1)
                 if len(parts) == 2:
                     s3_output_base = parts[0]
 
@@ -1778,9 +1778,9 @@ def main():
             local_output = f"/tmp/chunk_output_{JOB_ID}_{cid}.jsonl"
             write_output_jsonl(results, local_output, args.model)
 
-            upload_ok = upload_chunk_output(local_output, s3_output_path)
+            upload_ok = upload_chunk_output(local_output, output_uri)
             if upload_ok:
-                print(f"[Runner] Uploaded chunk {cid} output to {s3_output_path}")
+                print(f"[Runner] Uploaded chunk {cid} output to {output_uri}")
             else:
                 print(f"[Runner] FAILED to upload chunk {cid} — will NOT report complete")
             try:

--- a/tests/test_cloud_abstractions.py
+++ b/tests/test_cloud_abstractions.py
@@ -1,0 +1,118 @@
+from orca_server.cloud import (
+    AWSInstanceCatalog,
+    InstanceSpec,
+    PlacementCandidate,
+    QuotaRequest,
+    SkyPilotLaunchBackend,
+)
+from orca_server.config import AWS_INSTANCES
+from quota.region_selector import AWSQuotaProvider, RegionCandidate
+from storage.uri import is_storage_uri, parse_storage_uri
+
+
+def test_aws_instance_catalog_wraps_existing_table():
+    catalog = AWSInstanceCatalog(AWS_INSTANCES)
+
+    spec = catalog.get_instance("aws", "g6e.12xlarge")
+
+    assert spec == InstanceSpec(
+        cloud="aws",
+        instance_type="g6e.12xlarge",
+        gpu_name="L40S",
+        gpu_count=4,
+        vcpus=48,
+        vram_gb=48,
+        supports_vllm_v1=True,
+    )
+    assert len(catalog.list_instances("aws")) == len(AWS_INSTANCES)
+    assert catalog.list_instances("gcp") == []
+
+
+def test_placement_candidate_is_provider_neutral():
+    candidate = PlacementCandidate(
+        cloud="aws",
+        region="us-east-1",
+        instance_type="p5.48xlarge",
+        gpu_type="H100",
+        gpus_per_node=8,
+        num_nodes=2,
+        tp_size=8,
+        pp_size=2,
+        market="spot",
+        estimated_cost_per_hour=98.0,
+    )
+
+    assert candidate.cloud == "aws"
+    assert candidate.market == "spot"
+    assert candidate.num_nodes == 2
+
+
+def test_storage_uri_parsing_is_scheme_agnostic():
+    uri = parse_storage_uri("minio://bucket/path/to/file.jsonl")
+
+    assert uri.scheme == "minio"
+    assert uri.bucket == "bucket"
+    assert uri.key == "path/to/file.jsonl"
+    assert uri.uri == "minio://bucket/path/to/file.jsonl"
+    assert is_storage_uri("gs://bucket/object") is True
+    assert is_storage_uri("local/file.jsonl") is False
+
+
+def test_aws_quota_provider_delegates_to_existing_selector(monkeypatch):
+    def fake_get_ordered_regions(**kwargs):
+        assert kwargs == {
+            "instance_type": "g6e.12xlarge",
+            "num_nodes": 2,
+            "prefer_spot": False,
+            "target_market": "on_demand",
+        }
+        return [
+            RegionCandidate(
+                region="us-east-1",
+                use_spot=False,
+                available_quota=192,
+            )
+        ]
+
+    monkeypatch.setattr("quota.region_selector.get_ordered_regions", fake_get_ordered_regions)
+
+    provider = AWSQuotaProvider()
+    candidates = provider.get_region_candidates(
+        QuotaRequest(
+            cloud="aws",
+            instance_type="g6e.12xlarge",
+            num_nodes=2,
+            prefer_spot=False,
+            target_market="on_demand",
+        )
+    )
+
+    assert candidates[0].region == "us-east-1"
+    assert candidates[0].market == "on_demand"
+    assert candidates[0].use_spot is False
+    assert provider.get_region_candidates(QuotaRequest(cloud="gcp", instance_type="a3-highgpu-8g")) == []
+
+
+def test_skypilot_launch_backend_builds_resources_from_candidate():
+    backend = SkyPilotLaunchBackend(ports=8001)
+    resources = backend.build_resources(
+        PlacementCandidate(
+            cloud="aws",
+            region="us-west-2",
+            instance_type="g6e.12xlarge",
+            gpu_type="L40S",
+            gpus_per_node=4,
+            num_nodes=1,
+            tp_size=4,
+            pp_size=1,
+            market="on_demand",
+        )
+    )
+
+    assert resources == {
+        "instance_type": "g6e.12xlarge",
+        "disk_size": "300GB",
+        "region": "us-west-2",
+        "use_spot": False,
+        "ports": 8001,
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from orca_server.config import (
     INSTANCE_VRAM,
     VLLM_PORT,
 )
+from placement.roofline.gpu_specs import AWS_INSTANCE_GPU_MAP
 
 
 def test_derived_dicts_cover_all_instances():
@@ -43,6 +44,15 @@ def test_instance_vram_values():
     for inst, vram in INSTANCE_VRAM.items():
         assert vram == AWS_INSTANCES[inst][3]
         assert vram > 0
+
+
+def test_roofline_instance_gpu_map_matches_config():
+    """Roofline's duplicate instance map stays aligned with canonical config."""
+    for inst, (gpu_name, gpu_count, *_rest) in AWS_INSTANCES.items():
+        assert AWS_INSTANCE_GPU_MAP[inst] == {
+            "gpu_model": gpu_name,
+            "num_gpus": gpu_count,
+        }
 
 
 def test_a100_vram_differentiated():


### PR DESCRIPTION
## Summary
- Add provider-neutral cloud models and interfaces for placement, catalog, quota, pricing, and launch seams.
- Wrap the existing AWS/S3 behavior behind initial adapters while preserving current runtime behavior.
- Add generic storage URI handling plus generic storage download/delete routes, with chunk runner support for `input_uri` and `output_uri`.
- Apply tracked Ruff cleanup to profiling tooling so CI lint remains green on this branch.

## Validation
- `ruff check $(git ls-files '*.py')`
- `ruff format --check $(git ls-files '*.py')`
- `pytest` (`364 passed, 1 skipped`)