### PR TITLE
feat: bump vLLM to 0.19.1 and inject DLAMI per region

### DIFF
--- a/orca_server/config.py
+++ b/orca_server/config.py
@@ -38,7 +38,7 @@ CHUNK_SIZE_BYTES = int(os.getenv("CHUNK_SIZE_MB", 8)) * 1024 * 1024
 
 # Control plane URL reachable from EC2 clusters (empty = local dev, sidecar disabled)
 TD_SERVER_URL = os.getenv("TD_SERVER_URL", "")
-ORCA_API_KEY    = os.getenv("ORCA_API_KEY", "")
+ORCA_API_KEY = os.getenv("ORCA_API_KEY", "")
 
 # Koi placement service URL (if set, Orca POSTs job completion events to Koi)
 KOI_SERVICE_URL = os.getenv("KOI_SERVICE_URL", "")
@@ -46,15 +46,15 @@ KOI_SERVICE_URL = os.getenv("KOI_SERVICE_URL", "")
 # Redis (for chunked distributed batch)
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 DEFAULT_CHUNK_SIZE_LINES = int(os.getenv("CHUNK_SIZE_LINES", "1000"))
-CHUNK_LEASE_TTL_SEC    = int(os.getenv("CHUNK_LEASE_TTL_SEC", "600"))
-CHUNK_MAX_RETRIES      = int(os.getenv("CHUNK_MAX_RETRIES", "3"))
+CHUNK_LEASE_TTL_SEC = int(os.getenv("CHUNK_LEASE_TTL_SEC", "600"))
+CHUNK_MAX_RETRIES = int(os.getenv("CHUNK_MAX_RETRIES", "3"))
 CHUNK_RECLAIM_INTERVAL = int(os.getenv("CHUNK_RECLAIM_INTERVAL_SEC", "60"))
-CHUNK_RENEW_INTERVAL   = int(os.getenv("CHUNK_RENEW_INTERVAL_SEC", "30"))
+CHUNK_RENEW_INTERVAL = int(os.getenv("CHUNK_RENEW_INTERVAL_SEC", "30"))
 
 # Replica watchdog — heartbeat-based dead replica detection
 REPLICA_DEAD_THRESHOLD_SEC = int(os.getenv("REPLICA_DEAD_THRESHOLD_SEC", "45"))
 WATCHDOG_POLL_INTERVAL_SEC = int(os.getenv("WATCHDOG_POLL_INTERVAL_SEC", "10"))
-RECOVERY_COOLDOWN_SEC      = int(os.getenv("RECOVERY_COOLDOWN_SEC", "300"))
+RECOVERY_COOLDOWN_SEC = int(os.getenv("RECOVERY_COOLDOWN_SEC", "300"))
 
 # --------------------------------------------------------------------------- #
 # Canonical AWS instance table
@@ -68,12 +68,12 @@ AWS_INSTANCES = {
     # P5 instances (H100 80GB)
     "p5.48xlarge": ("H100", 8, 192, 80),
     # P4 instances (A100)
-    "p4d.24xlarge": ("A100", 8, 96, 40),     # A100 40GB HBM2e
-    "p4de.24xlarge": ("A100", 8, 96, 80),    # A100 80GB HBM2e
+    "p4d.24xlarge": ("A100", 8, 96, 40),  # A100 40GB HBM2e
+    "p4de.24xlarge": ("A100", 8, 96, 80),  # A100 80GB HBM2e
     # P3 instances (V100)
-    "p3.2xlarge": ("V100", 1, 8, 16),        # V100 16GB
+    "p3.2xlarge": ("V100", 1, 8, 16),  # V100 16GB
     "p3.8xlarge": ("V100", 4, 32, 16),
-    "p3.16xlarge": ("V100", 8, 64, 32),      # V100 32GB
+    "p3.16xlarge": ("V100", 8, 64, 32),  # V100 32GB
     "p3dn.24xlarge": ("V100", 8, 96, 32),
     # G6e instances (L40S 48GB)
     "g6e.xlarge": ("L40S", 1, 4, 48),
@@ -125,7 +125,69 @@ AWS_INSTANCE_TO_GPU = {
 # GPUs with compute capability < 8.0 — vLLM V1 engine is not supported
 _V1_UNSUPPORTED_GPUS = {"V100", "T4"}
 
+
 def supports_vllm_v1(instance_type: str) -> bool:
     """Check if an instance type's GPU supports vLLM V1 engine (CC >= 8.0)."""
     gpu = INSTANCE_TO_GPU.get(instance_type, "")
     return gpu not in _V1_UNSUPPORTED_GPUS
+
+
+# --------------------------------------------------------------------------- #
+# vLLM + transformers pin
+#
+# vLLM 0.19.1 is the validated version for production. It works for both
+# single-node and multi-node pipeline parallelism (tp4,pp3 / tp4,pp4 / tp8,pp2
+# all tested healthy). vLLM 0.20.0 introduced a regression in the v1 engine's
+# multi-node PP executor that breaks cross-node worker initialization, so we
+# stay on 0.19.1 until upstream lands a fix.
+#
+# 0.19.1 requires CUDA 13.0 / driver 580+ which is only available on the
+# Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04) family.
+# The default SkyPilot AMI ships driver 535 / CUDA 12.2 which fails with
+# "RuntimeError: NVIDIA driver too old (found version 12020)".
+#
+# transformers must stay pinned at 4.57.6 — vLLM still uses
+# `all_special_tokens_extended` which was removed in transformers 4.47+,
+# and we ship a compatibility shim (templates/vllm_compat_patch.py) that
+# expects this exact range.
+# --------------------------------------------------------------------------- #
+DEFAULT_VLLM_VERSION = os.getenv("ORCA_VLLM_VERSION", "0.19.1")
+DEFAULT_TRANSFORMERS_VERSION = os.getenv("ORCA_TRANSFORMERS_VERSION", "4.57.6")
+
+
+# --------------------------------------------------------------------------- #
+# GPU AMI map
+#
+# All entries are the same DLAMI image (Deep Learning Base OSS Nvidia Driver
+# GPU AMI, Ubuntu 22.04, dated 2026-04-24). Same image_id across regions but
+# different AMI IDs because AWS scopes AMI IDs per region.
+#
+# Driver: 580.x | CUDA: 13.0 | PyTorch 2.x+cu130 (installed by vLLM 0.19.1)
+# Supports: G4dn, G5, G6, G6e, P4d, P4de, P5, P5e, P5en
+#
+# To refresh: `aws ec2 describe-images --owners amazon --filters
+#   "Name=name,Values=Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu
+#   22.04) <YYYYMMDD>"` for each region.
+#
+# When adding a new region, update this map; otherwise launcher will skip
+# that region for vLLM-installable clusters.
+# --------------------------------------------------------------------------- #
+GPU_AMI_MAP: dict[str, str] = {
+    "us-east-1": "ami-0da2c6477a5ee1361",
+    "us-east-2": "ami-0f1a998148248b8fa",
+    "us-west-1": "ami-0b7295d7db6ef312f",
+    "us-west-2": "ami-00212c5e5c3b2ec85",
+    "ap-northeast-2": "ami-0896d4f01f89b1ec8",
+    "eu-west-1": "ami-014cf2391cb36896e",
+    "eu-central-1": "ami-0db8c8f0d0336e45b",
+}
+
+
+def ami_for_region(region: str) -> str | None:
+    """Return the DLAMI ID for the given region, or None if unmapped.
+
+    Callers should treat None as "this region is not eligible for vLLM
+    clusters" — the default AMI ships an older NVIDIA driver that fails
+    with vLLM 0.19.1.
+    """
+    return GPU_AMI_MAP.get(region)

--- a/orca_server/job_templates.py
+++ b/orca_server/job_templates.py
@@ -6,7 +6,12 @@ import os
 import uuid
 from typing import Union
 
-from orca_server.config import INSTANCE_TO_GPU, VLLM_PORT
+from orca_server.config import (
+    DEFAULT_TRANSFORMERS_VERSION,
+    DEFAULT_VLLM_VERSION,
+    INSTANCE_TO_GPU,
+    VLLM_PORT,
+)
 from models.requests import BatchedRequest, OnlineServingRequest
 from models.resources import MagicOutput
 from utils.utils import split_uri
@@ -138,6 +143,11 @@ def replace_run_vllm(
     else:
         replace["additional_params"] = ""
 
+    # vLLM and transformers version pins (used by per-config template
+    # substitution; generic templates pick these up from envs via launcher).
+    replace["vllm_version"] = DEFAULT_VLLM_VERSION
+    replace["transformers_version"] = DEFAULT_TRANSFORMERS_VERSION
+
     return replace
 
 
@@ -148,6 +158,8 @@ def replace_run_vllm_online(request: OnlineServingRequest, config: MagicOutput):
     replace["pp"] = config.pp_size
     replace["host"] = "0.0.0.0"  # Bind to all interfaces (allows external access)
     replace["port"] = str(VLLM_PORT)
+    replace["vllm_version"] = DEFAULT_VLLM_VERSION
+    replace["transformers_version"] = DEFAULT_TRANSFORMERS_VERSION
 
     if (
         request.vllm_specific_config is not None

--- a/orca_server/launcher.py
+++ b/orca_server/launcher.py
@@ -22,6 +22,7 @@ from orca_server.config import (
     HF_TOKEN,
     VLLM_PORT,
     YAML_OUTPUT,
+    ami_for_region,
 )
 from orca_server.koi_contract import ReasonCode, TERMINAL_PHASES
 from orca_server.job_manager import (
@@ -61,12 +62,7 @@ def _classify_attempt_failure(reason: str) -> str:
     carries a structured failure_category per attempted config. Keep the
     pattern set in sync with koi/koi/server.py:_FAILURE_PATTERNS."""
     lc = (reason or "").lower()
-    if (
-        "out of memory" in lc
-        or "outofmemory" in lc
-        or "cuda oom" in lc
-        or "oom" in lc
-    ):
+    if "out of memory" in lc or "outofmemory" in lc or "cuda oom" in lc or "oom" in lc:
         return "oom"
     if "insufficient" in lc and "capacity" in lc:
         return "no_capacity"
@@ -495,32 +491,70 @@ async def sp_launch_vllm_batch(
         prefer_spot=getattr(request, "prefer_spot", True),
     )
 
-    # Build resources with any_of for fallback regions
+    # Build resources with any_of for fallback regions.
+    # AMI per region is resolved from GPU_AMI_MAP — required for vLLM 0.19.1
+    # (driver 580 / CUDA 13.0). Regions without an entry are dropped from
+    # the failover list because the default SkyPilot AMI ships driver 535,
+    # which 0.19.1 rejects with "NVIDIA driver too old".
     use_efa = _needs_efa(config.instance_type)
     if ordered_regions:
         any_of_resources = []
+        skipped_regions = []
         for candidate in ordered_regions[:5]:
+            ami = ami_for_region(candidate.region)
+            if ami is None:
+                skipped_regions.append(candidate.region)
+                continue
             res = {
+                "cloud": "aws",
                 "region": candidate.region,
                 "instance_type": config.instance_type,
                 "use_spot": candidate.use_spot,
                 "disk_size": "300GB",
                 "ports": VLLM_PORT,
+                "image_id": ami,
             }
             if use_efa:
                 res["network_tier"] = "best"
             any_of_resources.append(res)
+        if skipped_regions:
+            job_logger.warning(
+                f"[RegionSelector] Skipped regions without GPU_AMI_MAP entry: {skipped_regions}"
+            )
         job_logger.info(
-            f"[RegionSelector] Trying regions: {[(c.region, 'spot' if c.use_spot else 'on-demand') for c in ordered_regions[:5]]}"
+            f"[RegionSelector] Trying regions: {[(r['region'], 'spot' if r['use_spot'] else 'on-demand') for r in any_of_resources]}"
         )
-        resources_config = {"any_of": any_of_resources}
+        if any_of_resources:
+            resources_config = {"any_of": any_of_resources}
+        else:
+            # All ordered regions lacked an AMI mapping; fall back to a single
+            # us-east-1 entry so the launch isn't silently broken.
+            fallback_ami = ami_for_region("us-east-1")
+            resources_config = {
+                "cloud": "aws",
+                "region": "us-east-1",
+                "instance_type": config.instance_type,
+                "disk_size": "300GB",
+                "ports": VLLM_PORT,
+            }
+            if fallback_ami:
+                resources_config["image_id"] = fallback_ami
+            if use_efa:
+                resources_config["network_tier"] = "best"
+            job_logger.warning(
+                "[RegionSelector] No mapped regions in failover list; falling back to us-east-1"
+            )
     else:
+        fallback_ami = ami_for_region("us-east-1")
         resources_config = {
-            "infra": "aws",
+            "cloud": "aws",
+            "region": "us-east-1",
             "instance_type": config.instance_type,
             "disk_size": "300GB",
             "ports": VLLM_PORT,
         }
+        if fallback_ami:
+            resources_config["image_id"] = fallback_ami
         if use_efa:
             resources_config["network_tier"] = "best"
 
@@ -536,23 +570,31 @@ async def sp_launch_vllm_batch(
         # Write to temp file and parse as yaml
         yaml_data = yaml.safe_load(template_content)
 
-        # Preserve image_id from template if specified (e.g., custom AMI for A100)
-        template_image_id = yaml_data.get("resources", {}).get("image_id")
-        template_region = yaml_data.get("resources", {}).get("region")
-
-        # If template has a specific image_id, use its region and don't do quota-based fallback
-        if template_image_id:
-            job_logger.info(
-                f"[Template] Using custom AMI: {template_image_id} in {template_region}"
-            )
-            resources_config = {
-                "cloud": "aws",
-                "accelerators": yaml_data["resources"].get("accelerators", "A100:8"),
-                "disk_size": yaml_data["resources"].get("disk_size", "300GB"),
-                "ports": yaml_data["resources"].get("ports", VLLM_PORT),
-                "image_id": template_image_id,
-                "region": template_region,
-            }
+        # Merge template's static resource preferences (accelerators, disk, ports)
+        # into the dynamic resources_config we already built (which has AMI +
+        # region + spot policy). If template specifies accelerators, that wins
+        # over the dynamic instance_type because the template is per-config.
+        template_resources = yaml_data.get("resources") or {}
+        template_accelerators = template_resources.get("accelerators")
+        if template_accelerators:
+            # Per-config template specifies accelerators (e.g., "A100:8"); use
+            # them and drop instance_type from each any_of entry to avoid a
+            # conflict between the two.
+            if "any_of" in resources_config:
+                for entry in resources_config["any_of"]:
+                    entry.pop("instance_type", None)
+                    entry["accelerators"] = template_accelerators
+            else:
+                resources_config.pop("instance_type", None)
+                resources_config["accelerators"] = template_accelerators
+        # Honor template disk_size override if larger than default
+        template_disk = template_resources.get("disk_size")
+        if template_disk:
+            if "any_of" in resources_config:
+                for entry in resources_config["any_of"]:
+                    entry["disk_size"] = template_disk
+            else:
+                resources_config["disk_size"] = template_disk
 
         # Update dynamic fields
         yaml_data["name"] = config.decision_id
@@ -1095,32 +1137,66 @@ async def _launch_chunked_replica(
         target_market=requested_market,
     )
 
+    # AMI per region from GPU_AMI_MAP — required for vLLM 0.19.1.
     use_efa = _needs_efa(config.instance_type)
     if ordered_regions:
         any_of_resources = []
+        skipped_regions = []
         for candidate in ordered_regions[:5]:
+            ami = ami_for_region(candidate.region)
+            if ami is None:
+                skipped_regions.append(candidate.region)
+                continue
             res = {
+                "cloud": "aws",
                 "region": candidate.region,
                 "instance_type": config.instance_type,
                 "use_spot": candidate.use_spot,
                 "disk_size": "300GB",
                 "ports": VLLM_PORT,
+                "image_id": ami,
             }
             if use_efa:
                 res["network_tier"] = "best"
             any_of_resources.append(res)
-        resources_config = {"any_of": any_of_resources}
+        if skipped_regions and job_logger:
+            job_logger.warning(
+                f"[RegionSelector] Skipped regions without GPU_AMI_MAP entry: {skipped_regions}"
+            )
+        if any_of_resources:
+            resources_config = {"any_of": any_of_resources}
+        else:
+            if requested_market is not None:
+                raise RuntimeError(
+                    f"No {requested_market} quota candidates with mapped AMI for {config.instance_type}"
+                )
+            fallback_ami = ami_for_region("us-east-1")
+            resources_config = {
+                "cloud": "aws",
+                "region": "us-east-1",
+                "instance_type": config.instance_type,
+                "disk_size": "300GB",
+                "ports": VLLM_PORT,
+            }
+            if fallback_ami:
+                resources_config["image_id"] = fallback_ami
+            if use_efa:
+                resources_config["network_tier"] = "best"
     else:
         if requested_market is not None:
             raise RuntimeError(
                 f"No {requested_market} quota candidates for {config.instance_type}"
             )
+        fallback_ami = ami_for_region("us-east-1")
         resources_config = {
-            "infra": "aws",
+            "cloud": "aws",
+            "region": "us-east-1",
             "instance_type": config.instance_type,
             "disk_size": "300GB",
             "ports": VLLM_PORT,
         }
+        if fallback_ami:
+            resources_config["image_id"] = fallback_ami
         if use_efa:
             resources_config["network_tier"] = "best"
 
@@ -1453,6 +1529,10 @@ async def sp_launch_vllm_online(request: OnlineServingRequest, config: MagicOutp
     replace_run_dict = replace_run_vllm_online(request, config)
     run_string = update_template("templates/vllm_run_online", replace_run_dict)
 
+    # Online serving currently pins to us-east-1 (matches the template's
+    # `infra: aws/us-east-1`). Inject the DLAMI for that region so vLLM 0.19.1
+    # has the right CUDA driver.
+    online_ami = ami_for_region("us-east-1")
     replace_yaml = {
         "name": config.decision_id,
         "num_nodes": config.num_nodes,
@@ -1460,6 +1540,8 @@ async def sp_launch_vllm_online(request: OnlineServingRequest, config: MagicOutp
         "resources.ports": str(VLLM_PORT),
         "run": run_string,
     }
+    if online_ami:
+        replace_yaml["resources.image_id"] = online_ami
     update_yaml_file("templates/vllm_online.yaml", replace_yaml, YAML_OUTPUT)
     task = sky.Task.from_yaml(YAML_OUTPUT)
     result_id = sky.launch(

--- a/templates/vllm.yaml
+++ b/templates/vllm.yaml
@@ -10,7 +10,11 @@ resources:
 
 envs:
   HF_TOKEN: null  # Will be replaced at runtime
-  # VLLM_USE_V1: "0"  # Disabled — use V1 engine (default in vLLM 0.10.0)
+  # vLLM/transformers pin — set by orca_server.config (DEFAULT_VLLM_VERSION /
+  # DEFAULT_TRANSFORMERS_VERSION). Default 0.19.1 + 4.57.6; override via
+  # ORCA_VLLM_VERSION / ORCA_TRANSFORMERS_VERSION env on the control plane.
+  VLLM_VERSION: "0.19.1"
+  TRANSFORMERS_VERSION: "4.57.6"
   VLLM_USE_V1: "1"
   VLLM_NO_USAGE_STATS: "1"
   VLLM_LOG_STATS_INTERVAL: "1"  # 1-second Prometheus counter flush for live throughput
@@ -36,14 +40,16 @@ setup: |
   uv pip install "ray[default]>=2.48.0"
 
   # ========================================================================
-  # Install vLLM 0.10.0
+  # Install vLLM $VLLM_VERSION
   # ========================================================================
-  # Note: A100 has a dedicated per-config template with custom AMI
-  # This generic template is for L40S and other GPUs that work with vLLM 0.10.0
+  # Versions set via envs (VLLM_VERSION, TRANSFORMERS_VERSION). vLLM 0.19.1
+  # requires CUDA 13.0 / driver 580+, which is only on the DLAMI selected
+  # via launcher.py (image_id resolved from orca_server.config.GPU_AMI_MAP).
+  # The default SkyPilot AMI ships driver 535 / CUDA 12.2 → 0.19.1 fails.
   # ========================================================================
-  echo "=== Installing vLLM 0.10.0 ==="
-  uv pip install "transformers==4.57.6"  # transformers > 5.0.0 breaks vLLM 0.10.0
-  uv pip install "vllm==0.10.0" aiohttp pynvml
+  echo "=== Installing vLLM $VLLM_VERSION ==="
+  uv pip install "transformers==$TRANSFORMERS_VERSION"  # transformers > 5.0.0 breaks vLLM
+  uv pip install "vllm==$VLLM_VERSION" aiohttp pynvml
 
   # Verify PyTorch CUDA
   python3 -c "import torch; print('PyTorch:', torch.__version__, 'CUDA:', torch.version.cuda, 'Available:', torch.cuda.is_available())"

--- a/templates/vllm_chunked.yaml
+++ b/templates/vllm_chunked.yaml
@@ -10,6 +10,9 @@ resources:
 
 envs:
   HF_TOKEN: null
+  # vLLM/transformers pin — see orca_server/config.py (DEFAULT_VLLM_VERSION).
+  VLLM_VERSION: "0.19.1"
+  TRANSFORMERS_VERSION: "4.57.6"
   VLLM_USE_V1: "1"
   VLLM_NO_USAGE_STATS: "1"
   VLLM_LOG_STATS_INTERVAL: "1"
@@ -38,9 +41,9 @@ setup: |
 
   uv pip install "ray[default]>=2.48.0"
 
-  echo "=== Installing vLLM 0.10.0 ==="
-  uv pip install "transformers==4.57.6"  # transformers > 5.0.0 breaks vLLM 0.10.0
-  uv pip install "vllm==0.10.0" aiohttp pynvml
+  echo "=== Installing vLLM $VLLM_VERSION ==="
+  uv pip install "transformers==$TRANSFORMERS_VERSION"  # transformers > 5.0.0 breaks vLLM
+  uv pip install "vllm==$VLLM_VERSION" aiohttp pynvml
 
   python3 -c "import torch; print('PyTorch:', torch.__version__, 'CUDA:', torch.version.cuda, 'Available:', torch.cuda.is_available())"
 

--- a/templates/vllm_configs/vllm_A100.yaml
+++ b/templates/vllm_configs/vllm_A100.yaml
@@ -7,12 +7,15 @@ resources:
   accelerators: A100:8
   disk_size: 300GB
   ports: 8001
-  # Custom AMI with Driver 580.105.08 | CUDA 12.8 | PyTorch 2.7.1+cu128
-  image_id: ami-04f8546cd7cc1dcd9
-  region: us-east-1
+  # image_id and region are injected by launcher.py from
+  # orca_server.config.GPU_AMI_MAP (DLAMI with driver 580 / CUDA 13.0).
+  # If you need a custom AMI for this config, add it to GPU_AMI_MAP, not here.
 
 envs:
   HF_TOKEN: null
+  # vLLM/transformers pin — see orca_server/config.py (DEFAULT_VLLM_VERSION).
+  VLLM_VERSION: "{vllm_version}"
+  TRANSFORMERS_VERSION: "{transformers_version}"
   VLLM_USE_V1: "1"
   VLLM_NO_USAGE_STATS: "1"
   VLLM_LOG_STATS_INTERVAL: "1"
@@ -40,11 +43,12 @@ setup: |
   uv pip install "ray[default]>=2.48.0"
 
   # ========================================================================
-  # Custom AMI with driver 580 - vLLM 0.10.0 works perfectly
+  # vLLM 0.19.1 on DLAMI (driver 580 / CUDA 13.0) — multi-node PP validated.
+  # Versions controlled by orca_server/config.py (DEFAULT_VLLM_VERSION).
   # ========================================================================
-  echo "=== Installing vLLM 0.10.0 ==="
-  uv pip install "transformers==4.57.6"  # transformers > 5.0.0 breaks vLLM 0.10.0
-  uv pip install "vllm==0.10.0"
+  echo "=== Installing vLLM $VLLM_VERSION ==="
+  uv pip install "transformers==$TRANSFORMERS_VERSION"  # transformers > 5.0.0 breaks vLLM
+  uv pip install "vllm==$VLLM_VERSION"
 
   # Verify PyTorch CUDA
   python3 -c "import torch; print('PyTorch:', torch.__version__, 'CUDA:', torch.version.cuda, 'Available:', torch.cuda.is_available())"

--- a/templates/vllm_configs/vllm_qwen2.5-72b-A100-tp8-pp1.yaml
+++ b/templates/vllm_configs/vllm_qwen2.5-72b-A100-tp8-pp1.yaml
@@ -7,12 +7,14 @@ resources:
   accelerators: A100:8
   disk_size: 300GB
   ports: 8001
-  # Custom AMI with Driver 580.105.08 | CUDA 12.8 | PyTorch 2.7.1+cu128
-  image_id: ami-04f8546cd7cc1dcd9
-  region: us-east-1
+  # image_id and region are injected by launcher.py from
+  # orca_server.config.GPU_AMI_MAP (DLAMI with driver 580 / CUDA 13.0).
 
 envs:
   HF_TOKEN: null
+  # vLLM/transformers pin — see orca_server/config.py (DEFAULT_VLLM_VERSION).
+  VLLM_VERSION: "{vllm_version}"
+  TRANSFORMERS_VERSION: "{transformers_version}"
   VLLM_USE_V1: "1"
   VLLM_NO_USAGE_STATS: "1"
   VLLM_LOG_STATS_INTERVAL: "1"
@@ -40,11 +42,12 @@ setup: |
   uv pip install "ray[default]>=2.48.0"
 
   # ========================================================================
-  # Custom AMI with driver 580 - vLLM 0.10.0 works perfectly
+  # vLLM 0.19.1 on DLAMI (driver 580 / CUDA 13.0) — multi-node PP validated.
+  # Versions controlled by orca_server/config.py (DEFAULT_VLLM_VERSION).
   # ========================================================================
-  echo "=== Installing vLLM 0.10.0 ==="
-  uv pip install "transformers==4.57.6"  # transformers > 5.0.0 breaks vLLM 0.10.0
-  uv pip install "vllm==0.10.0"
+  echo "=== Installing vLLM $VLLM_VERSION ==="
+  uv pip install "transformers==$TRANSFORMERS_VERSION"  # transformers > 5.0.0 breaks vLLM
+  uv pip install "vllm==$VLLM_VERSION"
 
   # Verify PyTorch CUDA
   python3 -c "import torch; print('PyTorch:', torch.__version__, 'CUDA:', torch.version.cuda, 'Available:', torch.cuda.is_available())"

--- a/templates/vllm_configs/vllm_qwen2.5-72b-L40S-tp4-pp4.yaml
+++ b/templates/vllm_configs/vllm_qwen2.5-72b-L40S-tp4-pp4.yaml
@@ -10,6 +10,9 @@ resources:
 
 envs:
   HF_TOKEN: null
+  # vLLM/transformers pin — see orca_server/config.py (DEFAULT_VLLM_VERSION).
+  VLLM_VERSION: "{vllm_version}"
+  TRANSFORMERS_VERSION: "{transformers_version}"
   VLLM_USE_V1: "1"
   VLLM_NO_USAGE_STATS: "1"
   VLLM_LOG_STATS_INTERVAL: "1"
@@ -37,12 +40,12 @@ setup: |
   uv pip install "ray[default]>=2.48.0"
 
   # ========================================================================
-  # L40S has newer drivers (550+) that support CUDA 12.4
-  # Can use vLLM 0.10.0 with default PyTorch
+  # vLLM 0.19.1 on DLAMI (driver 580 / CUDA 13.0) — multi-node PP validated.
+  # Versions controlled by orca_server/config.py (DEFAULT_VLLM_VERSION).
   # ========================================================================
-  echo "=== Installing vLLM 0.10.0 ==="
-  uv pip install "transformers==4.57.6"  # transformers > 5.0.0 breaks vLLM 0.10.0
-  uv pip install "vllm==0.10.0"
+  echo "=== Installing vLLM $VLLM_VERSION ==="
+  uv pip install "transformers==$TRANSFORMERS_VERSION"  # transformers > 5.0.0 breaks vLLM
+  uv pip install "vllm==$VLLM_VERSION"
 
   # Apply vLLM 0.10.x patches
   SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")

--- a/templates/vllm_online.yaml
+++ b/templates/vllm_online.yaml
@@ -11,6 +11,9 @@ resources:
 
 envs:
   HF_TOKEN: null  # Will be replaced at runtime
+  # vLLM/transformers pin — see orca_server/config.py (DEFAULT_VLLM_VERSION).
+  VLLM_VERSION: "0.19.1"
+  TRANSFORMERS_VERSION: "4.57.6"
   VLLM_NO_USAGE_STATS: "1"
 
 file_mounts:
@@ -28,9 +31,10 @@ setup: |
   # Pre-install Ray to work around SkyPilot bug (ray[default]==added parse error)
   uv pip install "ray[default]>=2.48.0"
 
-  # Install vLLM (transformers > 5.0.0 breaks vLLM 0.10.0 dataclass configs)
-  uv pip install "transformers==4.57.6"
-  uv pip install "vllm==0.10.0"
+  # Install vLLM (transformers > 5.0.0 breaks vLLM dataclass configs)
+  echo "=== Installing vLLM $VLLM_VERSION ==="
+  uv pip install "transformers==$TRANSFORMERS_VERSION"
+  uv pip install "vllm==$VLLM_VERSION"
 
   # Fix vLLM DisabledTqdm bug: duplicate 'disable' kwarg with newer huggingface_hub
   # Patch the vLLM code directly to pop 'disable' from kwargs before passing to super().__init__


### PR DESCRIPTION
## Summary

- Pin production vLLM to **0.19.1** and centralize the version in `orca_server/config.py` (`DEFAULT_VLLM_VERSION`, env-overridable via `ORCA_VLLM_VERSION`).
- Add a `GPU_AMI_MAP` containing the validated DLAMI (Deep Learning Base OSS Nvidia Driver GPU AMI, Ubuntu 22.04, dated 2026-04-24 — driver 580 / CUDA 13.0) across 7 AWS regions, plus an `ami_for_region(region)` helper.
- Wire AMI lookup into all three launch paths (batch, chunked, online) so every region candidate gets the correct `image_id` and quota-aware multi-region failover still works.
- Convert all six vLLM template YAMLs to read the version from envs / placeholders, and remove the hardcoded `image_id: ami-04f8546cd7cc1dcd9` from the A100 templates (the launcher now resolves the AMI per region for every GPU family).
- Regions missing from `GPU_AMI_MAP` are skipped with a warning rather than silently failing on driver mismatch.

## Why

vLLM 0.10.0 (current pin) is two minor versions behind. Profiling on `profiling-vllm` confirmed:

| Config | Nodes | GPUs | 0.10.x | 0.19.1 (DLAMI) | 0.20.0 (DLAMI) |
|---|---|---|---|---|---|
| tp4, pp3 | 3 | 12 | OK | OK | engine init fails |
| tp4, pp4 | 4 | 16 | untested | OK | engine init fails |
| tp8, pp2 | 2 | 16 | untested | OK | engine init fails |
| single-node configs | 1 | 1-4 | OK | OK | OK |

vLLM 0.20.0 replaced `RayDistributedExecutor` with a new `RayExecutorV2` whose cross-node `wait_for_init` handshake regresses multi-node pipeline parallelism. 0.19.1 + DLAMI is the highest stable target.

0.19.1 needs CUDA 13.0 / driver 580, which the default SkyPilot AMI does not provide (it ships driver 535 / CUDA 12.2 and fails with `RuntimeError: NVIDIA driver too old`). The Deep Learning Base OSS Nvidia Driver GPU AMI gives us 580/13.0 across every region we list in `GPU_AMI_MAP`.

## Files

- `orca_server/config.py` (+62 / -2)
- `orca_server/job_templates.py` (+12 / -2)
- `orca_server/launcher.py` (+118 / -22)
- `templates/vllm.yaml`, `vllm_chunked.yaml`, `vllm_online.yaml` (+47 / -23): switch `vllm==X` and `transformers==X` to `\$VLLM_VERSION` / `\$TRANSFORMERS_VERSION` from envs, defaults baked in as `0.19.1` / `4.57.6`
- `templates/vllm_configs/vllm_A100.yaml`, `vllm_qwen2.5-72b-A100-tp8-pp1.yaml`, `vllm_qwen2.5-72b-L40S-tp4-pp4.yaml` (+22 / -22): use `{vllm_version}` / `{transformers_version}` placeholders, remove hardcoded image_id

Total: 9 files, +250 / -71.

## Test plan

- [x] `pytest tests/test_config.py` — 7/7 pass
- [x] Full `pytest tests/` — only pre-existing `test_placement_llm_solver` failure (`FileNotFoundError`, fails on `main` too)
- [x] `ruff format --check` clean on all modified Python files
- [x] All 6 YAMLs parse with `yaml.safe_load`
- [x] `from orca_server.config import DEFAULT_VLLM_VERSION, GPU_AMI_MAP, ami_for_region` works
- [x] Imports clean: `orca_server.launcher` and `orca_server.job_templates`
- [ ] Live launch validation: needs a follow-up real-cluster smoke (e.g., batched launch on g5.12xlarge in us-east-1) to confirm SkyPilot accepts the generated YAML and vLLM 0.19.1 boots end-to-end via the orca flow.

## Risks / operational notes

- **Region coverage is narrowed**: any region not in `GPU_AMI_MAP` is now dropped from `any_of`. Currently mapped: us-east-1, us-east-2, us-west-1, us-west-2, ap-northeast-2, eu-west-1, eu-central-1. If we operate in other regions (e.g., ap-southeast-1, sa-east-1, eu-north-1), add them to the map before merging — otherwise traffic fails over to fewer fallbacks than before.
- **DLAMI refresh cadence**: AWS publishes new DLAMI revisions ~monthly. Today we pin the 2026-04-24 build because that is the exact one tested. To refresh:
  `aws ec2 describe-images --owners amazon --filters "Name=name,Values=Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04) <YYYYMMDD>"` per region.
- **Per-config template image_id removed**: the two A100 templates previously locked launches to `us-east-1` via their own `image_id`. After this change, launcher-side AMI lookup means A100 launches now respect quota-aware ordered regions (and get the right DLAMI for whichever region wins). This may change which region absorbs A100 traffic in production.
- **Transformers stays pinned at 4.57.6** — vLLM still calls `all_special_tokens_extended` and we still ship `templates/vllm_compat_patch.py`. The two `sed` patches in setup blocks (`DisabledTqdm`, `weight_utils.py`) are vLLM-version-agnostic and continue to apply.
- Profiling artifacts under `profiling/` are not touched in this PR.