### PR TITLE
Orca: rank-native reconciliation, colocated job routers, and live telemetry

### DIFF
--- a/KOI_CHANGES.md
+++ b/KOI_CHANGES.md
@@ -8,7 +8,7 @@ field, or an integration Koi has not built yet.
 ## 1. Required: `instance_type` in every rank config
 
 Orca cannot invent placement. A ladder entry whose `config` lacks
-`instance_type` is **silently skipped** by `ladder_to_chains` (logged, not
+`instance_type` is **silently skipped** by `ladder_to_ranks` (logged, not
 fatal) — the rank simply never launches. Today the S4 prompt only *asks* the
 LLM for it and `validation/validator.py` does not check it.
 
@@ -40,7 +40,7 @@ place/swap without them fails to compile — the action is logged and skipped
 inside Koi at S6, and the **whole plan** fails to persist.
 
 **Ask (pick one):**
-- map `TERMINATE` → store `preempt` (Orca now implements preempt: chains torn
+- map `TERMINATE` → store `preempt` (Orca now implements preempt: ranks torn
   down, job → paused) and keep `DIAGNOSE` out of persisted plans, or
 - coordinate a store enum addition first (schema-owner decision).
 
@@ -48,41 +48,34 @@ inside Koi at S6, and the **whole plan** fails to persist.
 
 The executor persists only rank-level `mechanism_id`; the action-level one is
 dropped. Ranks that rely on inheriting the action's mechanism lose
-attribution in `chains.shape_json`.
+attribution in `ranks.shape_json`.
 
 **Ask:** stamp `mechanism_id` explicitly on every rank dict when building the
 ladder (the inheritance currently happens only in the EIG/switch-cost
 adapters, not in the persisted plan).
 
-## 5. Build: telemetry adapter over `GpuMetricStore`
+## 5. Telemetry adapter over `GpuMetricStore`
 
-`src/infra/telemetry.py` is a stub, so S7 evidence rows have no real data.
-The collector side is live: `gpu_metrics` gets one row per physical GPU per
-10s. Reading contract (clients in `tandemn_system_data`):
-
-- `GpuMetricStore.rows_for_rank(job_id, rank_id)` — the rank's rows
-  across its chains/GPUs. `rank_id` here **is** Koi's ladder `rank_id`
-  (`rank_0`, ...): Orca propagates it plan → chain shape → pod label →
-  telemetry, so it joins directly to `evidence_rows.rank_id`.
-- `rows_for_chain(chain_id)` — one DP replica. `chain_id` is the canonical
-  `chains.chain_id`.
-- `rows_in_window(job_id, start, end)` for trajectories.
+`src/infra/telemetry.py` reads one raw row per physical GPU and aggregates it
+to persistent `rank_<ULID>` evidence. The runtime identity is
+`(job_id, rank_id, chain_index)`, where `chain_index` is Grove's zero-based
+replica index. `rows_for_rank` and window reads expose the raw samples.
 
 Aggregation rules:
 - **Inference metrics** (`throughput_token_per_sec`, `p99_ttft_ms`,
   `cost_per_token`, ...) are chain-scoped and **repeat on every GPU row of a
-  TP>1 chain** — aggregate one value per distinct `chain_id`, never per row.
+  TP>1 replica** — aggregate one value per distinct `chain_index`, never per row.
 - **GPU hardware metrics** (`gpu_mem_used_fraction`, `sm_utilization`, ...)
   are genuinely per-row.
-- Rows with `chain_id IS NULL` are idle GPUs on tracked nodes (stranded
-  capacity) — they belong to no chain but count toward cluster utilization.
+- Rows with `chain_index IS NULL` are idle GPUs on tracked nodes (stranded
+  capacity) and still count toward cluster utilization.
 
 ## 6. Semantics: `n_replicas` is a ceiling, not a floor
 
 Orca compiles `n_replicas` into the Dynamo pool Planner's `max_gpu_budget`;
 the Planner scales DP width within `[1, n_replicas]` on its own SLA loop.
-Chain rows in the store are *authorized* capacity, not live pods — live width
-per rank = distinct `chain_id`s in recent `gpu_metrics`. If a plan ever means
+Rank rows store the authorized `n_replicas` ceiling, not live pods — live width
+is the distinct `chain_index` count in recent `gpu_metrics`. If a plan ever means
 "at least K replicas", say so — plumbing a `min_endpoint` through is a
 one-line Orca change once the contract carries it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 tandemn-orca = "tandemn_orca.orca:main"
 tandemn-gpu-metrics-collector = "tandemn_orca.scripts.gpu_metrics_collector:main"
 tandemn-submit-job = "tandemn_orca.scripts.submit_job:main"
+tandemn-endpoint = "tandemn_orca.scripts.endpoint:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/tandemn_orca/__init__.py
+++ b/src/tandemn_orca/__init__.py
@@ -1,7 +1,7 @@
 """tandemn_orca — the executor.
 
 Orca polls Koi's plans from the canonical store, applies the per-job
-actions (gang-launching chains, transitioning jobs), and records what
+actions (launching ranks, transitioning jobs), and records what
 happened. It is the only writer of the job/chain lifecycle; Koi reads.
 
 See tandemn-store DATA_ARCHITECTURE.md and docs/KOI_INTEGRATION.md for

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -27,7 +27,6 @@ PLANNER_IMAGE = "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1"
 # len(service name) <= 45 for pod naming; our longest service is
 # "VllmDecodeWorker" (16), so DGD names must stay within 29.
 MAX_DGD_NAME = 29
-ROUTER_TELEMETRY_SECRET = "tandemn-router-telemetry"
 
 
 def compile_job(job_id: str, ranks: list[Rank], namespace: str = "default") -> list[dict[str, Any]]:
@@ -36,13 +35,13 @@ def compile_job(job_id: str, ranks: list[Rank], namespace: str = "default") -> l
     return [render_rank_dgd(job_id, rank, namespace) for rank in ranks]
 
 
-def render_router_configmap(
+def render_router_config(
     job_id: str,
     ranks: list[Rank],
     max_num_seq_by_rank: dict[str, int],
-    namespace: str = "default",
+    ports_by_rank: dict[str, int],
 ) -> dict[str, Any]:
-    """Render the per-job router's global deployment registry."""
+    """Render the laptop router's per-job deployment registry."""
     plan_ids = {rank.plan_id for rank in ranks if rank.plan_id}
     if len(plan_ids) != 1 or len(ranks) == 0:
         raise ValueError("router config requires ranks from exactly one plan")
@@ -56,11 +55,14 @@ def render_router_configmap(
         max_num_seq = max_num_seq_by_rank.get(rank.rank_id)
         if not max_num_seq:
             raise ValueError(f"rank {rank.rank_id}: max_num_seq must be a positive int")
+        port = ports_by_rank.get(rank.rank_id)
+        if not port:
+            raise ValueError(f"rank {rank.rank_id}: local tunnel port is required")
         deployments.append(
             {
                 "id": pool_dgd_name(job_id, rank),
                 "rank_id": rank.rank_id,
-                "endpoint": frontend_service_endpoint(job_id, rank, namespace),
+                "endpoint": f"http://127.0.0.1:{port}",
                 "env": list(env),
                 "enabled": True,
                 "max_num_seq": max_num_seq,
@@ -69,129 +71,12 @@ def render_router_configmap(
         )
 
     plan_id = plan_ids.pop()
-    name = dgd_name(job_id, "router-config")
     return {
-        "apiVersion": "v1",
-        "kind": "ConfigMap",
-        "metadata": {
-            "name": name,
-            "namespace": namespace,
-            "labels": {
-                "tandemn.com/managed-by": "orca",
-                "tandemn.com/job-id": job_id,
-                "tandemn.com/plan-id": plan_id,
-                "tandemn.com/resource-kind": "router-config",
-            },
-        },
-        "data": {
-            "router.json": json.dumps(
-                {
-                    "version": plan_id,
-                    "job_id": job_id,
-                    "overflow_threshold": 0.8,
-                    "deployments": deployments,
-                },
-                separators=(",", ":"),
-            )
-        },
+        "version": plan_id,
+        "job_id": job_id,
+        "overflow_threshold": 0.8,
+        "deployments": deployments,
     }
-
-
-def router_configmap_name(job_id: str) -> str:
-    return dgd_name(job_id, "router-config")
-
-
-def render_router_objects(
-    job_id: str,
-    ranks: list[Rank],
-    max_num_seq_by_rank: dict[str, int],
-    image: str,
-    namespace: str = "default",
-) -> list[dict[str, Any]]:
-    """Render the ConfigMap, Deployment, and Service for one job router."""
-    if not image:
-        raise ValueError("router image is required")
-    name = router_name(job_id)
-    configmap = render_router_configmap(job_id, ranks, max_num_seq_by_rank, namespace)
-    resource_labels = {
-        "app.kubernetes.io/name": "tandemn-router",
-        "tandemn.com/managed-by": "orca",
-        "tandemn.com/job-id": job_id,
-    }
-    pod_labels = {**resource_labels, "tandemn.com/resource-kind": "router"}
-    return [
-        configmap,
-        {
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "metadata": {"name": name, "namespace": namespace, "labels": pod_labels},
-            "spec": {
-                "replicas": 1,
-                "selector": {"matchLabels": resource_labels},
-                "template": {
-                    "metadata": {"labels": pod_labels},
-                    "spec": {
-                        "containers": [
-                            {
-                                "name": "router",
-                                "image": image,
-                                "args": [
-                                    "-config",
-                                    "/config/router.json",
-                                    "-listen",
-                                    ":8080",
-                                ],
-                                "ports": [{"name": "http", "containerPort": 8080}],
-                                "env": [
-                                    {
-                                        "name": "TANDEMN_ROUTER_TELEMETRY_TOKEN",
-                                        "valueFrom": {
-                                            "secretKeyRef": {
-                                                "name": ROUTER_TELEMETRY_SECRET,
-                                                "key": "token",
-                                            }
-                                        },
-                                    }
-                                ],
-                                "volumeMounts": [
-                                    {"name": "config", "mountPath": "/config", "readOnly": True}
-                                ],
-                                "readinessProbe": {"httpGet": {"path": "/readyz", "port": "http"}},
-                                "livenessProbe": {"httpGet": {"path": "/healthz", "port": "http"}},
-                                "resources": {
-                                    "requests": {"cpu": "50m", "memory": "64Mi"},
-                                    "limits": {"memory": "128Mi"},
-                                },
-                            }
-                        ],
-                        "volumes": [
-                            {
-                                "name": "config",
-                                "configMap": {"name": router_configmap_name(job_id)},
-                            }
-                        ],
-                    },
-                },
-            },
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {"name": name, "namespace": namespace, "labels": pod_labels},
-            "spec": {
-                "selector": resource_labels,
-                "ports": [{"name": "http", "port": 80, "targetPort": "http"}],
-            },
-        },
-    ]
-
-
-def router_name(job_id: str) -> str:
-    return dgd_name(job_id, "router")
-
-
-def frontend_service_endpoint(job_id: str, rank: Rank, namespace: str) -> str:
-    return f"http://{pool_dgd_name(job_id, rank)}-frontend.{namespace}.svc.cluster.local:8000"
 
 
 def pool_key(rank: Rank) -> str:

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -27,6 +27,7 @@ PLANNER_IMAGE = "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1"
 # len(service name) <= 45 for pod naming; our longest service is
 # "VllmDecodeWorker" (16), so DGD names must stay within 29.
 MAX_DGD_NAME = 29
+ROUTER_TELEMETRY_SECRET = "tandemn-router-telemetry"
 
 
 def compile_job(job_id: str, ranks: list[Rank], namespace: str = "default") -> list[dict[str, Any]]:
@@ -61,6 +62,7 @@ def render_router_configmap(
         deployments.append(
             {
                 "id": pool_dgd_name(job_id, rank),
+                "rank_id": rank.rank_id,
                 "endpoint": endpoint,
                 "env": list(env),
                 "enabled": True,
@@ -143,10 +145,21 @@ def render_router_objects(
                                     ":8080",
                                 ],
                                 "ports": [{"name": "http", "containerPort": 8080}],
+                                "env": [
+                                    {
+                                        "name": "TANDEMN_ROUTER_TELEMETRY_TOKEN",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": ROUTER_TELEMETRY_SECRET,
+                                                "key": "token",
+                                            }
+                                        },
+                                    }
+                                ],
                                 "volumeMounts": [
                                     {"name": "config", "mountPath": "/config", "readOnly": True}
                                 ],
-                                "readinessProbe": {"httpGet": {"path": "/healthz", "port": "http"}},
+                                "readinessProbe": {"httpGet": {"path": "/readyz", "port": "http"}},
                                 "livenessProbe": {"httpGet": {"path": "/healthz", "port": "http"}},
                                 "resources": {
                                     "requests": {"cpu": "50m", "memory": "64Mi"},

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -36,7 +36,10 @@ def compile_job(job_id: str, ranks: list[Rank], namespace: str = "default") -> l
 
 
 def render_router_configmap(
-    job_id: str, ranks: list[Rank], namespace: str = "default"
+    job_id: str,
+    ranks: list[Rank],
+    max_num_seq_by_rank: dict[str, int],
+    namespace: str = "default",
 ) -> dict[str, Any]:
     """Render the per-job router's global deployment registry."""
     plan_ids = {rank.plan_id for rank in ranks if rank.plan_id}
@@ -52,16 +55,17 @@ def render_router_configmap(
         endpoint = shape.get("router_endpoint")
         if not isinstance(endpoint, str) or not endpoint:
             raise ValueError(f"rank {rank.rank_id}: router_endpoint is required")
-        maximum = shape.get("maximum_requests")
-        if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0:
-            raise ValueError(f"rank {rank.rank_id}: maximum_requests must be a positive int")
+        max_num_seq = max_num_seq_by_rank.get(rank.rank_id)
+        if not max_num_seq:
+            raise ValueError(f"rank {rank.rank_id}: max_num_seq must be a positive int")
         deployments.append(
             {
                 "id": pool_dgd_name(job_id, rank),
                 "endpoint": endpoint,
                 "env": list(env),
                 "enabled": True,
-                "maximum_requests": maximum,
+                "max_num_seq": max_num_seq,
+                "maximum_requests": rank.n_replicas * max_num_seq,
             }
         )
 
@@ -101,6 +105,7 @@ def router_configmap_name(job_id: str) -> str:
 def render_router_objects(
     job_id: str,
     ranks: list[Rank],
+    max_num_seq_by_rank: dict[str, int],
     image: str,
     namespace: str = "default",
 ) -> list[dict[str, Any]]:
@@ -108,7 +113,7 @@ def render_router_objects(
     if not image:
         raise ValueError("router image is required")
     name = router_name(job_id)
-    configmap = render_router_configmap(job_id, ranks, namespace)
+    configmap = render_router_configmap(job_id, ranks, max_num_seq_by_rank, namespace)
     resource_labels = {
         "app.kubernetes.io/name": "tandemn-router",
         "tandemn.com/managed-by": "orca",

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -28,6 +28,17 @@ PLANNER_IMAGE = "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1"
 # "VllmDecodeWorker" (16), so DGD names must stay within 29.
 MAX_DGD_NAME = 29
 
+# Per-job router listen ports live above the rank tunnel range
+# (launcher: 18000 + span 10000) so a router never collides with a tunnel.
+ROUTER_LISTEN_PORT_BASE = 28000
+ROUTER_LISTEN_PORT_SPAN = 1000
+
+
+def router_listen_port(job_id: str) -> int:
+    """Deterministic user-facing port for one job's router process."""
+    digest = hashlib.sha256(job_id.encode()).digest()
+    return ROUTER_LISTEN_PORT_BASE + int.from_bytes(digest[:4], "big") % ROUTER_LISTEN_PORT_SPAN
+
 
 def compile_job(job_id: str, ranks: list[Rank], namespace: str = "default") -> list[dict[str, Any]]:
     if len({rank.rank_id for rank in ranks}) != len(ranks):
@@ -74,6 +85,7 @@ def render_router_config(
     return {
         "version": plan_id,
         "job_id": job_id,
+        "listen_port": router_listen_port(job_id),
         "overflow_threshold": 0.8,
         "deployments": deployments,
     }

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -1,4 +1,4 @@
-"""Compile Orca Chain rows into Dynamo Kubernetes objects.
+"""Compile Orca Rank rows into Dynamo Kubernetes objects.
 
 No Kubernetes calls live here; this file only returns dicts ready for server-side apply.
 
@@ -17,7 +17,7 @@ import hashlib
 import json
 from typing import Any
 
-from tandemn_system_data.models.chain import Chain
+from tandemn_system_data.models.rank import Rank
 
 FRONTEND_IMAGE = "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1"
 RUNTIME_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1"
@@ -29,28 +29,156 @@ PLANNER_IMAGE = "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1"
 MAX_DGD_NAME = 29
 
 
-def compile_job(
-    job_id: str, chains: list[Chain], namespace: str = "default"
+def compile_job(job_id: str, ranks: list[Rank], namespace: str = "default") -> list[dict[str, Any]]:
+    if len({rank.rank_id for rank in ranks}) != len(ranks):
+        raise ValueError("duplicate rank_id")
+    return [render_rank_dgd(job_id, rank, namespace) for rank in ranks]
+
+
+def render_router_configmap(
+    job_id: str, ranks: list[Rank], namespace: str = "default"
+) -> dict[str, Any]:
+    """Render the per-job router's global deployment registry."""
+    plan_ids = {rank.plan_id for rank in ranks if rank.plan_id}
+    if len(plan_ids) != 1 or len(ranks) == 0:
+        raise ValueError("router config requires ranks from exactly one plan")
+
+    deployments = []
+    for rank in sorted(ranks, key=lambda item: item.rank_id):
+        shape = rank.shape_json
+        env = shape.get("env")
+        if not isinstance(env, (list, tuple)) or len(env) != 5 or not all(env):
+            raise ValueError(f"rank {rank.rank_id}: router config requires a five-part env")
+        endpoint = shape.get("router_endpoint")
+        if not isinstance(endpoint, str) or not endpoint:
+            raise ValueError(f"rank {rank.rank_id}: router_endpoint is required")
+        maximum = shape.get("maximum_requests")
+        if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0:
+            raise ValueError(f"rank {rank.rank_id}: maximum_requests must be a positive int")
+        deployments.append(
+            {
+                "id": pool_dgd_name(job_id, rank),
+                "endpoint": endpoint,
+                "env": list(env),
+                "enabled": True,
+                "maximum_requests": maximum,
+            }
+        )
+
+    plan_id = plan_ids.pop()
+    name = dgd_name(job_id, "router-config")
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": {
+                "tandemn.com/managed-by": "orca",
+                "tandemn.com/job-id": job_id,
+                "tandemn.com/plan-id": plan_id,
+                "tandemn.com/resource-kind": "router-config",
+            },
+        },
+        "data": {
+            "router.json": json.dumps(
+                {
+                    "version": plan_id,
+                    "job_id": job_id,
+                    "overflow_threshold": 0.8,
+                    "deployments": deployments,
+                },
+                separators=(",", ":"),
+            )
+        },
+    }
+
+
+def router_configmap_name(job_id: str) -> str:
+    return dgd_name(job_id, "router-config")
+
+
+def render_router_objects(
+    job_id: str,
+    ranks: list[Rank],
+    image: str,
+    namespace: str = "default",
 ) -> list[dict[str, Any]]:
-    groups = group_chains(chains)
-    if not groups:
-        return []
+    """Render the ConfigMap, Deployment, and Service for one job router."""
+    if not image:
+        raise ValueError("router image is required")
+    name = router_name(job_id)
+    configmap = render_router_configmap(job_id, ranks, namespace)
+    resource_labels = {
+        "app.kubernetes.io/name": "tandemn-router",
+        "tandemn.com/managed-by": "orca",
+        "tandemn.com/job-id": job_id,
+    }
+    pod_labels = {**resource_labels, "tandemn.com/resource-kind": "router"}
     return [
-        *(render_pool_dgd(job_id, key, group, namespace) for key, group in groups.items()),
+        configmap,
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": name, "namespace": namespace, "labels": pod_labels},
+            "spec": {
+                "replicas": 1,
+                "selector": {"matchLabels": resource_labels},
+                "template": {
+                    "metadata": {"labels": pod_labels},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "router",
+                                "image": image,
+                                "args": [
+                                    "-config",
+                                    "/config/router.json",
+                                    "-listen",
+                                    ":8080",
+                                ],
+                                "ports": [{"name": "http", "containerPort": 8080}],
+                                "volumeMounts": [
+                                    {"name": "config", "mountPath": "/config", "readOnly": True}
+                                ],
+                                "readinessProbe": {"httpGet": {"path": "/healthz", "port": "http"}},
+                                "livenessProbe": {"httpGet": {"path": "/healthz", "port": "http"}},
+                                "resources": {
+                                    "requests": {"cpu": "50m", "memory": "64Mi"},
+                                    "limits": {"memory": "128Mi"},
+                                },
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "config",
+                                "configMap": {"name": router_configmap_name(job_id)},
+                            }
+                        ],
+                    },
+                },
+            },
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": name, "namespace": namespace, "labels": pod_labels},
+            "spec": {
+                "selector": resource_labels,
+                "ports": [{"name": "http", "port": 80, "targetPort": "http"}],
+            },
+        },
     ]
 
 
-def group_chains(chains: list[Chain]) -> dict[str, list[Chain]]:
-    grouped: dict[str, list[Chain]] = {}
-    for chain in chains:
-        grouped.setdefault(pool_key(chain), []).append(chain)
-    return dict(grouped)
+def router_name(job_id: str) -> str:
+    return dgd_name(job_id, "router")
 
 
-def pool_key(chain: Chain) -> str:
-    shape = chain.shape_json
+def pool_key(rank: Rank) -> str:
+    shape = rank.shape_json
     return k8s_name(
-        f"{required(shape, 'rank_id')}-{required(shape, 'instance_type')}-{required(shape, 'gpu_type')}"
+        f"{rank.rank_id}-{required(shape, 'instance_type')}-{required(shape, 'gpu_type')}"
     )
 
 
@@ -75,9 +203,9 @@ def k8s_name(value: str) -> str:
     return "".join(ch for ch in value if ch.isalnum() or ch == "-")[:63].strip("-")
 
 
-def pool_dgd_name(job_id: str, key: str, chains: list[Chain]) -> str:
+def pool_dgd_name(job_id: str, rank: Rank) -> str:
     """Pool DGD name using the canonical rank ID."""
-    return dgd_name(job_id, required(chains[0].shape_json, "rank_id"))
+    return dgd_name(job_id, rank.rank_id)
 
 
 def labels(
@@ -118,19 +246,20 @@ def dynamo_namespace(namespace: str, name: str) -> str:
     return f"{namespace}-{name}"
 
 
-def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) -> dict[str, Any]:
-    name = pool_dgd_name(job_id, key, chains)
-    shape = chains[0].shape_json
-    rank_id = required(shape, "rank_id")
-    plan_id = chains[0].plan_id
-    # gpu_count is the chain's world size (tp * pp, ... total GPUs); split
+def render_rank_dgd(job_id: str, rank: Rank, namespace: str) -> dict[str, Any]:
+    key = pool_key(rank)
+    name = pool_dgd_name(job_id, rank)
+    shape = rank.shape_json
+    rank_id = rank.rank_id
+    plan_id = rank.plan_id
+    # gpu_count is one replica's world size (tp * pp, ... total GPUs); split
     # across node_count physical nodes for multinode TP/PP (default: one node,
     # gpus_per_node == gpu_count, byte-identical to the single-node DGD).
-    gpu_count = worker_gpu_count(chains)
-    node_count = chain_node_count(chains)
+    gpu_count = worker_gpu_count(rank)
+    node_count = rank_node_count(rank)
     if gpu_count % node_count != 0:
         raise ValueError(
-            f"chain {chains[0].chain_id}: count={gpu_count} does not divide "
+            f"rank {rank.rank_id}: count={gpu_count} does not divide "
             f"evenly across node_count={node_count}"
         )
     gpus_per_node = gpu_count // node_count
@@ -193,7 +322,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                         "requests": {"gpu": str(gpus_per_node)},
                         "limits": {"gpu": str(gpus_per_node)},
                     },
-                    # Only present for multinode chains; the operator rejects
+                    # Only present for multinode replicas; the operator rejects
                     # multinode without Grove/LWS installed and asks LWS/Grove
                     # to gang-schedule this many pods, one per node.
                     **({"multinode": {"nodeCount": node_count}} if node_count > 1 else {}),
@@ -218,7 +347,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                         "mainContainer": {
                             "image": PLANNER_IMAGE,
                             "command": ["python3", "-m", "dynamo.planner"],
-                            "args": ["--config", planner_config(chains)],
+                            "args": ["--config", planner_config(rank)],
                         }
                     },
                 },
@@ -287,7 +416,7 @@ def _vllm_dtype(shape: dict[str, Any]) -> str | None:
     return str(weight or activation) if weight or activation else None
 
 
-def planner_config(chains: list[Chain]) -> str:
+def planner_config(rank: Rank) -> str:
     """PlannerConfig for one pool's standalone (non-hierarchical) Planner.
 
     Field names/values match the documented PlannerConfig reference
@@ -303,7 +432,7 @@ def planner_config(chains: list[Chain]) -> str:
     fields, which the docs don't reconcile. Runtime-unverified which the
     installed Planner binary actually accepts.
     """
-    shape = chains[0].shape_json
+    shape = rank.shape_json
     config = {
         "mode": "agg",
         "backend": required(shape, "engine_name"),
@@ -315,7 +444,7 @@ def planner_config(chains: list[Chain]) -> str:
         "load_predictor": "prophet",
         "load_adjustment_interval_seconds": 5,
         "min_endpoint": 1,
-        "max_gpu_budget": max_gpu_budget(chains),
+        "max_gpu_budget": max_gpu_budget(rank),
         "ttft_ms": required_float(shape, "target_p99_ttft_ms"),
         "itl_ms": required_float(shape, "target_p99_tpot_ms"),
     }
@@ -328,29 +457,23 @@ def capacity_type_for(shape: dict[str, Any]) -> str:
     return {"reserved": "reserved", "on_demand": "on-demand"}.get(str(market), str(market))
 
 
-def worker_gpu_count(chains: list[Chain]) -> int:
-    count = chains[0].shape_json.get("count")
+def worker_gpu_count(rank: Rank) -> int:
+    count = rank.shape_json.get("count")
     if type(count) is not int or count <= 0:
-        raise ValueError(f"chain {chains[0].chain_id} missing positive int count")
+        raise ValueError(f"rank {rank.rank_id} missing positive int count")
     return count
 
 
-def chain_node_count(chains: list[Chain]) -> int:
-    """Physical nodes the chain's worker pod-group spans; 1 = single node."""
-    node_count = chains[0].shape_json.get("node_count", 1)
+def rank_node_count(rank: Rank) -> int:
+    """Physical nodes one replica's worker pod-group spans; 1 = single node."""
+    node_count = rank.shape_json.get("node_count", 1)
     if type(node_count) is not int or node_count < 1:
-        raise ValueError(f"chain {chains[0].chain_id} node_count must be a positive int")
+        raise ValueError(f"rank {rank.rank_id} node_count must be a positive int")
     return node_count
 
 
-def max_gpu_budget(chains: list[Chain]) -> int:
-    total = 0
-    for chain in chains:
-        count = chain.shape_json.get("count")
-        if type(count) is not int or count <= 0:
-            raise ValueError(f"chain {chain.chain_id} missing positive int count")
-        total += count
-    return total
+def max_gpu_budget(rank: Rank) -> int:
+    return worker_gpu_count(rank) * rank.n_replicas
 
 
 def required(shape: dict[str, Any], key: str) -> str:

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -53,9 +53,6 @@ def render_router_configmap(
         env = shape.get("env")
         if not isinstance(env, (list, tuple)) or len(env) != 5 or not all(env):
             raise ValueError(f"rank {rank.rank_id}: router config requires a five-part env")
-        endpoint = shape.get("router_endpoint")
-        if not isinstance(endpoint, str) or not endpoint:
-            raise ValueError(f"rank {rank.rank_id}: router_endpoint is required")
         max_num_seq = max_num_seq_by_rank.get(rank.rank_id)
         if not max_num_seq:
             raise ValueError(f"rank {rank.rank_id}: max_num_seq must be a positive int")
@@ -63,7 +60,7 @@ def render_router_configmap(
             {
                 "id": pool_dgd_name(job_id, rank),
                 "rank_id": rank.rank_id,
-                "endpoint": endpoint,
+                "endpoint": frontend_service_endpoint(job_id, rank, namespace),
                 "env": list(env),
                 "enabled": True,
                 "max_num_seq": max_num_seq,
@@ -191,6 +188,10 @@ def render_router_objects(
 
 def router_name(job_id: str) -> str:
     return dgd_name(job_id, "router")
+
+
+def frontend_service_endpoint(job_id: str, rank: Rank, namespace: str) -> str:
+    return f"http://{pool_dgd_name(job_id, rank)}-frontend.{namespace}.svc.cluster.local:8000"
 
 
 def pool_key(rank: Rank) -> str:

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -100,11 +100,15 @@ def labels(
     return result
 
 
-def pod_metadata(job_id: str, rank_id: str, *, worker: bool = False) -> dict[str, Any]:
+def pod_metadata(
+    job_id: str, rank_id: str, plan_id: str | None, *, worker: bool = False
+) -> dict[str, Any]:
     pod_labels = {
         "tandemn.com/job-id": job_id,
         "tandemn.com/rank-id": rank_id,
     }
+    if plan_id:
+        pod_labels["tandemn.com/plan-id"] = plan_id
     if worker:
         pod_labels["tandemn.com/pods-discovery"] = "dynamo-worker"
     return {"labels": pod_labels}
@@ -143,7 +147,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                 "Frontend": {
                     "componentType": "frontend",
                     "replicas": 1,
-                    "extraPodMetadata": pod_metadata(job_id, rank_id),
+                    "extraPodMetadata": pod_metadata(job_id, rank_id, plan_id),
                     "extraPodSpec": {
                         "mainContainer": {
                             "image": FRONTEND_IMAGE,
@@ -160,7 +164,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                 "LocalRouter": {
                     "componentType": "default",
                     "replicas": 1,
-                    "extraPodMetadata": pod_metadata(job_id, rank_id),
+                    "extraPodMetadata": pod_metadata(job_id, rank_id, plan_id),
                     "extraPodSpec": {
                         "mainContainer": {
                             "image": RUNTIME_IMAGE,
@@ -184,7 +188,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                     # would make every Orca re-apply fight the adapter (webhook
                     # rejection or a reset to the initial value).
                     "scalingAdapter": {"enabled": True},
-                    "extraPodMetadata": pod_metadata(job_id, rank_id, worker=True),
+                    "extraPodMetadata": pod_metadata(job_id, rank_id, plan_id, worker=True),
                     "resources": {
                         "requests": {"gpu": str(gpus_per_node)},
                         "limits": {"gpu": str(gpus_per_node)},
@@ -209,7 +213,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                 "Planner": {
                     "componentType": "planner",
                     "replicas": 1,
-                    "extraPodMetadata": pod_metadata(job_id, rank_id),
+                    "extraPodMetadata": pod_metadata(job_id, rank_id, plan_id),
                     "extraPodSpec": {
                         "mainContainer": {
                             "image": PLANNER_IMAGE,

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -49,15 +49,8 @@ def group_chains(chains: list[Chain]) -> dict[str, list[Chain]]:
 
 def pool_key(chain: Chain) -> str:
     shape = chain.shape_json
-    # rank_id (Koi's ladder rank id, e.g. "rank_0") pools per rung so the
-    # rung's pods can carry one tandemn.ai/rank-id label; without it,
-    # same-shape rungs merge and rank identity is not attributable.
-    if shape.get("rank_id"):
-        return k8s_name(
-            f"{shape['rank_id']}-{required(shape, 'instance_type')}-{required(shape, 'gpu_type')}"
-        )
     return k8s_name(
-        f"{chain.role}-{required(shape, 'instance_type')}-{required(shape, 'gpu_type')}"
+        f"{required(shape, 'rank_id')}-{required(shape, 'instance_type')}-{required(shape, 'gpu_type')}"
     )
 
 
@@ -66,7 +59,7 @@ def dgd_name(job_id: str, suffix: str) -> str:
 
     The job tag is the ULID tail, not the full job id (a full
     ``job-01kwwez...`` already busts the operator's 45-char pod-naming
-    budget); the full job_id lives in the tandemn.ai/job-id label. A suffix
+    budget); the full job_id lives in the tandemn.com/job-id label. A suffix
     that would not fit is replaced by an 8-char hash of itself.
     """
     tag = k8s_name(job_id).removeprefix("job-")[-10:].strip("-")
@@ -83,26 +76,38 @@ def k8s_name(value: str) -> str:
 
 
 def pool_dgd_name(job_id: str, key: str, chains: list[Chain]) -> str:
-    """Pool DGD name, preferring the short rank_id over the descriptive key."""
-    return dgd_name(job_id, str(chains[0].shape_json.get("rank_id") or key))
+    """Pool DGD name using the canonical rank ID."""
+    return dgd_name(job_id, required(chains[0].shape_json, "rank_id"))
 
 
 def labels(
     job_id: str,
+    rank_id: str,
     plan_id: str | None,
     resource_kind: str,
     pool: str | None = None,
 ) -> dict[str, str]:
     result = {
-        "tandemn.ai/managed-by": "orca",
-        "tandemn.ai/job-id": job_id,
-        "tandemn.ai/resource-kind": resource_kind,
+        "tandemn.com/managed-by": "orca",
+        "tandemn.com/job-id": job_id,
+        "tandemn.com/rank-id": rank_id,
+        "tandemn.com/resource-kind": resource_kind,
     }
     if plan_id:
-        result["tandemn.ai/plan-id"] = plan_id
+        result["tandemn.com/plan-id"] = plan_id
     if pool:
-        result["tandemn.ai/pool-key"] = pool
+        result["tandemn.com/pool-key"] = pool
     return result
+
+
+def pod_metadata(job_id: str, rank_id: str, *, worker: bool = False) -> dict[str, Any]:
+    pod_labels = {
+        "tandemn.com/job-id": job_id,
+        "tandemn.com/rank-id": rank_id,
+    }
+    if worker:
+        pod_labels["tandemn.com/pods-discovery"] = "dynamo-worker"
+    return {"labels": pod_labels}
 
 
 def dynamo_namespace(namespace: str, name: str) -> str:
@@ -112,6 +117,7 @@ def dynamo_namespace(namespace: str, name: str) -> str:
 def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) -> dict[str, Any]:
     name = pool_dgd_name(job_id, key, chains)
     shape = chains[0].shape_json
+    rank_id = required(shape, "rank_id")
     plan_id = chains[0].plan_id
     # gpu_count is the chain's world size (tp * pp, ... total GPUs); split
     # across node_count physical nodes for multinode TP/PP (default: one node,
@@ -127,13 +133,17 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
     return {
         "apiVersion": "nvidia.com/v1alpha1",
         "kind": "DynamoGraphDeployment",
-        "metadata": {"name": name, "labels": labels(job_id, plan_id, "pool", key)},
+        "metadata": {
+            "name": name,
+            "labels": labels(job_id, rank_id, plan_id, "pool", key),
+        },
         "spec": {
             "backendFramework": required(shape, "engine_name"),
             "services": {
                 "Frontend": {
                     "componentType": "frontend",
                     "replicas": 1,
+                    "extraPodMetadata": pod_metadata(job_id, rank_id),
                     "extraPodSpec": {
                         "mainContainer": {
                             "image": FRONTEND_IMAGE,
@@ -150,6 +160,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                 "LocalRouter": {
                     "componentType": "default",
                     "replicas": 1,
+                    "extraPodMetadata": pod_metadata(job_id, rank_id),
                     "extraPodSpec": {
                         "mainContainer": {
                             "image": RUNTIME_IMAGE,
@@ -173,19 +184,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                     # would make every Orca re-apply fight the adapter (webhook
                     # rejection or a reset to the initial value).
                     "scalingAdapter": {"enabled": True},
-                    # The gpu-metrics collector lifts these pod labels: job-id
-                    # keys the pod to its job's chain rows, rank-id groups the
-                    # rung's chains/GPUs under one rank in gpu_metrics.
-                    "extraPodMetadata": {
-                        "labels": {
-                            "tandemn.ai/job-id": job_id,
-                            **(
-                                {"tandemn.ai/rank-id": str(shape["rank_id"])}
-                                if shape.get("rank_id")
-                                else {}
-                            ),
-                        }
-                    },
+                    "extraPodMetadata": pod_metadata(job_id, rank_id, worker=True),
                     "resources": {
                         "requests": {"gpu": str(gpus_per_node)},
                         "limits": {"gpu": str(gpus_per_node)},
@@ -210,6 +209,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                 "Planner": {
                     "componentType": "planner",
                     "replicas": 1,
+                    "extraPodMetadata": pod_metadata(job_id, rank_id),
                     "extraPodSpec": {
                         "mainContainer": {
                             "image": PLANNER_IMAGE,
@@ -218,7 +218,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
                         }
                     },
                 },
-            }
+            },
         },
     }
 
@@ -226,7 +226,7 @@ def render_pool_dgd(job_id: str, key: str, chains: list[Chain], namespace: str) 
 def node_selector(shape: dict[str, Any]) -> dict[str, str]:
     capacity_type = capacity_type_for(shape)
     selector = {
-        # "tandemn.ai/launch-class": "tdm-gpu-cr" if capacity_type == "reserved" else "tdm-gpu-flex",
+        # "tandemn.com/launch-class": "tdm-gpu-cr" if capacity_type == "reserved" else "tdm-gpu-flex",
         "node.kubernetes.io/instance-type": required(shape, "instance_type"),
     }
     if capacity_type == "reserved":

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -78,6 +78,11 @@ def render_router_config(
                 "enabled": True,
                 "max_num_seq": max_num_seq,
                 "maximum_requests": rank.n_replicas * max_num_seq,
+                # Replica ceiling for the overflow gate: above the KV
+                # threshold the router sheds new sessions only once
+                # ready_replicas reaches this, leaving earlier pressure to
+                # local Dynamo autoscaling.
+                "max_replicas": rank.n_replicas,
             }
         )
 

--- a/src/tandemn_orca/dynamo_kubernetes.py
+++ b/src/tandemn_orca/dynamo_kubernetes.py
@@ -17,7 +17,19 @@ VERSION = "v1alpha1"
 DGD_PLURAL = "dynamographdeployments"
 
 
-def load_kube_client(namespace: str = "default") -> DynamoKubernetesClient:
+def load_kube_client(
+    namespace: str = "default",
+    kubeconfig: str | None = None,
+    context: str | None = None,
+) -> DynamoKubernetesClient:
+    if kubeconfig is not None or context is not None:
+        api_client = config.new_client_from_config(config_file=kubeconfig, context=context)
+        return DynamoKubernetesClient(
+            namespace,
+            core=client.CoreV1Api(api_client),
+            custom=client.CustomObjectsApi(api_client),
+            apps=client.AppsV1Api(api_client),
+        )
     try:
         config.load_incluster_config()
     except ConfigException:
@@ -34,10 +46,17 @@ def job_selector(job_id: str) -> str:
 
 
 class DynamoKubernetesClient:
-    def __init__(self, namespace: str = "default", core: Any = None, custom: Any = None) -> None:
+    def __init__(
+        self,
+        namespace: str = "default",
+        core: Any = None,
+        custom: Any = None,
+        apps: Any = None,
+    ) -> None:
         self.namespace = namespace
         self.core = core or client.CoreV1Api()
         self.custom = custom or client.CustomObjectsApi()
+        self.apps = apps or client.AppsV1Api()
 
     def list_job_objects(self, job_id: str) -> set[ObjectKey]:
         selector = job_selector(job_id)
@@ -61,6 +80,26 @@ class DynamoKubernetesClient:
         kind, name = object_key(obj)
         if kind == "ConfigMap":
             self.core.patch_namespaced_config_map(
+                name,
+                self.namespace,
+                obj,
+                field_manager=FIELD_MANAGER,
+                force=True,
+                _content_type=APPLY,
+            )
+            return
+        if kind == "Deployment":
+            self.apps.patch_namespaced_deployment(
+                name,
+                self.namespace,
+                obj,
+                field_manager=FIELD_MANAGER,
+                force=True,
+                _content_type=APPLY,
+            )
+            return
+        if kind == "Service":
+            self.core.patch_namespaced_service(
                 name,
                 self.namespace,
                 obj,
@@ -95,6 +134,12 @@ class DynamoKubernetesClient:
         try:
             if kind == "ConfigMap":
                 self.core.delete_namespaced_config_map(name, self.namespace)
+                return
+            if kind == "Deployment":
+                self.apps.delete_namespaced_deployment(name, self.namespace)
+                return
+            if kind == "Service":
+                self.core.delete_namespaced_service(name, self.namespace)
                 return
             if kind == "DynamoGraphDeployment":
                 self.custom.delete_namespaced_custom_object(

--- a/src/tandemn_orca/dynamo_kubernetes.py
+++ b/src/tandemn_orca/dynamo_kubernetes.py
@@ -30,7 +30,7 @@ def object_key(obj: dict[str, Any]) -> ObjectKey:
 
 
 def job_selector(job_id: str) -> str:
-    return f"tandemn.ai/managed-by=orca,tandemn.ai/job-id={job_id}"
+    return f"tandemn.com/managed-by=orca,tandemn.com/job-id={job_id}"
 
 
 class DynamoKubernetesClient:

--- a/src/tandemn_orca/dynamo_kubernetes.py
+++ b/src/tandemn_orca/dynamo_kubernetes.py
@@ -63,11 +63,17 @@ class DynamoKubernetesClient:
         configmaps = self.core.list_namespaced_config_map(
             self.namespace, label_selector=selector
         ).items
+        services = self.core.list_namespaced_service(self.namespace, label_selector=selector).items
+        deployments = self.apps.list_namespaced_deployment(
+            self.namespace, label_selector=selector
+        ).items
         dgds = self.custom.list_namespaced_custom_object(
             GROUP, VERSION, self.namespace, DGD_PLURAL, label_selector=selector
         ).get("items", [])
         return {
             *(("ConfigMap", item.metadata.name) for item in configmaps),
+            *(("Service", item.metadata.name) for item in services),
+            *(("Deployment", item.metadata.name) for item in deployments),
             *(("DynamoGraphDeployment", item["metadata"]["name"]) for item in dgds),
         }
 

--- a/src/tandemn_orca/dynamo_kubernetes.py
+++ b/src/tandemn_orca/dynamo_kubernetes.py
@@ -26,9 +26,7 @@ def load_kube_client(
         api_client = config.new_client_from_config(config_file=kubeconfig, context=context)
         return DynamoKubernetesClient(
             namespace,
-            core=client.CoreV1Api(api_client),
             custom=client.CustomObjectsApi(api_client),
-            apps=client.AppsV1Api(api_client),
         )
     try:
         config.load_incluster_config()
@@ -49,31 +47,17 @@ class DynamoKubernetesClient:
     def __init__(
         self,
         namespace: str = "default",
-        core: Any = None,
         custom: Any = None,
-        apps: Any = None,
     ) -> None:
         self.namespace = namespace
-        self.core = core or client.CoreV1Api()
         self.custom = custom or client.CustomObjectsApi()
-        self.apps = apps or client.AppsV1Api()
 
     def list_job_objects(self, job_id: str) -> set[ObjectKey]:
         selector = job_selector(job_id)
-        configmaps = self.core.list_namespaced_config_map(
-            self.namespace, label_selector=selector
-        ).items
-        services = self.core.list_namespaced_service(self.namespace, label_selector=selector).items
-        deployments = self.apps.list_namespaced_deployment(
-            self.namespace, label_selector=selector
-        ).items
         dgds = self.custom.list_namespaced_custom_object(
             GROUP, VERSION, self.namespace, DGD_PLURAL, label_selector=selector
         ).get("items", [])
         return {
-            *(("ConfigMap", item.metadata.name) for item in configmaps),
-            *(("Service", item.metadata.name) for item in services),
-            *(("Deployment", item.metadata.name) for item in deployments),
             *(("DynamoGraphDeployment", item["metadata"]["name"]) for item in dgds),
         }
 
@@ -84,36 +68,6 @@ class DynamoKubernetesClient:
 
     def apply(self, obj: dict[str, Any]) -> None:
         kind, name = object_key(obj)
-        if kind == "ConfigMap":
-            self.core.patch_namespaced_config_map(
-                name,
-                self.namespace,
-                obj,
-                field_manager=FIELD_MANAGER,
-                force=True,
-                _content_type=APPLY,
-            )
-            return
-        if kind == "Deployment":
-            self.apps.patch_namespaced_deployment(
-                name,
-                self.namespace,
-                obj,
-                field_manager=FIELD_MANAGER,
-                force=True,
-                _content_type=APPLY,
-            )
-            return
-        if kind == "Service":
-            self.core.patch_namespaced_service(
-                name,
-                self.namespace,
-                obj,
-                field_manager=FIELD_MANAGER,
-                force=True,
-                _content_type=APPLY,
-            )
-            return
         if kind == "DynamoGraphDeployment":
             self.custom.patch_namespaced_custom_object(
                 GROUP,
@@ -138,15 +92,6 @@ class DynamoKubernetesClient:
 
     def delete(self, kind: str, name: str) -> None:
         try:
-            if kind == "ConfigMap":
-                self.core.delete_namespaced_config_map(name, self.namespace)
-                return
-            if kind == "Deployment":
-                self.apps.delete_namespaced_deployment(name, self.namespace)
-                return
-            if kind == "Service":
-                self.core.delete_namespaced_service(name, self.namespace)
-                return
             if kind == "DynamoGraphDeployment":
                 self.custom.delete_namespaced_custom_object(
                     GROUP, VERSION, self.namespace, DGD_PLURAL, name

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -11,8 +11,12 @@ infrastructure.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import os
 from collections.abc import Callable
+from pathlib import Path
 from typing import Protocol
 
 from tandemn_system_data.clients import ModelCatalogStore
@@ -20,7 +24,8 @@ from tandemn_system_data.models.rank import Rank
 
 from tandemn_orca.dynamo_compiler import (
     compile_job,
-    render_router_objects,
+    pool_dgd_name,
+    render_router_config,
 )
 from tandemn_orca.dynamo_kubernetes import (
     DynamoKubernetesClient,
@@ -90,36 +95,47 @@ class DynamoLauncher:
         self,
         namespace: str = "default",
         k8s: DynamoKubernetesClient | None = None,
-        router_image: str | None = None,
+        router_config_dir: str | None = None,
+        router_port_base: int = 18000,
+        router_port_span: int = 10000,
         model_catalogs: ModelCatalogStore | None = None,
     ) -> None:
         self.namespace = namespace
         self.k8s = k8s or load_kube_client(namespace)
-        self.router_image = router_image
+        self.router_config_dir = Path(router_config_dir) if router_config_dir else None
+        self.router_port_base = router_port_base
+        self.router_port_span = router_port_span
         self.model_catalogs = model_catalogs
 
     def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
         desired = compile_job(job_id, ranks, self.namespace)
-        if self.router_image:
+        router_config = None
+        ports: dict[str, int] = {}
+        if self.router_config_dir is not None:
             max_num_seq = _max_num_seq_by_rank(ranks, self.model_catalogs)
-            desired.extend(
-                render_router_objects(
-                    job_id,
-                    ranks,
-                    max_num_seq,
-                    self.router_image,
-                    self.namespace,
-                )
-            )
+            ports = _ports_by_rank(ranks, self.router_port_base, self.router_port_span)
+            router_config = render_router_config(job_id, ranks, max_num_seq, ports)
         desired_keys = {object_key(obj) for obj in desired}
         stale = self.k8s.list_job_objects(job_id) - desired_keys
         apply_error = _call(self.k8s.apply_many, desired)
         if apply_error:
             raise ReconcileError(apply_error, None)
         self._delete_stale(stale)
+        if router_config is not None:
+            assert self.router_config_dir is not None
+            _write_router_config(self.router_config_dir, job_id, router_config)
+            for rank in ranks:
+                logger.info(
+                    "router tunnel: kubectl --namespace %s port-forward service/%s-frontend %s:8000",
+                    self.namespace,
+                    pool_dgd_name(job_id, rank),
+                    ports[rank.rank_id],
+                )
 
     def teardown_job(self, job_id: str) -> None:
         self.k8s.delete_all_for_job(job_id)
+        if self.router_config_dir is not None:
+            self.router_config_dir.joinpath(f"{job_id}.json").unlink(missing_ok=True)
 
     def _delete_stale(self, stale: set[ObjectKey]) -> None:
         delete_error = _call(self.k8s.delete_many, stale)
@@ -139,7 +155,7 @@ def _max_num_seq_by_rank(
     ranks: list[Rank], model_catalogs: ModelCatalogStore | None
 ) -> dict[str, int]:
     if model_catalogs is None:
-        raise ModelCatalogError("router publishing requires a ModelCatalogStore")
+        raise ModelCatalogError("local router config requires a ModelCatalogStore")
     values: dict[str, int] = {}
     for rank in ranks:
         model_id = rank.shape_json.get("model_id")
@@ -169,3 +185,32 @@ def _max_num_seq_by_rank(
             )
         values[rank.rank_id] = value
     return values
+
+
+def _ports_by_rank(ranks: list[Rank], base: int, span: int) -> dict[str, int]:
+    if base < 1 or span < 1 or base + span > 65536:
+        raise ValueError("router port range must fit within 1..65535")
+    ports: dict[str, int] = {}
+    used: dict[int, str] = {}
+    for rank in ranks:
+        digest = hashlib.sha256(rank.rank_id.encode()).digest()
+        port = base + int.from_bytes(digest[:4], "big") % span
+        if port in used and used[port] != rank.rank_id:
+            raise ValueError(
+                f"router port collision between ranks {used[port]!r} and {rank.rank_id!r}"
+            )
+        ports[rank.rank_id] = port
+        used[port] = rank.rank_id
+    return ports
+
+
+def _write_router_config(directory: Path, job_id: str, config: dict) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{job_id}.json"
+    temporary = directory / f".{job_id}.json.tmp"
+    with temporary.open("w") as file:
+        json.dump(config, file, indent=2)
+        file.write("\n")
+        file.flush()
+        os.fsync(file.fileno())
+    os.replace(temporary, path)

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -33,6 +33,7 @@ from tandemn_orca.dynamo_kubernetes import (
     load_kube_client,
     object_key,
 )
+from tandemn_orca.tunnels import PortForwardManager, TunnelSpec
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,7 @@ class MultiClusterLauncher:
         router_port_span: int = 10000,
         model_catalogs: ModelCatalogStore | None = None,
         default_cluster: str | None = None,
+        tunnels: PortForwardManager | None = None,
     ) -> None:
         if not launchers:
             raise ValueError("at least one cluster launcher is required")
@@ -140,6 +142,7 @@ class MultiClusterLauncher:
         self.router_port_span = router_port_span
         self.model_catalogs = model_catalogs
         self.default_cluster = default_cluster
+        self.tunnels = tunnels
 
     def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
         groups: dict[str, list[Rank]] = {key: [] for key in self.launchers}
@@ -161,6 +164,22 @@ class MultiClusterLauncher:
 
         if router_config is not None:
             assert self.router_config_dir is not None
+            if self.tunnels is not None:
+                self.tunnels.reconcile(
+                    job_id,
+                    [
+                        TunnelSpec(
+                            job_id=job_id,
+                            rank_id=rank.rank_id,
+                            context=self.launchers[key].context,
+                            namespace=self.launchers[key].namespace,
+                            service=f"{pool_dgd_name(job_id, rank)}-frontend",
+                            local_port=ports[rank.rank_id],
+                        )
+                        for key, grouped_ranks in groups.items()
+                        for rank in grouped_ranks
+                    ],
+                )
             _write_router_config(self.router_config_dir, job_id, router_config)
             for key, grouped_ranks in groups.items():
                 for rank in grouped_ranks:
@@ -176,6 +195,8 @@ class MultiClusterLauncher:
     def teardown_job(self, job_id: str) -> None:
         for launcher in self.launchers.values():
             launcher.teardown_job(job_id)
+        if self.tunnels is not None:
+            self.tunnels.reconcile(job_id, [])
         if self.router_config_dir is not None:
             self.router_config_dir.joinpath(f"{job_id}.json").unlink(missing_ok=True)
 

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -21,8 +21,6 @@ from tandemn_system_data.models.rank import Rank
 from tandemn_orca.dynamo_compiler import (
     compile_job,
     render_router_objects,
-    router_configmap_name,
-    router_name,
 )
 from tandemn_orca.dynamo_kubernetes import (
     DynamoKubernetesClient,
@@ -92,50 +90,36 @@ class DynamoLauncher:
         self,
         namespace: str = "default",
         k8s: DynamoKubernetesClient | None = None,
-        router_k8s: DynamoKubernetesClient | None = None,
         router_image: str | None = None,
         model_catalogs: ModelCatalogStore | None = None,
     ) -> None:
         self.namespace = namespace
         self.k8s = k8s or load_kube_client(namespace)
-        self.router_k8s = router_k8s
         self.router_image = router_image
         self.model_catalogs = model_catalogs
 
     def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
         desired = compile_job(job_id, ranks, self.namespace)
-        router_objects = None
-        if self.router_k8s is not None:
+        if self.router_image:
             max_num_seq = _max_num_seq_by_rank(ranks, self.model_catalogs)
-            router_objects = render_router_objects(
-                job_id,
-                ranks,
-                max_num_seq,
-                self.router_image or "",
-                self.router_k8s.namespace,
+            desired.extend(
+                render_router_objects(
+                    job_id,
+                    ranks,
+                    max_num_seq,
+                    self.router_image,
+                    self.namespace,
+                )
             )
         desired_keys = {object_key(obj) for obj in desired}
         stale = self.k8s.list_job_objects(job_id) - desired_keys
         apply_error = _call(self.k8s.apply_many, desired)
         if apply_error:
             raise ReconcileError(apply_error, None)
-        if self.router_k8s is not None and router_objects is not None:
-            apply_error = _call(self.router_k8s.apply_many, router_objects)
-            if apply_error:
-                raise ReconcileError(apply_error, None)
         self._delete_stale(stale)
 
     def teardown_job(self, job_id: str) -> None:
         self.k8s.delete_all_for_job(job_id)
-        if self.router_k8s is not None:
-            name = router_name(job_id)
-            self.router_k8s.delete_many(
-                {
-                    ("ConfigMap", router_configmap_name(job_id)),
-                    ("Deployment", name),
-                    ("Service", name),
-                }
-            )
 
     def _delete_stale(self, stale: set[ObjectKey]) -> None:
         delete_error = _call(self.k8s.delete_many, stale)

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -15,6 +15,7 @@ import logging
 from collections.abc import Callable
 from typing import Protocol
 
+from tandemn_system_data.clients import ModelCatalogStore
 from tandemn_system_data.models.rank import Rank
 
 from tandemn_orca.dynamo_compiler import (
@@ -61,6 +62,10 @@ class ReconcileError(RuntimeError):
         super().__init__("; ".join(parts))
 
 
+class ModelCatalogError(ValueError):
+    """A router capacity value is missing or invalid for a selected rank."""
+
+
 class NoopLauncher:
     """Records intent only — no infrastructure is touched.
 
@@ -89,26 +94,32 @@ class DynamoLauncher:
         k8s: DynamoKubernetesClient | None = None,
         router_k8s: DynamoKubernetesClient | None = None,
         router_image: str | None = None,
+        model_catalogs: ModelCatalogStore | None = None,
     ) -> None:
         self.namespace = namespace
         self.k8s = k8s or load_kube_client(namespace)
         self.router_k8s = router_k8s
         self.router_image = router_image
+        self.model_catalogs = model_catalogs
 
     def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
         desired = compile_job(job_id, ranks, self.namespace)
+        router_objects = None
+        if self.router_k8s is not None:
+            max_num_seq = _max_num_seq_by_rank(ranks, self.model_catalogs)
+            router_objects = render_router_objects(
+                job_id,
+                ranks,
+                max_num_seq,
+                self.router_image or "",
+                self.router_k8s.namespace,
+            )
         desired_keys = {object_key(obj) for obj in desired}
         stale = self.k8s.list_job_objects(job_id) - desired_keys
         apply_error = _call(self.k8s.apply_many, desired)
         if apply_error:
             raise ReconcileError(apply_error, None)
-        if self.router_k8s is not None:
-            router_objects = render_router_objects(
-                job_id,
-                ranks,
-                self.router_image or "",
-                self.router_k8s.namespace,
-            )
+        if self.router_k8s is not None and router_objects is not None:
             apply_error = _call(self.router_k8s.apply_many, router_objects)
             if apply_error:
                 raise ReconcileError(apply_error, None)
@@ -138,3 +149,39 @@ def _call[T](fn: Callable[[T], object], arg: T) -> BaseException | None:
     except BaseException as exc:
         return exc
     return None
+
+
+def _max_num_seq_by_rank(
+    ranks: list[Rank], model_catalogs: ModelCatalogStore | None
+) -> dict[str, int]:
+    if model_catalogs is None:
+        raise ModelCatalogError("router publishing requires a ModelCatalogStore")
+    values: dict[str, int] = {}
+    for rank in ranks:
+        model_id = rank.shape_json.get("model_id")
+        gpu_type = rank.shape_json.get("gpu_type")
+        if not model_id or not gpu_type:
+            raise ModelCatalogError(
+                f"rank {rank.rank_id} is missing model_id or gpu_type for ModelCatalog lookup"
+            )
+        catalog = model_catalogs.get(str(model_id))
+        if catalog is None:
+            raise ModelCatalogError(f"ModelCatalog {model_id!r} is missing")
+        matches = [
+            entry
+            for entry in catalog.max_num_seq
+            if isinstance(entry, dict) and str(entry.get("gpu_type")) == str(gpu_type)
+        ]
+        if len(matches) != 1:
+            raise ModelCatalogError(
+                f"ModelCatalog {model_id!r} field 'max_num_seq' must contain exactly one "
+                f"entry for gpu_type {gpu_type!r}"
+            )
+        value = matches[0].get("value")
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ModelCatalogError(
+                f"ModelCatalog {model_id!r} field 'max_num_seq' for gpu_type "
+                f"{gpu_type!r} must be a positive integer"
+            )
+        values[rank.rank_id] = value
+    return values

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -33,7 +33,7 @@ from tandemn_orca.dynamo_kubernetes import (
     load_kube_client,
     object_key,
 )
-from tandemn_orca.tunnels import PortForwardManager, TunnelSpec
+from tandemn_orca.tunnels import PortForwardManager, RouterProcessManager, TunnelSpec
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +133,7 @@ class MultiClusterLauncher:
         model_catalogs: ModelCatalogStore | None = None,
         default_cluster: str | None = None,
         tunnels: PortForwardManager | None = None,
+        routers: RouterProcessManager | None = None,
     ) -> None:
         if not launchers:
             raise ValueError("at least one cluster launcher is required")
@@ -143,6 +144,7 @@ class MultiClusterLauncher:
         self.model_catalogs = model_catalogs
         self.default_cluster = default_cluster
         self.tunnels = tunnels
+        self.routers = routers
 
     def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
         groups: dict[str, list[Rank]] = {key: [] for key in self.launchers}
@@ -181,6 +183,8 @@ class MultiClusterLauncher:
                     ],
                 )
             _write_router_config(self.router_config_dir, job_id, router_config)
+            if self.routers is not None:
+                self.routers.reconcile(job_id, str(self.router_config_dir / f"{job_id}.json"))
             for key, grouped_ranks in groups.items():
                 for rank in grouped_ranks:
                     logger.info(
@@ -197,6 +201,8 @@ class MultiClusterLauncher:
             launcher.teardown_job(job_id)
         if self.tunnels is not None:
             self.tunnels.reconcile(job_id, [])
+        if self.routers is not None:
+            self.routers.reconcile(job_id, None)
         if self.router_config_dir is not None:
             self.router_config_dir.joinpath(f"{job_id}.json").unlink(missing_ok=True)
 

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -1,10 +1,10 @@
-"""Launcher seam — make a job's desired chains real.
+"""Launcher seam — make a job's desired ranks real.
 
-Orca records canonical chain rows in the store; bringing up the actual GPU
+Orca records canonical rank rows in the store; bringing up the actual GPU
 workers is a swappable implementation (DynamoLauncher applies DGDs;
 NoopLauncher records intent only).
 
-A Launcher operates on canonical ``Chain`` rows Orca has produced. Recording
+A Launcher operates on canonical ``Rank`` rows Orca has produced. Recording
 rows and updating status/events stays in Orca; the launcher only touches
 infrastructure.
 """
@@ -15,9 +15,14 @@ import logging
 from collections.abc import Callable
 from typing import Protocol
 
-from tandemn_system_data.models.chain import Chain
+from tandemn_system_data.models.rank import Rank
 
-from tandemn_orca.dynamo_compiler import compile_job
+from tandemn_orca.dynamo_compiler import (
+    compile_job,
+    render_router_objects,
+    router_configmap_name,
+    router_name,
+)
 from tandemn_orca.dynamo_kubernetes import (
     DynamoKubernetesClient,
     ObjectKey,
@@ -29,10 +34,10 @@ logger = logging.getLogger(__name__)
 
 
 class Launcher(Protocol):
-    """Reconciles job infrastructure to match Orca's Chain rows."""
+    """Reconciles job infrastructure to match Orca's Rank rows."""
 
-    def reconcile(self, job_id: str, chains: list[Chain]) -> None:
-        """Make infrastructure match the desired chains for one job."""
+    def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
+        """Make infrastructure match the desired ranks for one job."""
         ...
 
     def teardown_job(self, job_id: str) -> None:
@@ -59,18 +64,18 @@ class ReconcileError(RuntimeError):
 class NoopLauncher:
     """Records intent only — no infrastructure is touched.
 
-    Used when Orca should persist chain rows without touching a cluster
+    Used when Orca should persist rank rows without touching a cluster
     (tests, dry runs); production uses DynamoLauncher.
     """
 
-    def reconcile(self, job_id: str, chains: list[Chain]) -> None:
-        for chain in chains:
+    def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
+        for rank in ranks:
             logger.info(
-                "noop reconcile: job=%s chain=%s role=%s shape=%s",
+                "noop reconcile: job=%s rank=%s role=%s shape=%s",
                 job_id,
-                chain.chain_id,
-                chain.role,
-                chain.shape_json,
+                rank.rank_id,
+                rank.role,
+                rank.shape_json,
             )
 
     def teardown_job(self, job_id: str) -> None:
@@ -82,25 +87,49 @@ class DynamoLauncher:
         self,
         namespace: str = "default",
         k8s: DynamoKubernetesClient | None = None,
+        router_k8s: DynamoKubernetesClient | None = None,
+        router_image: str | None = None,
     ) -> None:
         self.namespace = namespace
         self.k8s = k8s or load_kube_client(namespace)
+        self.router_k8s = router_k8s
+        self.router_image = router_image
 
-    def reconcile(self, job_id: str, chains: list[Chain]) -> None:
-        desired = compile_job(job_id, chains, self.namespace)
+    def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
+        desired = compile_job(job_id, ranks, self.namespace)
         desired_keys = {object_key(obj) for obj in desired}
         stale = self.k8s.list_job_objects(job_id) - desired_keys
-        self._apply_and_delete(desired, stale)
+        apply_error = _call(self.k8s.apply_many, desired)
+        if apply_error:
+            raise ReconcileError(apply_error, None)
+        if self.router_k8s is not None:
+            router_objects = render_router_objects(
+                job_id,
+                ranks,
+                self.router_image or "",
+                self.router_k8s.namespace,
+            )
+            apply_error = _call(self.router_k8s.apply_many, router_objects)
+            if apply_error:
+                raise ReconcileError(apply_error, None)
+        self._delete_stale(stale)
 
     def teardown_job(self, job_id: str) -> None:
         self.k8s.delete_all_for_job(job_id)
+        if self.router_k8s is not None:
+            name = router_name(job_id)
+            self.router_k8s.delete_many(
+                {
+                    ("ConfigMap", router_configmap_name(job_id)),
+                    ("Deployment", name),
+                    ("Service", name),
+                }
+            )
 
-    def _apply_and_delete(self, desired: list[dict], stale: set[ObjectKey]) -> None:
-
-        apply_error = _call(self.k8s.apply_many, desired)
+    def _delete_stale(self, stale: set[ObjectKey]) -> None:
         delete_error = _call(self.k8s.delete_many, stale)
-        if apply_error or delete_error:
-            raise ReconcileError(apply_error, delete_error)
+        if delete_error:
+            raise ReconcileError(None, delete_error)
 
 
 def _call[T](fn: Callable[[T], object], arg: T) -> BaseException | None:

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -95,52 +95,89 @@ class DynamoLauncher:
         self,
         namespace: str = "default",
         k8s: DynamoKubernetesClient | None = None,
-        router_config_dir: str | None = None,
-        router_port_base: int = 18000,
-        router_port_span: int = 10000,
-        model_catalogs: ModelCatalogStore | None = None,
+        context: str | None = None,
     ) -> None:
         self.namespace = namespace
         self.k8s = k8s or load_kube_client(namespace)
-        self.router_config_dir = Path(router_config_dir) if router_config_dir else None
-        self.router_port_base = router_port_base
-        self.router_port_span = router_port_span
-        self.model_catalogs = model_catalogs
+        self.context = context
 
     def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
         desired = compile_job(job_id, ranks, self.namespace)
-        router_config = None
-        ports: dict[str, int] = {}
-        if self.router_config_dir is not None:
-            max_num_seq = _max_num_seq_by_rank(ranks, self.model_catalogs)
-            ports = _ports_by_rank(ranks, self.router_port_base, self.router_port_span)
-            router_config = render_router_config(job_id, ranks, max_num_seq, ports)
         desired_keys = {object_key(obj) for obj in desired}
         stale = self.k8s.list_job_objects(job_id) - desired_keys
         apply_error = _call(self.k8s.apply_many, desired)
         if apply_error:
             raise ReconcileError(apply_error, None)
         self._delete_stale(stale)
-        if router_config is not None:
-            assert self.router_config_dir is not None
-            _write_router_config(self.router_config_dir, job_id, router_config)
-            for rank in ranks:
-                logger.info(
-                    "router tunnel: kubectl --namespace %s port-forward service/%s-frontend %s:8000",
-                    self.namespace,
-                    pool_dgd_name(job_id, rank),
-                    ports[rank.rank_id],
-                )
 
     def teardown_job(self, job_id: str) -> None:
         self.k8s.delete_all_for_job(job_id)
-        if self.router_config_dir is not None:
-            self.router_config_dir.joinpath(f"{job_id}.json").unlink(missing_ok=True)
 
     def _delete_stale(self, stale: set[ObjectKey]) -> None:
         delete_error = _call(self.k8s.delete_many, stale)
         if delete_error:
             raise ReconcileError(None, delete_error)
+
+
+class MultiClusterLauncher:
+    """Apply rank groups to kube contexts and publish one laptop router config."""
+
+    def __init__(
+        self,
+        launchers: dict[str, DynamoLauncher],
+        *,
+        router_config_dir: str | None = None,
+        router_port_base: int = 18000,
+        router_port_span: int = 10000,
+        model_catalogs: ModelCatalogStore | None = None,
+        default_cluster: str | None = None,
+    ) -> None:
+        if not launchers:
+            raise ValueError("at least one cluster launcher is required")
+        self.launchers = launchers
+        self.router_config_dir = Path(router_config_dir) if router_config_dir else None
+        self.router_port_base = router_port_base
+        self.router_port_span = router_port_span
+        self.model_catalogs = model_catalogs
+        self.default_cluster = default_cluster
+
+    def reconcile(self, job_id: str, ranks: list[Rank]) -> None:
+        groups: dict[str, list[Rank]] = {key: [] for key in self.launchers}
+        for rank in ranks:
+            key = self.default_cluster or _rank_cluster_key(rank)
+            if key not in groups:
+                raise ValueError(f"no kube context configured for rank environment {key!r}")
+            groups[key].append(rank)
+
+        router_config = None
+        ports: dict[str, int] = {}
+        if self.router_config_dir is not None:
+            max_num_seq = _max_num_seq_by_rank(ranks, self.model_catalogs)
+            ports = _ports_by_rank(ranks, self.router_port_base, self.router_port_span)
+            router_config = render_router_config(job_id, ranks, max_num_seq, ports)
+
+        for key, launcher in self.launchers.items():
+            launcher.reconcile(job_id, groups[key])
+
+        if router_config is not None:
+            assert self.router_config_dir is not None
+            _write_router_config(self.router_config_dir, job_id, router_config)
+            for key, grouped_ranks in groups.items():
+                for rank in grouped_ranks:
+                    logger.info(
+                        "router tunnel: kubectl --context %s --namespace %s port-forward "
+                        "service/%s-frontend %s:8000",
+                        self.launchers[key].context or key,
+                        self.launchers[key].namespace,
+                        pool_dgd_name(job_id, rank),
+                        ports[rank.rank_id],
+                    )
+
+    def teardown_job(self, job_id: str) -> None:
+        for launcher in self.launchers.values():
+            launcher.teardown_job(job_id)
+        if self.router_config_dir is not None:
+            self.router_config_dir.joinpath(f"{job_id}.json").unlink(missing_ok=True)
 
 
 def _call[T](fn: Callable[[T], object], arg: T) -> BaseException | None:
@@ -185,6 +222,13 @@ def _max_num_seq_by_rank(
             )
         values[rank.rank_id] = value
     return values
+
+
+def _rank_cluster_key(rank: Rank) -> str:
+    env = rank.shape_json.get("env")
+    if not isinstance(env, (list, tuple)) or len(env) != 5 or not env[1] or not env[2]:
+        raise ValueError(f"rank {rank.rank_id} requires a five-part env for cluster selection")
+    return f"{env[1]}|{env[2]}"
 
 
 def _ports_by_rank(ranks: list[Rank], base: int, span: int) -> dict[str, int]:

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -4,24 +4,23 @@ One pass: poll the plans Koi has created but not yet applied, apply each
 action, and CAS the plan to ``applied``.
 
 Action semantics (DATA_ARCHITECTURE.md §6):
-    place    waiting|paused -> running   record the ladder's chains + apply DGDs
+    place    waiting|paused -> running   record the ladder's ranks + apply DGDs
     keep     running                     no change
     defer    waiting                     no change
-    preempt  running -> paused           tear down the job's chains
+    preempt  running -> paused           tear down the job's ranks
     swap     running                     relaunch on a new ladder
 
-Chain rows are *authorized* capacity, not launched pods: the pool DGD's worker
+Rank rows are *authorized* capacity, not launched pods: the pool DGD's worker
 replicas are owned by Dynamo's scaling adapter (DGDSA), and the in-pool Planner
 scales DP width within [min_endpoint, max_gpu_budget]. Actual live width per
-rank = distinct chain_ids in recent gpu_metrics rows.
+rank = distinct chain indexes in recent gpu_metrics rows.
 
 Ladder shape (opaque JSONB; Koi <-> Orca contract):
-    [{"role": "aggregate", "rank_id": "rank_0", "env": [...], "config": {...},
+    [{"role": "aggregate", "rank_id": "rank_<ULID>", "env": [...], "config": {...},
       "n_replicas": 3}]
-``count`` / ``gpu_count`` is the GPU count per chain (required, positive int).
-``chains`` / ``n_replicas`` is how many chain rows to record for max capacity.
-``rank_id`` is Koi's logical rank id (unique within the job's action; Koi
-autofills ``rank_{i}``); Orca preserves it into chain shapes, DGDs and pods.
+``count`` / ``gpu_count`` is the GPU count per replica (required, positive int).
+``chains`` / ``n_replicas`` is the rank's maximum runtime replica count.
+``rank_id`` is the canonical Koi-supplied ``rank_<ULID>`` preserved into DGDs and pods.
 """
 
 from __future__ import annotations
@@ -29,23 +28,26 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import re
 import time
 from typing import Any
 
 from tandemn_system_data.clients import JobStore, PlanStore, PostgresClient
-from tandemn_system_data.models.chain import Chain
-from tandemn_system_data.models.enums import ActionType, ChainRole, ChainStatus, JobStatus
+from tandemn_system_data.models.enums import ActionType, JobStatus, RankRole, RankStatus, ReasonCode
 from tandemn_system_data.models.plan import Plan, PlanAction
+from tandemn_system_data.models.rank import Rank
 
+from tandemn_orca.dynamo_kubernetes import load_kube_client
 from tandemn_orca.launcher import DynamoLauncher, Launcher, NoopLauncher
 from tandemn_orca.scripts.resource_map_from_aws import CapacityRefresher, parse_region_csv
 
 logger = logging.getLogger(__name__)
 
-ACTIVE_CHAIN_STATUSES = (ChainStatus.LAUNCHING, ChainStatus.RUNNING)
+ACTIVE_RANK_STATUSES = (RankStatus.LAUNCHING, RankStatus.RUNNING)
+RANK_ID_RE = re.compile(r"rank_[0-7][0-9A-HJKMNP-TV-Z]{25}\Z")
 
 
-def ladder_to_chains(
+def ladder_to_ranks(
     ladder: list[dict[str, Any]] | None,
     *,
     job_id: str,
@@ -53,8 +55,8 @@ def ladder_to_chains(
     target_p99_ttft_ms: float | None = None,
     target_p99_tpot_ms: float | None = None,
     job_spec: dict[str, Any] | None = None,
-) -> list[Chain]:
-    """Translate a ladder into Chain rows, skipping malformed entries.
+) -> list[Rank]:
+    """Translate a ladder into Rank rows, skipping malformed entries.
 
     A missing/invalid role, config, replica count, GPU count, or instance type
     skips the entry. Koi keeps some launch fields outside the rank config, so
@@ -62,7 +64,8 @@ def ladder_to_chains(
     the job's ``spec_json``, ``engine_name`` defaulting to ``vllm``.
     """
     job_spec = job_spec or {}
-    chains: list[Chain] = []
+    ranks: list[Rank] = []
+    seen_rank_ids: set[str] = set()
     for entry in ladder or []:
         if not isinstance(entry, dict):
             logger.warning("skipping non-dict ladder entry: %r", entry)
@@ -86,12 +89,13 @@ def ladder_to_chains(
         shape_json.setdefault("sp", 1)
         shape_json.setdefault("ep", 1)
         shape_json.setdefault("cp", 1)
-        # Koi's logical rank id; required so every DGD and pod has canonical
-        # identity matching Koi's evidence rows.
-        if not entry.get("rank_id"):
-            logger.warning("skipping ladder entry without rank_id: %r", entry)
+        rank_id = entry.get("rank_id")
+        if not isinstance(rank_id, str) or RANK_ID_RE.fullmatch(rank_id) is None:
+            logger.warning("skipping ladder entry without canonical rank_<ULID>: %r", entry)
             continue
-        shape_json["rank_id"] = str(entry["rank_id"])
+        if rank_id in seen_rank_ids:
+            raise ValueError(f"duplicate rank_id {rank_id}")
+        seen_rank_ids.add(rank_id)
         env = entry.get("env")
         if env is not None:
             shape_json["env"] = list(env) if isinstance(env, (list, tuple)) else env
@@ -118,18 +122,22 @@ def ladder_to_chains(
             logger.warning("skipping unlaunchable ladder entry (missing %s): %r", missing, entry)
             continue
 
-        for replica_index in range(replicas):
-            replica_shape = dict(shape_json)
-            replica_shape["replica_index"] = replica_index
-            chains.append(
-                Chain(job_id=job_id, plan_id=plan_id, role=role, shape_json=replica_shape)
+        ranks.append(
+            Rank(
+                rank_id=rank_id,
+                job_id=job_id,
+                plan_id=plan_id,
+                role=role,
+                shape_json=shape_json,
+                n_replicas=replicas,
             )
-    return chains
+        )
+    return ranks
 
 
-def _parse_role(role_name: object) -> ChainRole | None:
+def _parse_role(role_name: object) -> RankRole | None:
     try:
-        return ChainRole(role_name)
+        return RankRole(role_name)
     except ValueError:
         return None
 
@@ -184,24 +192,30 @@ class Orca:
     # ----- per-action handlers --------------------------------------------
 
     def _place(self, plan: Plan, action: PlanAction) -> None:
-        """waiting|paused -> running: record the ladder's chains and apply DGDs."""
+        """waiting|paused -> running: record the ladder's ranks and apply DGDs."""
+        job = self._jobs.get(action.job_id)
+        ranks = self._materialize_ranks(plan, action, job.spec_json if job else None)
+        previous_status = (
+            job.status if job and job.status in (JobStatus.WAITING, JobStatus.PAUSED) else None
+        )
         moved = self._jobs.transition(
             action.job_id,
             JobStatus.RUNNING,
             [JobStatus.WAITING, JobStatus.PAUSED],
         )
         if not moved:
-            logger.warning(
-                "place: job %s not in waiting|paused; launching chains anyway", action.job_id
-            )
-        self._launch_ladder(plan, action)
+            raise ValueError(f"place: job {action.job_id} is not waiting or paused")
+        try:
+            self._launch_ranks(action.job_id, ranks)
+        except Exception:
+            if moved and previous_status is not None:
+                self._jobs.transition(action.job_id, previous_status, [JobStatus.RUNNING])
+            raise
         logger.info("placed job %s (plan %s)", action.job_id, plan.plan_id)
 
     def _preempt(self, plan: Plan, action: PlanAction) -> None:
-        """running -> paused: tear down the job's chains, keep the job row."""
-        # Collect + tear down while the job still reads as running; the
-        # chain lookup goes through running_jobs.
-        self._teardown_chains(plan.user_id, action.job_id)
+        """running -> paused: tear down the job's ranks, keep the job row."""
+        self._teardown_ranks(action.job_id)
         moved = self._jobs.transition(action.job_id, JobStatus.PAUSED, [JobStatus.RUNNING])
         if not moved:
             logger.warning("preempt: job %s was not running", action.job_id)
@@ -211,55 +225,96 @@ class Orca:
         """running: relaunch on a new ladder.
 
         Dynamo reconciliation deletes stale DGDs by diff. Orca only marks the
-        old Chain rows stopped after writing the new desired rows.
+        old Rank rows stopped after writing and reconciling the new desired rows.
         """
-        old_chain_ids = self._active_chain_ids(plan.user_id, action.job_id)
-        self._launch_ladder(plan, action)
-        self._stop_chains(old_chain_ids)
+        old_ranks = self._jobs.active_ranks(action.job_id)
+        old_by_id = {rank.rank_id: rank for rank in old_ranks}
+        job = self._jobs.get(action.job_id)
+        if job is None or job.status is not JobStatus.RUNNING:
+            raise ValueError(f"swap: job {action.job_id} is not running")
+        ranks = self._materialize_ranks(plan, action, job.spec_json if job else None)
+        ranks = [
+            rank.model_copy(
+                update={
+                    "status": old_by_id[rank.rank_id].status,
+                    "reason_code": old_by_id[rank.rank_id].reason_code,
+                }
+            )
+            if rank.rank_id in old_by_id
+            else rank
+            for rank in ranks
+        ]
+        recorded = self._launch_ranks(action.job_id, ranks, old_by_id)
+        self._stop_ranks(set(old_by_id) - {rank.rank_id for rank in recorded})
         logger.info("swapped job %s (plan %s)", action.job_id, plan.plan_id)
 
     # ----- launcher seam ---------------------------------------------------
 
-    def _launch_ladder(self, plan: Plan, action: PlanAction) -> list[Chain]:
-        job = self._jobs.get(action.job_id)
-        chains = ladder_to_chains(
+    def _materialize_ranks(
+        self, plan: Plan, action: PlanAction, job_spec: dict[str, Any] | None
+    ) -> list[Rank]:
+        ranks = ladder_to_ranks(
             action.ladder,
             job_id=action.job_id,
             plan_id=plan.plan_id,
             target_p99_ttft_ms=action.target_p99_ttft_ms,
             target_p99_tpot_ms=action.target_p99_tpot_ms,
-            job_spec=job.spec_json if job else None,
+            job_spec=job_spec,
         )
-        if not chains:
-            logger.warning("no launchable chains for job %s (plan %s)", action.job_id, plan.plan_id)
-            return []
-        # Record canonical rows (status=LAUNCHING) first, then bring up the
-        # real workers behind the launcher seam.
-        recorded = self._jobs.launch_chains(chains)
-        self._launcher.reconcile(action.job_id, recorded)
+        if not ranks:
+            raise ValueError(f"no launchable ranks for job {action.job_id} (plan {plan.plan_id})")
+        return ranks
+
+    def _launch_ranks(
+        self,
+        job_id: str,
+        ranks: list[Rank],
+        previous: dict[str, Rank] | None = None,
+    ) -> list[Rank]:
+        previous = previous or {}
+        recorded = self._jobs.launch_ranks(ranks)
+        try:
+            self._launcher.reconcile(job_id, recorded)
+        except Exception:
+            try:
+                reused = [previous[rank.rank_id] for rank in recorded if rank.rank_id in previous]
+                if reused:
+                    self._jobs.launch_ranks(reused)
+            finally:
+                for rank in recorded:
+                    if rank.rank_id not in previous:
+                        self._jobs.set_rank_status(
+                            rank.rank_id,
+                            RankStatus.FAILED,
+                            [RankStatus.LAUNCHING],
+                            reason_code=ReasonCode.LAUNCH_FAILED,
+                        )
+            raise
+        for rank in recorded:
+            self._jobs.set_rank_status(rank.rank_id, RankStatus.RUNNING, [rank.status])
         return recorded
 
-    def _teardown_chains(self, user_id: str, job_id: str) -> None:
-        chain_ids = self._active_chain_ids(user_id, job_id)
+    def _teardown_ranks(self, job_id: str) -> None:
+        rank_ids = self._active_rank_ids(job_id)
         self._launcher.teardown_job(job_id)
-        self._stop_chains(chain_ids)
+        self._stop_ranks(rank_ids)
 
-    def _active_chain_ids(self, user_id: str, job_id: str) -> list[str]:
-        for running in self._jobs.running_jobs(user_id):
-            if running.job.job_id != job_id:
-                continue
-            return [c.chain_id for c in running.chains]
-        return []
+    def _active_rank_ids(self, job_id: str) -> set[str]:
+        return {rank.rank_id for rank in self._jobs.active_ranks(job_id)}
 
-    def _stop_chains(self, chain_ids: list[str]) -> None:
-        for chain_id in chain_ids:
-            self._jobs.set_chain_status(chain_id, ChainStatus.STOPPED, list(ACTIVE_CHAIN_STATUSES))
+    def _stop_ranks(self, rank_ids: set[str]) -> None:
+        for rank_id in rank_ids:
+            self._jobs.set_rank_status(rank_id, RankStatus.STOPPED, list(ACTIVE_RANK_STATUSES))
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Orca against Tandemn Store plans.")
     parser.add_argument("--user-id", default=os.getenv("TANDEMN_USER_ID"))
     parser.add_argument("--namespace", default=os.getenv("TANDEMN_K8S_NAMESPACE", "default"))
+    parser.add_argument("--router-namespace", default=os.getenv("TANDEMN_ROUTER_NAMESPACE"))
+    parser.add_argument("--router-kubeconfig", default=os.getenv("TANDEMN_ROUTER_KUBECONFIG"))
+    parser.add_argument("--router-context", default=os.getenv("TANDEMN_ROUTER_CONTEXT"))
+    parser.add_argument("--router-image", default=os.getenv("TANDEMN_ROUTER_IMAGE"))
     parser.add_argument(
         "--aws-regions",
         default=os.getenv("TANDEMN_AWS_REGIONS", "us-east-1,us-east-2,us-west-1,us-west-2"),
@@ -283,6 +338,10 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     if not args.user_id:
         raise SystemExit("--user-id or TANDEMN_USER_ID is required")
+    if args.router_namespace and not args.router_image:
+        raise SystemExit(
+            "--router-image or TANDEMN_ROUTER_IMAGE is required with router publishing"
+        )
 
     client = PostgresClient()
     refresher = CapacityRefresher(
@@ -296,7 +355,19 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:
         logger.exception("capacity refresh failed")
 
-    orca = Orca(client, launcher=DynamoLauncher(namespace=args.namespace))
+    router_k8s = (
+        load_kube_client(args.router_namespace, args.router_kubeconfig, args.router_context)
+        if args.router_namespace
+        else None
+    )
+    orca = Orca(
+        client,
+        launcher=DynamoLauncher(
+            namespace=args.namespace,
+            router_k8s=router_k8s,
+            router_image=args.router_image,
+        ),
+    )
     while True:
         try:
             refresher.refresh_if_due()

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import re
+import signal
 import time
 from typing import Any
 
@@ -433,6 +434,7 @@ def main(argv: list[str] | None = None) -> None:
     else:
         launchers = {"default": DynamoLauncher(namespace=args.namespace)}
         default_cluster = "default"
+    tunnel_manager = PortForwardManager() if args.router_config_dir else None
     launcher = MultiClusterLauncher(
         launchers,
         router_config_dir=args.router_config_dir,
@@ -440,28 +442,41 @@ def main(argv: list[str] | None = None) -> None:
         router_port_span=args.router_port_span,
         model_catalogs=ModelCatalogStore(client) if args.router_config_dir else None,
         default_cluster=default_cluster,
-        tunnels=PortForwardManager() if args.router_config_dir else None,
+        tunnels=tunnel_manager,
     )
     orca = Orca(client, launcher=launcher)
+    previous_sigterm = None
+    if tunnel_manager is not None:
+
+        def stop_on_sigterm(*_args: object) -> None:
+            raise KeyboardInterrupt
+
+        previous_sigterm = signal.signal(signal.SIGTERM, stop_on_sigterm)
     try:
-        reconciled = orca.reconcile_running(args.user_id)
-        logger.info("reconciled %s running job(s)", reconciled)
-    except Exception:
-        logger.exception("running job reconciliation failed")
-    while True:
-        if not args.skip_capacity_refresh:
-            try:
-                refresher.refresh_if_due()
-            except Exception:
-                logger.exception("capacity refresh failed")
         try:
-            applied = orca.apply_pending(args.user_id)
-            logger.info("applied %s plan(s) for user %s", applied, args.user_id)
+            reconciled = orca.reconcile_running(args.user_id)
+            logger.info("reconciled %s running job(s)", reconciled)
         except Exception:
-            logger.exception("orca apply loop failed")
-        if args.once:
-            return
-        time.sleep(args.interval_seconds)
+            logger.exception("running job reconciliation failed")
+        while True:
+            if not args.skip_capacity_refresh:
+                try:
+                    refresher.refresh_if_due()
+                except Exception:
+                    logger.exception("capacity refresh failed")
+            try:
+                applied = orca.apply_pending(args.user_id)
+                logger.info("applied %s plan(s) for user %s", applied, args.user_id)
+            except Exception:
+                logger.exception("orca apply loop failed")
+            if args.once:
+                return
+            time.sleep(args.interval_seconds)
+    finally:
+        if tunnel_manager is not None:
+            tunnel_manager.close()
+        if previous_sigterm is not None:
+            signal.signal(signal.SIGTERM, previous_sigterm)
 
 
 if __name__ == "__main__":

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -47,6 +47,7 @@ from tandemn_orca.launcher import (
     NoopLauncher,
 )
 from tandemn_orca.scripts.resource_map_from_aws import CapacityRefresher, parse_region_csv
+from tandemn_orca.tunnels import PortForwardManager
 
 logger = logging.getLogger(__name__)
 
@@ -415,6 +416,7 @@ def main(argv: list[str] | None = None) -> None:
         router_port_span=args.router_port_span,
         model_catalogs=ModelCatalogStore(client) if args.router_config_dir else None,
         default_cluster=default_cluster,
+        tunnels=PortForwardManager() if args.router_config_dir else None,
     )
     orca = Orca(client, launcher=launcher)
     while True:

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -26,6 +26,7 @@ Ladder shape (opaque JSONB; Koi <-> Orca contract):
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import re
@@ -37,7 +38,14 @@ from tandemn_system_data.models.enums import ActionType, JobStatus, RankRole, Ra
 from tandemn_system_data.models.plan import Plan, PlanAction
 from tandemn_system_data.models.rank import Rank
 
-from tandemn_orca.launcher import DynamoLauncher, Launcher, ModelCatalogError, NoopLauncher
+from tandemn_orca.dynamo_kubernetes import load_kube_client
+from tandemn_orca.launcher import (
+    DynamoLauncher,
+    Launcher,
+    ModelCatalogError,
+    MultiClusterLauncher,
+    NoopLauncher,
+)
 from tandemn_orca.scripts.resource_map_from_aws import CapacityRefresher, parse_region_csv
 
 logger = logging.getLogger(__name__)
@@ -329,6 +337,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--user-id", default=os.getenv("TANDEMN_USER_ID"))
     parser.add_argument("--namespace", default=os.getenv("TANDEMN_K8S_NAMESPACE", "default"))
     parser.add_argument("--router-config-dir", default=os.getenv("TANDEMN_ROUTER_CONFIG_DIR"))
+    parser.add_argument("--cluster-contexts", default=os.getenv("TANDEMN_CLUSTER_CONTEXTS"))
     parser.add_argument(
         "--router-port-base",
         type=int,
@@ -357,6 +366,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def load_cluster_contexts(path: str) -> dict[str, str]:
+    with open(path) as file:
+        raw = json.load(file)
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError("cluster context map must be a non-empty JSON object")
+    contexts = {str(key): str(value) for key, value in raw.items() if key and value}
+    if len(contexts) != len(raw):
+        raise ValueError("cluster context keys and values must be non-empty")
+    return contexts
+
+
 def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO)
     args = parse_args(argv)
@@ -374,16 +394,29 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:
         logger.exception("capacity refresh failed")
 
-    orca = Orca(
-        client,
-        launcher=DynamoLauncher(
-            namespace=args.namespace,
-            router_config_dir=args.router_config_dir,
-            router_port_base=args.router_port_base,
-            router_port_span=args.router_port_span,
-            model_catalogs=ModelCatalogStore(client) if args.router_config_dir else None,
-        ),
+    if args.cluster_contexts:
+        contexts = load_cluster_contexts(args.cluster_contexts)
+        launchers = {
+            key: DynamoLauncher(
+                namespace=args.namespace,
+                k8s=load_kube_client(args.namespace, context=context),
+                context=context,
+            )
+            for key, context in contexts.items()
+        }
+        default_cluster = None
+    else:
+        launchers = {"default": DynamoLauncher(namespace=args.namespace)}
+        default_cluster = "default"
+    launcher = MultiClusterLauncher(
+        launchers,
+        router_config_dir=args.router_config_dir,
+        router_port_base=args.router_port_base,
+        router_port_span=args.router_port_span,
+        model_catalogs=ModelCatalogStore(client) if args.router_config_dir else None,
+        default_cluster=default_cluster,
     )
+    orca = Orca(client, launcher=launcher)
     while True:
         try:
             refresher.refresh_if_due()

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -454,11 +454,19 @@ def main(argv: list[str] | None = None) -> None:
         previous_sigterm = signal.signal(signal.SIGTERM, stop_on_sigterm)
     try:
         try:
+            applied = orca.apply_pending(args.user_id)
+            logger.info("applied %s pending plan(s) at startup", applied)
+        except Exception:
+            logger.exception("initial plan apply failed")
+        try:
             reconciled = orca.reconcile_running(args.user_id)
             logger.info("reconciled %s running job(s)", reconciled)
         except Exception:
             logger.exception("running job reconciliation failed")
+        if args.once:
+            return
         while True:
+            time.sleep(args.interval_seconds)
             if not args.skip_capacity_refresh:
                 try:
                     refresher.refresh_if_due()
@@ -469,9 +477,6 @@ def main(argv: list[str] | None = None) -> None:
                 logger.info("applied %s plan(s) for user %s", applied, args.user_id)
             except Exception:
                 logger.exception("orca apply loop failed")
-            if args.once:
-                return
-            time.sleep(args.interval_seconds)
     finally:
         if tunnel_manager is not None:
             tunnel_manager.close()

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -118,9 +118,11 @@ def ladder_to_chains(
             logger.warning("skipping unlaunchable ladder entry (missing %s): %r", missing, entry)
             continue
 
-        for _ in range(replicas):
+        for replica_index in range(replicas):
+            replica_shape = dict(shape_json)
+            replica_shape["replica_index"] = replica_index
             chains.append(
-                Chain(job_id=job_id, plan_id=plan_id, role=role, shape_json=dict(shape_json))
+                Chain(job_id=job_id, plan_id=plan_id, role=role, shape_json=replica_shape)
             )
     return chains
 

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -86,10 +86,12 @@ def ladder_to_chains(
         shape_json.setdefault("sp", 1)
         shape_json.setdefault("ep", 1)
         shape_json.setdefault("cp", 1)
-        # Koi's logical rank id; preserved so DGDs/pods/telemetry group the
-        # rank's chains under the same key Koi uses in its evidence rows.
-        if entry.get("rank_id") is not None:
-            shape_json["rank_id"] = str(entry["rank_id"])
+        # Koi's logical rank id; required so every DGD and pod has canonical
+        # identity matching Koi's evidence rows.
+        if not entry.get("rank_id"):
+            logger.warning("skipping ladder entry without rank_id: %r", entry)
+            continue
+        shape_json["rank_id"] = str(entry["rank_id"])
         env = entry.get("env")
         if env is not None:
             shape_json["env"] = list(env) if isinstance(env, (list, tuple)) else env

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -328,7 +328,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Orca against Tandemn Store plans.")
     parser.add_argument("--user-id", default=os.getenv("TANDEMN_USER_ID"))
     parser.add_argument("--namespace", default=os.getenv("TANDEMN_K8S_NAMESPACE", "default"))
-    parser.add_argument("--router-image", default=os.getenv("TANDEMN_ROUTER_IMAGE"))
+    parser.add_argument("--router-config-dir", default=os.getenv("TANDEMN_ROUTER_CONFIG_DIR"))
+    parser.add_argument(
+        "--router-port-base",
+        type=int,
+        default=int(os.getenv("TANDEMN_ROUTER_PORT_BASE", "18000")),
+    )
+    parser.add_argument(
+        "--router-port-span",
+        type=int,
+        default=int(os.getenv("TANDEMN_ROUTER_PORT_SPAN", "10000")),
+    )
     parser.add_argument(
         "--aws-regions",
         default=os.getenv("TANDEMN_AWS_REGIONS", "us-east-1,us-east-2,us-west-1,us-west-2"),
@@ -368,8 +378,10 @@ def main(argv: list[str] | None = None) -> None:
         client,
         launcher=DynamoLauncher(
             namespace=args.namespace,
-            router_image=args.router_image,
-            model_catalogs=ModelCatalogStore(client) if args.router_image else None,
+            router_config_dir=args.router_config_dir,
+            router_port_base=args.router_port_base,
+            router_port_span=args.router_port_span,
+            model_catalogs=ModelCatalogStore(client) if args.router_config_dir else None,
         ),
     )
     while True:

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -37,7 +37,6 @@ from tandemn_system_data.models.enums import ActionType, JobStatus, RankRole, Ra
 from tandemn_system_data.models.plan import Plan, PlanAction
 from tandemn_system_data.models.rank import Rank
 
-from tandemn_orca.dynamo_kubernetes import load_kube_client
 from tandemn_orca.launcher import DynamoLauncher, Launcher, ModelCatalogError, NoopLauncher
 from tandemn_orca.scripts.resource_map_from_aws import CapacityRefresher, parse_region_csv
 
@@ -329,9 +328,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Orca against Tandemn Store plans.")
     parser.add_argument("--user-id", default=os.getenv("TANDEMN_USER_ID"))
     parser.add_argument("--namespace", default=os.getenv("TANDEMN_K8S_NAMESPACE", "default"))
-    parser.add_argument("--router-namespace", default=os.getenv("TANDEMN_ROUTER_NAMESPACE"))
-    parser.add_argument("--router-kubeconfig", default=os.getenv("TANDEMN_ROUTER_KUBECONFIG"))
-    parser.add_argument("--router-context", default=os.getenv("TANDEMN_ROUTER_CONTEXT"))
     parser.add_argument("--router-image", default=os.getenv("TANDEMN_ROUTER_IMAGE"))
     parser.add_argument(
         "--aws-regions",
@@ -356,11 +352,6 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     if not args.user_id:
         raise SystemExit("--user-id or TANDEMN_USER_ID is required")
-    if args.router_namespace and not args.router_image:
-        raise SystemExit(
-            "--router-image or TANDEMN_ROUTER_IMAGE is required with router publishing"
-        )
-
     client = PostgresClient()
     refresher = CapacityRefresher(
         client,
@@ -373,18 +364,12 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:
         logger.exception("capacity refresh failed")
 
-    router_k8s = (
-        load_kube_client(args.router_namespace, args.router_kubeconfig, args.router_context)
-        if args.router_namespace
-        else None
-    )
     orca = Orca(
         client,
         launcher=DynamoLauncher(
             namespace=args.namespace,
-            router_k8s=router_k8s,
             router_image=args.router_image,
-            model_catalogs=ModelCatalogStore(client) if router_k8s is not None else None,
+            model_catalogs=ModelCatalogStore(client) if args.router_image else None,
         ),
     )
     while True:

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -364,6 +364,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=float(os.getenv("TANDEMN_ORCA_POLL_SECONDS", "5")),
     )
     parser.add_argument("--once", action="store_true")
+    parser.add_argument("--skip-capacity-refresh", action="store_true")
     return parser.parse_args(argv)
 
 
@@ -390,10 +391,11 @@ def main(argv: list[str] | None = None) -> None:
         parse_region_csv(args.aws_regions),
         refresh_seconds=args.capacity_refresh_seconds,
     )
-    try:
-        refresher.refresh_if_due(force=True)
-    except Exception:
-        logger.exception("capacity refresh failed")
+    if not args.skip_capacity_refresh:
+        try:
+            refresher.refresh_if_due(force=True)
+        except Exception:
+            logger.exception("capacity refresh failed")
 
     if args.cluster_contexts:
         contexts = load_cluster_contexts(args.cluster_contexts)
@@ -420,10 +422,11 @@ def main(argv: list[str] | None = None) -> None:
     )
     orca = Orca(client, launcher=launcher)
     while True:
-        try:
-            refresher.refresh_if_due()
-        except Exception:
-            logger.exception("capacity refresh failed")
+        if not args.skip_capacity_refresh:
+            try:
+                refresher.refresh_if_due()
+            except Exception:
+                logger.exception("capacity refresh failed")
         try:
             applied = orca.apply_pending(args.user_id)
             logger.info("applied %s plan(s) for user %s", applied, args.user_id)

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -32,13 +32,13 @@ import re
 import time
 from typing import Any
 
-from tandemn_system_data.clients import JobStore, PlanStore, PostgresClient
+from tandemn_system_data.clients import JobStore, ModelCatalogStore, PlanStore, PostgresClient
 from tandemn_system_data.models.enums import ActionType, JobStatus, RankRole, RankStatus, ReasonCode
 from tandemn_system_data.models.plan import Plan, PlanAction
 from tandemn_system_data.models.rank import Rank
 
 from tandemn_orca.dynamo_kubernetes import load_kube_client
-from tandemn_orca.launcher import DynamoLauncher, Launcher, NoopLauncher
+from tandemn_orca.launcher import DynamoLauncher, Launcher, ModelCatalogError, NoopLauncher
 from tandemn_orca.scripts.resource_map_from_aws import CapacityRefresher, parse_region_csv
 
 logger = logging.getLogger(__name__)
@@ -207,6 +207,14 @@ class Orca:
             raise ValueError(f"place: job {action.job_id} is not waiting or paused")
         try:
             self._launch_ranks(action.job_id, ranks)
+        except ModelCatalogError as exc:
+            self._jobs.fail(
+                action.job_id,
+                [JobStatus.RUNNING],
+                finish_reason=ReasonCode.MODEL_CATALOG_INVALID,
+                error_message=str(exc),
+            )
+            raise
         except Exception:
             if moved and previous_status is not None:
                 self._jobs.transition(action.job_id, previous_status, [JobStatus.RUNNING])
@@ -244,7 +252,12 @@ class Orca:
             else rank
             for rank in ranks
         ]
-        recorded = self._launch_ranks(action.job_id, ranks, old_by_id)
+        try:
+            recorded = self._launch_ranks(action.job_id, ranks, old_by_id)
+        except ModelCatalogError as exc:
+            self._jobs.set_error(action.job_id, str(exc))
+            raise
+        self._jobs.set_error(action.job_id, None)
         self._stop_ranks(set(old_by_id) - {rank.rank_id for rank in recorded})
         logger.info("swapped job %s (plan %s)", action.job_id, plan.plan_id)
 
@@ -275,19 +288,24 @@ class Orca:
         recorded = self._jobs.launch_ranks(ranks)
         try:
             self._launcher.reconcile(job_id, recorded)
-        except Exception:
+        except Exception as exc:
             try:
                 reused = [previous[rank.rank_id] for rank in recorded if rank.rank_id in previous]
                 if reused:
                     self._jobs.launch_ranks(reused)
             finally:
+                reason_code = (
+                    ReasonCode.MODEL_CATALOG_INVALID
+                    if isinstance(exc, ModelCatalogError)
+                    else ReasonCode.LAUNCH_FAILED
+                )
                 for rank in recorded:
                     if rank.rank_id not in previous:
                         self._jobs.set_rank_status(
                             rank.rank_id,
                             RankStatus.FAILED,
                             [RankStatus.LAUNCHING],
-                            reason_code=ReasonCode.LAUNCH_FAILED,
+                            reason_code=reason_code,
                         )
             raise
         for rank in recorded:
@@ -366,6 +384,7 @@ def main(argv: list[str] | None = None) -> None:
             namespace=args.namespace,
             router_k8s=router_k8s,
             router_image=args.router_image,
+            model_catalogs=ModelCatalogStore(client) if router_k8s is not None else None,
         ),
     )
     while True:

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -172,6 +172,28 @@ class Orca:
                 logger.info("plan %s already applied, skipping", plan.plan_id)
         return applied
 
+    def reconcile_running(self, user_id: str) -> int:
+        """Restore infrastructure, local configs, and tunnels after Orca restarts."""
+        reconciled = 0
+        for running in self._jobs.running_jobs(user_id):
+            ranks = [
+                Rank(
+                    rank_id=allocation.rank_id,
+                    job_id=running.job.job_id,
+                    plan_id=allocation.plan_id,
+                    role=allocation.role,
+                    shape_json=dict(allocation.shape_json),
+                    n_replicas=allocation.n_replicas,
+                    status=allocation.status,
+                    reason_code=allocation.reason_code,
+                )
+                for allocation in running.ranks
+            ]
+            if ranks:
+                self._launcher.reconcile(running.job.job_id, ranks)
+                reconciled += 1
+        return reconciled
+
     def _apply_plan(self, plan: Plan) -> None:
         for action in plan.actions:
             # One bad action must not wedge the plan: an exception here would
@@ -421,6 +443,11 @@ def main(argv: list[str] | None = None) -> None:
         tunnels=PortForwardManager() if args.router_config_dir else None,
     )
     orca = Orca(client, launcher=launcher)
+    try:
+        reconciled = orca.reconcile_running(args.user_id)
+        logger.info("reconciled %s running job(s)", reconciled)
+    except Exception:
+        logger.exception("running job reconciliation failed")
     while True:
         if not args.skip_capacity_refresh:
             try:

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -48,7 +48,7 @@ from tandemn_orca.launcher import (
     NoopLauncher,
 )
 from tandemn_orca.scripts.resource_map_from_aws import CapacityRefresher, parse_region_csv
-from tandemn_orca.tunnels import PortForwardManager
+from tandemn_orca.tunnels import PortForwardManager, RouterProcessManager
 
 logger = logging.getLogger(__name__)
 
@@ -361,6 +361,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--user-id", default=os.getenv("TANDEMN_USER_ID"))
     parser.add_argument("--namespace", default=os.getenv("TANDEMN_K8S_NAMESPACE", "default"))
     parser.add_argument("--router-config-dir", default=os.getenv("TANDEMN_ROUTER_CONFIG_DIR"))
+    parser.add_argument("--router-binary", default=os.getenv("TANDEMN_ROUTER_BINARY"))
     parser.add_argument("--cluster-contexts", default=os.getenv("TANDEMN_CLUSTER_CONTEXTS"))
     parser.add_argument(
         "--router-port-base",
@@ -435,6 +436,13 @@ def main(argv: list[str] | None = None) -> None:
         launchers = {"default": DynamoLauncher(namespace=args.namespace)}
         default_cluster = "default"
     tunnel_manager = PortForwardManager() if args.router_config_dir else None
+    router_manager = None
+    if args.router_binary and args.router_config_dir:
+        if not os.getenv("TANDEMN_ROUTER_TELEMETRY_TOKEN"):
+            raise SystemExit(
+                "--router-binary requires TANDEMN_ROUTER_TELEMETRY_TOKEN in the environment"
+            )
+        router_manager = RouterProcessManager(args.router_binary)
     launcher = MultiClusterLauncher(
         launchers,
         router_config_dir=args.router_config_dir,
@@ -443,6 +451,7 @@ def main(argv: list[str] | None = None) -> None:
         model_catalogs=ModelCatalogStore(client) if args.router_config_dir else None,
         default_cluster=default_cluster,
         tunnels=tunnel_manager,
+        routers=router_manager,
     )
     orca = Orca(client, launcher=launcher)
     previous_sigterm = None
@@ -478,6 +487,8 @@ def main(argv: list[str] | None = None) -> None:
             except Exception:
                 logger.exception("orca apply loop failed")
     finally:
+        if router_manager is not None:
+            router_manager.close()
         if tunnel_manager is not None:
             tunnel_manager.close()
         if previous_sigterm is not None:

--- a/src/tandemn_orca/scripts/endpoint.py
+++ b/src/tandemn_orca/scripts/endpoint.py
@@ -1,0 +1,73 @@
+"""Resolve a job's user-facing inference endpoint.
+
+Orca renders each job's router config with a deterministic ``listen_port``
+(hash of the job ID); the router binds it when started without ``-listen``.
+This CLI closes the loop: job ID in, ``http://127.0.0.1:<port>`` out, straight
+from the config file — the same source of truth the router reads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from tandemn_orca.dynamo_compiler import router_listen_port
+
+DEFAULT_CONFIG_DIR = "~/.tandemn/router-configs"
+
+
+def resolve_endpoint(job_id: str, config_dir: Path) -> str:
+    """The job's router URL; falls back to the derived port for old configs."""
+    path = config_dir / f"{job_id}.json"
+    try:
+        config = json.loads(path.read_text())
+    except FileNotFoundError:
+        raise SystemExit(
+            f"no router config for {job_id!r} in {config_dir} — is the job placed and Orca running?"
+        ) from None
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"unreadable router config {path}: {error}") from None
+    port = config.get("listen_port") or router_listen_port(job_id)
+    if not isinstance(port, int) or not 0 < port < 65536:
+        raise SystemExit(f"router config {path} has invalid listen_port {port!r}")
+    return f"http://127.0.0.1:{port}"
+
+
+def check_ready(endpoint: str, timeout: float = 2.0) -> bool:
+    try:
+        with urllib.request.urlopen(f"{endpoint}/readyz", timeout=timeout) as response:
+            return response.status == 200
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job_id", help="job ID, e.g. job_01KZ...")
+    parser.add_argument(
+        "--router-config-dir",
+        default=os.environ.get("TANDEMN_ROUTER_CONFIG_DIR", DEFAULT_CONFIG_DIR),
+        help=f"where Orca writes per-job router configs (default {DEFAULT_CONFIG_DIR})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="probe the router's /readyz and fail if it is not serving",
+    )
+    args = parser.parse_args()
+
+    endpoint = resolve_endpoint(args.job_id, Path(args.router_config_dir).expanduser())
+    print(endpoint)
+    if args.check and not check_ready(endpoint):
+        print(f"router at {endpoint} is not ready", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -2,7 +2,7 @@
 
 One collector per cluster ("fleet mode"): every Dynamo worker pod in
 ``--namespace`` is tracked, across all DGDs and jobs. Identity is discovered,
-not configured: ``job_id`` + ``rank_id`` from the ``tandemn.ai/*`` pod labels
+not configured: ``job_id`` + ``rank_id`` from the ``tandemn.com/*`` pod labels
 Orca stamps, the served
 model from the worker's ``--model`` arg, the node's instance type from its
 ``node.kubernetes.io/instance-type`` label.
@@ -212,13 +212,12 @@ def _gpu_selector(target: dict[str, str]) -> str:
 #   chain = one serving unit == one worker (a DP replica within the rank)
 #   worker spans N GPUs (its local ranks) under TP/PP.
 _LABEL_DYN_NS = "nvidia.com/dynamo-namespace"
-_LABEL_COMPONENT = "nvidia.com/dynamo-component-type"
 # PD-disaggregation role of the worker: "prefill" | "decode" (absent = aggregated).
 _LABEL_SUBCOMPONENT = "nvidia.com/dynamo-sub-component-type"
-# Optional tandemn job-model labels (present when Orca launched the ladder).
-_LABEL_JOB = "tandemn.ai/job-id"
-_LABEL_RANK = "tandemn.ai/rank-id"
-_LABEL_CHAIN = "tandemn.ai/chain-id"
+_LABEL_DISCOVERY = "tandemn.com/pods-discovery"
+_LABEL_JOB = "tandemn.com/job-id"
+_LABEL_RANK = "tandemn.com/rank-id"
+_LABEL_CHAIN = "tandemn.com/chain-id"
 
 # Node label carrying the EC2 instance type (standard on EKS/Karpenter nodes).
 _NODE_LABEL_INSTANCE_TYPE = "node.kubernetes.io/instance-type"
@@ -306,13 +305,13 @@ class KubeWorkerIndex:
 
     def by_pod(self) -> dict[str, WorkerInfo]:
         """All Dynamo worker pods in the namespace, keyed by pod name."""
-        selector = f"{_LABEL_COMPONENT} in (worker,decode,prefill)"
+        selector = f"{_LABEL_DISCOVERY}=dynamo-worker"
         pods = self._core.list_namespaced_pod(self._namespace, label_selector=selector).items
         index: dict[str, WorkerInfo] = {}
         for pod in pods:
             labels = pod.metadata.labels or {}
             # A chain == a worker; fall back to the pod name when Orca did not
-            # stamp an explicit chain-id label. rank_id/job_id (the tandemn.ai
+            # stamp an explicit chain-id label. rank_id/job_id (the tandemn.com
             # labels) are only known when Orca launched the ladder, else None.
             chain_id = labels.get(_LABEL_CHAIN) or pod.metadata.name
             index[pod.metadata.name] = WorkerInfo(
@@ -348,7 +347,7 @@ def assign_canonical_chain_ids(workers_by_pod: dict[str, WorkerInfo], chains: li
 
     workers_by_rank: dict[str | None, list[WorkerInfo]] = {}
     for worker in workers_by_pod.values():
-        # chain_id != pod name means an explicit tandemn.ai/chain-id label.
+        # chain_id != pod name means an explicit tandemn.com/chain-id label.
         if worker.chain_id == worker.worker_id:
             workers_by_rank.setdefault(worker.rank_id, []).append(worker)
 

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -10,17 +10,14 @@ model from the worker's ``--model`` arg, the node's instance type from its
 Writes one ``GpuMetric`` row per physical GPU per tick. Granularity:
 
 - GPU hardware metrics (DCGM) are scoped to that one GPU (by ``UUID``).
-- Inference metrics (vLLM) are scoped to the chain/worker that owns the GPU (by
-  the worker pod name), so a multi-replica deployment records each chain's own
+- Inference metrics (vLLM) are scoped to the worker that owns the GPU (by
+  the worker pod name), so a multi-replica deployment records each replica's own
   numbers instead of a deployment-wide sum.
 
-Tandemn job model, coarse -> fine: a ``rank_id`` is a ladder rung (rank config)
-realized by N chains / DP replicas; a ``chain_id`` is one serving unit == one
-worker pod; a chain spans N GPUs, each with a ``local_rank`` (its index in the
-chain). ``chain_id`` is the canonical ``chains.chain_id`` from the store:
-chains within a rank are fungible DP replicas, so each job's worker pods are
-mapped onto its chain rows deterministically (both sides sorted). Pods without
-a job label (or beyond the job's chain rows) fall back to the pod name.
+Tandemn job model, coarse -> fine: a ``rank_id`` is a persisted ladder rung and
+``chain_index`` is Grove's runtime DP-replica index within that rank. A replica
+spans N GPUs, each with a ``local_rank``. Pod identity is accepted only when its
+job, plan, rank, and chain index match an active Rank row.
 
 The GPU->chain join uses dcgm-exporter's pod attribution: with
 ``DCGM_EXPORTER_KUBERNETES=true`` (cloud-setup/EKS/dcgm-exporter.yaml) each DCGM
@@ -32,9 +29,9 @@ capacity on tracked nodes.
 Run once (``--once``) or loop on a fixed ``COLLECT_INTERVAL_SECONDS`` cadence.
 Metrics that are topology- or config-gated (NVLink/comm/expert;
 ``sm_utilization``) return no series and are left ``None``. ``cost_per_token``
-uses the ``--user-id`` resource map's ``price_per_instance_hour`` for the
-worker node's instance type (the resource map is assumed accurate);
-``slo_margin`` uses the chain's ``target_p99_ttft_ms`` from its shape.
+sums the ``--user-id`` resource map's ``price_per_instance_hour`` across a
+chain's member nodes (the resource map is assumed accurate);
+``slo_margin`` uses the rank's ``target_p99_ttft_ms`` from its shape.
 
 Prometheus URL: ``--prometheus-url`` or ``TANDEMN_PROMETHEUS_URL``. Postgres:
 ``TANDEMN_POSTGRES_URL`` (see tandemn-store). Kubernetes config is loaded
@@ -61,7 +58,7 @@ from tandemn_system_data.clients import (
     PostgresClient,
     ResourceMapStore,
 )
-from tandemn_system_data.models import Chain, GpuMetric, ResourceMap
+from tandemn_system_data.models import GpuMetric, Rank, ResourceMap
 
 logger = logging.getLogger(__name__)
 
@@ -208,8 +205,8 @@ def _gpu_selector(target: dict[str, str]) -> str:
 
 
 # Dynamo/tandemn pod labels. Tandemn job model, coarse -> fine:
-#   rank  = a ladder rung (rank config), realized by N chains / DP replicas
-#   chain = one serving unit == one worker (a DP replica within the rank)
+#   rank  = a persisted ladder rung, realized by N runtime DP replicas
+#   chain = Grove's nonnegative replica index within the rank
 #   worker spans N GPUs (its local ranks) under TP/PP.
 _LABEL_DYN_NS = "nvidia.com/dynamo-namespace"
 # PD-disaggregation role of the worker: "prefill" | "decode" (absent = aggregated).
@@ -219,6 +216,7 @@ _LABEL_JOB = "tandemn.com/job-id"
 _LABEL_RANK = "tandemn.com/rank-id"
 _LABEL_PLAN = "tandemn.com/plan-id"
 _LABEL_PCSG_INDEX = "grove.io/podcliquescalinggroup-replica-index"
+_LABEL_POD_CLIQUE = "grove.io/podclique"
 _LABEL_POD_INDEX = "grove.io/podclique-pod-index"
 
 # Node label carrying the EC2 instance type (standard on EKS/Karpenter nodes).
@@ -226,13 +224,11 @@ _NODE_LABEL_INSTANCE_TYPE = "node.kubernetes.io/instance-type"
 
 
 class WorkerInfo:
-    """Identity of one Dynamo worker pod (== one chain / DP replica).
+    """Identity of one Dynamo worker pod (one runtime DP replica).
 
-    Joined to the node it runs on. ``rank_id`` is the ladder rung the chain
-    belongs to (shared across the rank's chains); ``chain_id`` is the serving
-    unit (canonical chains.chain_id after ``assign_canonical_chain_ids``);
-    ``worker_id`` is the pod name, kept internally for the
-    vLLM ``pod=`` selector but not stored. Per-GPU local ranks are resolved
+    Joined to the node it runs on. ``rank_id`` is the persisted ladder rung and
+    ``chain_index`` is Grove's replica index. ``worker_id`` is the pod name,
+    kept internally for the vLLM ``pod=`` selector but not stored. Per-GPU local ranks are resolved
     separately from the DCGM ``gpu`` index.
     """
 
@@ -246,9 +242,9 @@ class WorkerInfo:
         role: str | None,
         job_id: str | None = None,
         plan_id: str | None = None,
-        replica_index: int | None = None,
+        chain_index: int | None = None,
+        member_index: int | None = None,
         pod_index: int | None = None,
-        chain_id: str | None = None,
         model_name: str | None = None,
         ttft_target_ms: float | None = None,
     ) -> None:
@@ -256,12 +252,14 @@ class WorkerInfo:
         self.node_name = node_name
         self.dynamo_namespace = dynamo_namespace
         self.rank_id = rank_id
-        self.chain_id = chain_id
+        self.chain_index = chain_index
         self.role = role
         self.job_id = job_id
         self.plan_id = plan_id
-        self.replica_index = replica_index
+        self.member_index = member_index
         self.pod_index = pod_index
+        self.node_count = 1
+        self.gpus_per_node = 1
         self.model_name = model_name
         self.ttft_target_ms = ttft_target_ms
 
@@ -285,7 +283,7 @@ def _index(value: str | None) -> int | None:
 
 
 class KubeWorkerIndex:
-    """Indexes every Dynamo worker pod (chain) in the namespace by pod name.
+    """Indexes every Dynamo worker pod in the namespace by pod name.
 
     dcgm-exporter's PodResources mapping names the pod that owns each GPU
     (``exported_pod``); this index supplies that pod's identity labels. The
@@ -327,9 +325,14 @@ class KubeWorkerIndex:
         for pod in pods:
             labels = pod.metadata.labels or {}
             pod_index = _index(labels.get(_LABEL_POD_INDEX))
-            replica_index = _index(labels.get(_LABEL_PCSG_INDEX))
-            if replica_index is None:
-                replica_index = pod_index
+            scaling_group_index = _index(labels.get(_LABEL_PCSG_INDEX))
+            clique = labels.get(_LABEL_POD_CLIQUE, "")
+            member_index = None
+            if scaling_group_index is not None:
+                if clique.endswith("-ldr"):
+                    member_index = 0
+                elif clique.endswith("-wkr") and pod_index is not None:
+                    member_index = pod_index + 1
             index[pod.metadata.name] = WorkerInfo(
                 worker_id=pod.metadata.name,
                 node_name=pod.spec.node_name or "",
@@ -338,42 +341,50 @@ class KubeWorkerIndex:
                 role=labels.get(_LABEL_SUBCOMPONENT),
                 job_id=labels.get(_LABEL_JOB),
                 plan_id=labels.get(_LABEL_PLAN),
-                replica_index=replica_index,
+                chain_index=scaling_group_index if scaling_group_index is not None else pod_index,
+                member_index=member_index,
                 pod_index=pod_index,
                 model_name=_model_from_pod(pod),
             )
         return index
 
 
-def assign_canonical_chain_ids(workers_by_pod: dict[str, WorkerInfo], chains: list[Chain]) -> None:
-    """Resolve canonical chain IDs from plan, rank, and Grove replica index."""
-    by_slot: dict[tuple[str, str, str, int], Chain | None] = {}
-    for chain in chains:
-        rank_id = chain.shape_json.get("rank_id")
-        replica_index = chain.shape_json.get("replica_index")
-        if (
-            not chain.plan_id
-            or not rank_id
-            or not isinstance(replica_index, int)
-            or isinstance(replica_index, bool)
-            or replica_index < 0
-        ):
+def validate_rank_identity(workers_by_pod: dict[str, WorkerInfo], ranks: list[Rank]) -> None:
+    """Accept pod identity only when it matches one active Rank and replica range."""
+    by_identity: dict[tuple[str, str, str], Rank | None] = {}
+    for rank in ranks:
+        if not rank.plan_id:
             continue
-        key = (chain.job_id, chain.plan_id, str(rank_id), replica_index)
-        by_slot[key] = None if key in by_slot else chain
+        key = (rank.job_id, rank.plan_id, rank.rank_id)
+        by_identity[key] = None if key in by_identity else rank
 
     for worker in workers_by_pod.values():
-        worker.chain_id = None
-        if not worker.job_id or not worker.plan_id or not worker.rank_id:
+        rank = by_identity.get((worker.job_id or "", worker.plan_id or "", worker.rank_id or ""))
+        node_count = rank.shape_json.get("node_count", 1) if rank else None
+        gpu_count = rank.shape_json.get("count") if rank else None
+        if (
+            rank is None
+            or worker.chain_index is None
+            or worker.chain_index < 0
+            or worker.chain_index >= rank.n_replicas
+            or type(node_count) is not int
+            or node_count < 1
+            or type(gpu_count) is not int
+            or gpu_count < 1
+            or gpu_count % node_count != 0
+            or (node_count > 1 and worker.member_index is None)
+            or (worker.member_index is not None and worker.member_index >= node_count)
+        ):
+            worker.job_id = None
+            worker.plan_id = None
+            worker.rank_id = None
+            worker.chain_index = None
+            worker.role = None
+            worker.ttft_target_ms = None
             continue
-        if worker.replica_index is None:
-            continue
-        key = (worker.job_id, worker.plan_id, worker.rank_id, worker.replica_index)
-        chain = by_slot.get(key)
-        if chain is None:
-            continue
-        worker.chain_id = chain.chain_id
-        target = chain.shape_json.get("target_p99_ttft_ms")
+        worker.node_count = node_count
+        worker.gpus_per_node = gpu_count // node_count
+        target = rank.shape_json.get("target_p99_ttft_ms")
         if isinstance(target, (int, float)):
             worker.ttft_target_ms = float(target)
 
@@ -418,18 +429,18 @@ def collect_once(
     instance_types_by_node: dict[str, str] | None = None,
     prices_by_instance_type: dict[str, float | None] | None = None,
 ) -> list[GpuMetric]:
-    """One GpuMetric per GPU: GPU metrics per-GPU, inference metrics per-chain.
+    """One GpuMetric per GPU: GPU metrics per-GPU, inference metrics per replica.
 
     A GPU's ``owner_pod`` (dcgm-exporter PodResources mapping) picks its
-    chain/worker from ``workers_by_pod``, so inference metrics are scoped to
-    that chain rather than summed across the whole deployment. A GPU no worker
+    replica/worker from ``workers_by_pod``, so inference metrics are scoped to
+    that replica rather than summed across the whole deployment. A GPU no worker
     owns still gets a row -- hardware metrics only, identity
-    (``job_id``/``rank_id``/``chain_id``/``local_rank``/``role``) and
+    (``job_id``/``rank_id``/``chain_index``/``local_rank``/``role``) and
     inference metrics all None -- so aggregate utilization sees idle capacity.
 
-    ``prices_by_instance_type`` holds instance $/hour; a chain's
-    ``cost_per_token`` uses its node's instance price as-is, repeated on each
-    of its GPU rows.
+    ``prices_by_instance_type`` holds instance $/hour; a replica's
+    ``cost_per_token`` uses the sum across all member nodes, repeated on each
+    GPU row.
     """
     # Inference metrics are per-worker; cache so GPUs sharing a worker (TP>1)
     # reuse one query pass.
@@ -445,9 +456,8 @@ def collect_once(
             "all GPUs will be recorded as unowned"
         )
 
-    # local_rank is the GPU's index within its worker. The DCGM ``gpu`` label
-    # is node-local (a packed node numbers a worker's GPUs 2,3), so rank the
-    # worker's owned GPUs by that index instead of using it directly.
+    # DCGM indexes are node-local. Grove's clique member index supplies the
+    # multinode offset; single-node workers have no member index.
     local_ranks: dict[str, str] = {}
     owned: dict[str, list[dict[str, str]]] = {}
     for target in targets:
@@ -455,18 +465,50 @@ def collect_once(
             owned.setdefault(target["owner_pod"], []).append(target)
     for pod_targets in owned.values():
         pod_targets.sort(key=lambda t: (len(t.get("gpu_index", "")), t.get("gpu_index", "")))
+        indexed_worker = workers_by_pod[pod_targets[0]["owner_pod"]]
+        offset = (indexed_worker.member_index or 0) * indexed_worker.gpus_per_node
         for rank, target in enumerate(pod_targets):
-            local_ranks[target["gpu_uuid"]] = str(rank)
+            local_ranks[target["gpu_uuid"]] = str(offset + rank)
+
+    chain_nodes: dict[tuple[str, str, int], set[str]] = {}
+    chain_node_counts: dict[tuple[str, str, int], int] = {}
+    for chain_worker in workers_by_pod.values():
+        if not chain_worker.job_id or not chain_worker.rank_id or chain_worker.chain_index is None:
+            continue
+        key = (chain_worker.job_id, chain_worker.rank_id, chain_worker.chain_index)
+        if chain_worker.node_name:
+            chain_nodes.setdefault(key, set()).add(chain_worker.node_name)
+        chain_node_counts[key] = chain_worker.node_count
+
+    chain_prices: dict[tuple[str, str, int], float | None] = {}
+    for key, nodes in chain_nodes.items():
+        prices = [
+            (prices_by_instance_type or {}).get((instance_types_by_node or {}).get(node_name, ""))
+            for node_name in nodes
+        ]
+        chain_prices[key] = (
+            sum(price for price in prices if price is not None)
+            if len(nodes) == chain_node_counts[key] and all(price is not None for price in prices)
+            else None
+        )
 
     samples = []
     for target in targets:
         worker = workers_by_pod.get(target.get("owner_pod", ""))
+        if worker is not None and (
+            not worker.job_id
+            or not worker.plan_id
+            or not worker.rank_id
+            or worker.chain_index is None
+        ):
+            worker = None
 
         if worker is not None:
+            assert worker.job_id and worker.rank_id and worker.chain_index is not None
             node_name: str | None = worker.node_name or None
             instance_type = (instance_types_by_node or {}).get(node_name or "")
             if worker.worker_id not in worker_cache:
-                price = (prices_by_instance_type or {}).get(instance_type or "")
+                price = chain_prices.get((worker.job_id, worker.rank_id, worker.chain_index))
                 worker_cache[worker.worker_id] = _worker_inference_values(
                     prom,
                     worker,
@@ -491,7 +533,7 @@ def collect_once(
                 job_id=worker.job_id if worker else None,
                 gpu_uuid=target["gpu_uuid"],
                 rank_id=worker.rank_id if worker else None,
-                chain_id=worker.chain_id if worker else None,
+                chain_index=worker.chain_index if worker else None,
                 # An idle GPU has no local_rank.
                 local_rank=local_ranks.get(target["gpu_uuid"]) if worker else None,
                 role=worker.role if worker else None,
@@ -570,11 +612,11 @@ def main(argv: list[str] | None = None) -> int:
 
     for _ in _ticks(args.once):
         workers_by_pod = kube.by_pod()
-        # Canonical chain ids, one job at a time (job ids come from pod labels).
+        # Fetch active rows by labeled job, then validate every pod so missing
+        # job identity cannot retain a rank or chain index.
         job_ids = sorted({w.job_id for w in workers_by_pod.values() if w.job_id})
-        for job_id in job_ids:
-            job_workers = {pod: w for pod, w in workers_by_pod.items() if w.job_id == job_id}
-            assign_canonical_chain_ids(job_workers, jobs.active_chains(job_id))
+        ranks = [rank for job_id in job_ids for rank in jobs.active_ranks(job_id)]
+        validate_rank_identity(workers_by_pod, ranks)
 
         node_names_by_ip, instance_types_by_node = kube.nodes()
         # Re-read per tick: the map is one row and Orca republishes prices.

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -403,15 +403,13 @@ class KubeWorkerIndex:
 
 def validate_rank_identity(workers_by_pod: dict[str, WorkerInfo], ranks: list[Rank]) -> None:
     """Accept pod identity only when it matches one active Rank and replica range."""
-    by_identity: dict[tuple[str, str, str], Rank | None] = {}
+    by_identity: dict[tuple[str, str], Rank | None] = {}
     for rank in ranks:
-        if not rank.plan_id:
-            continue
-        key = (rank.job_id, rank.plan_id, rank.rank_id)
+        key = (rank.job_id, rank.rank_id)
         by_identity[key] = None if key in by_identity else rank
 
     for worker in workers_by_pod.values():
-        rank = by_identity.get((worker.job_id or "", worker.plan_id or "", worker.rank_id or ""))
+        rank = by_identity.get((worker.job_id or "", worker.rank_id or ""))
         node_count = rank.shape_json.get("node_count", 1) if rank else None
         gpu_count = rank.shape_json.get("count") if rank else None
         if (

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -63,6 +63,8 @@ from tandemn_system_data.clients import (
 )
 from tandemn_system_data.models import GpuMetric, Rank, ResourceMap
 
+from tandemn_orca.dynamo_compiler import router_listen_port
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_PROMETHEUS_URL = "http://localhost:9090"
@@ -123,10 +125,6 @@ WORKER_QUERIES: dict[str, str] = {
     ),
     "decode_itr_counts_per_second": (
         "sum(rate(vllm:request_decode_time_seconds_count{{{worker}}}[1m]))"
-    ),
-    "kv_pressure_score": (
-        "max(vllm:kv_cache_usage_perc{{{worker}}}) + sum(vllm:num_requests_waiting{{{worker}}}) "
-        "+ sum(rate(vllm:num_preemptions_total{{{worker}}}[5m]))"
     ),
     "pd_inbalance": (
         "sum(rate(vllm:request_prefill_time_seconds_sum{{{worker}}}[5m])) / "
@@ -212,13 +210,18 @@ class RankTelemetrySnapshot:
 
 
 class RouterTelemetryClient:
-    def __init__(self, url_template: str, token: str, timeout: float = 5.0) -> None:
+    def __init__(self, url_template: str | None, token: str, timeout: float = 5.0) -> None:
         self.url_template = url_template
         self.token = token
         self.timeout = timeout
 
     def push(self, snapshot: RankTelemetrySnapshot) -> None:
-        base_url = self.url_template.format(job_id=snapshot.job_id).rstrip("/")
+        if self.url_template:
+            base_url = self.url_template.format(job_id=snapshot.job_id).rstrip("/")
+        else:
+            # Each job's router binds its deterministic listen_port; derive it
+            # so one collector feeds every job's router without configuration.
+            base_url = f"http://127.0.0.1:{router_listen_port(snapshot.job_id)}"
         request = urllib.request.Request(
             f"{base_url}/internal/telemetry",
             data=json.dumps(
@@ -743,9 +746,11 @@ def main(argv: list[str] | None = None) -> int:
         ResourceMapStore(client, user_id=args.user_id) if args.user_id is not None else None
     )
     kube = KubeWorkerIndex(namespace=args.namespace, context=args.kube_context)
+    # With a token but no template, the client derives each job's router URL
+    # from its deterministic listen_port — one collector, N job routers.
     router_telemetry = (
-        RouterTelemetryClient(args.router_url_template, args.router_telemetry_token)
-        if args.router_url_template
+        RouterTelemetryClient(args.router_url_template or None, args.router_telemetry_token)
+        if args.router_telemetry_token
         else None
     )
 

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -148,7 +148,7 @@ class PrometheusClient:
         try:
             with urllib.request.urlopen(url, timeout=self._timeout) as resp:
                 payload = json.load(resp)
-        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as error:
             logger.warning("prometheus query failed: %s", error)
             return None
         results = payload.get("data", {}).get("result", [])
@@ -172,7 +172,7 @@ class PrometheusClient:
         try:
             with urllib.request.urlopen(url, timeout=self._timeout) as resp:
                 payload = json.load(resp)
-        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as error:
             logger.warning("prometheus gpu discovery failed: %s", error)
             return []
         targets = []

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -332,15 +332,21 @@ class KubeWorkerIndex:
     ``instance`` label carries the node's InternalIP) and its instance type.
     """
 
-    def __init__(self, namespace: str = "default", core: Any = None) -> None:
+    def __init__(
+        self, namespace: str = "default", core: Any = None, context: str | None = None
+    ) -> None:
         from kubernetes import client, config
 
         if core is None:
-            try:
-                config.load_incluster_config()
-            except Exception:
-                config.load_kube_config()
-            core = client.CoreV1Api()
+            if context is not None:
+                api_client = config.new_client_from_config(context=context)
+                core = client.CoreV1Api(api_client)
+            else:
+                try:
+                    config.load_incluster_config()
+                except Exception:
+                    config.load_kube_config()
+                core = client.CoreV1Api()
         self._core = core
         self._namespace = namespace
 
@@ -512,6 +518,16 @@ def collect_rank_telemetry(
             )
         )
     return snapshots
+
+
+def local_ranks_for_workers(ranks: list[Rank], workers_by_pod: dict[str, WorkerInfo]) -> list[Rank]:
+    """Keep only ranks with runtime pods in this collector's cluster."""
+    local = {
+        (worker.job_id, worker.rank_id)
+        for worker in workers_by_pod.values()
+        if worker.job_id and worker.rank_id and worker.chain_index is not None
+    }
+    return [rank for rank in ranks if (rank.job_id, rank.rank_id) in local]
 
 
 def collect_once(
@@ -688,6 +704,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--namespace", default="default", help="Kubernetes namespace of the worker pods"
     )
     parser.add_argument(
+        "--kube-context",
+        default=os.getenv("TANDEMN_KUBE_CONTEXT"),
+        help="Kubeconfig context for this collector process",
+    )
+    parser.add_argument(
         "--user-id",
         default=os.getenv("TANDEMN_USER_ID"),
         help="Resource map owner (or TANDEMN_USER_ID); prices instances for cost_per_token",
@@ -713,7 +734,7 @@ def main(argv: list[str] | None = None) -> int:
     resource_maps = (
         ResourceMapStore(client, user_id=args.user_id) if args.user_id is not None else None
     )
-    kube = KubeWorkerIndex(namespace=args.namespace)
+    kube = KubeWorkerIndex(namespace=args.namespace, context=args.kube_context)
     router_telemetry = (
         RouterTelemetryClient(args.router_url_template, args.router_telemetry_token)
         if args.router_url_template
@@ -728,7 +749,8 @@ def main(argv: list[str] | None = None) -> int:
         ranks = [rank for job_id in job_ids for rank in jobs.active_ranks(job_id)]
         validate_rank_identity(workers_by_pod, ranks)
         if router_telemetry is not None:
-            for snapshot in collect_rank_telemetry(prom, workers_by_pod, ranks):
+            local_ranks = local_ranks_for_workers(ranks, workers_by_pod)
+            for snapshot in collect_rank_telemetry(prom, workers_by_pod, local_ranks):
                 try:
                     router_telemetry.push(snapshot)
                 except (urllib.error.URLError, TimeoutError, OSError):

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -105,7 +105,7 @@ WORKER_QUERIES: dict[str, str] = {
     "throughput_token_per_sec": "sum(rate(vllm:generation_tokens_total{{{worker}}}[1m]))",
     "live_batch_size": "sum(vllm:num_requests_running{{{worker}}})",
     "depth_req_q": "sum(vllm:num_requests_waiting{{{worker}}})",
-    "kv_cache_util": "max(vllm:kv_cache_usage_perc{{{worker}}})",
+    "kv_cache_util": "max(dynamo_component_gpu_cache_usage_percent{{{worker}}})",
     "kvcache_hit_rate": (
         "sum(rate(vllm:prefix_cache_hits_total{{{worker}}}[5m])) / "
         "sum(rate(vllm:prefix_cache_queries_total{{{worker}}}[5m]))"
@@ -208,6 +208,7 @@ class RankTelemetrySnapshot:
     pending_requests: int
     ready_replicas: int
     observed_at: datetime
+    kv_cache_util: float = 0.0
 
 
 class RouterTelemetryClient:
@@ -492,6 +493,7 @@ def collect_rank_telemetry(
             chains.setdefault(worker.chain_index, []).append(worker)
 
         active = pending = ready_replicas = 0
+        kv_samples: list[float] = []
         for members in chains.values():
             if len([member for member in members if member.ready]) < members[0].node_count:
                 continue
@@ -504,6 +506,9 @@ def collect_rank_telemetry(
             active += math.ceil(max(0.0, running))
             pending += math.ceil(max(0.0, waiting))
             ready_replicas += 1
+            kv = prom.query_scalar(WORKER_QUERIES["kv_cache_util"].format(worker=selector))
+            if kv is not None:
+                kv_samples.append(max(0.0, kv))
 
         snapshots.append(
             RankTelemetrySnapshot(
@@ -513,6 +518,11 @@ def collect_rank_telemetry(
                 pending_requests=pending,
                 ready_replicas=ready_replicas,
                 observed_at=observed_at,
+                # Rank-level utilization, the planner's signal: replicas have
+                # equal-size caches, so the mean across chains is used/capacity
+                # for the whole rank. Chains with no KV sample drop out of the
+                # mean rather than dragging it toward zero.
+                kv_cache_util=sum(kv_samples) / len(kv_samples) if kv_samples else 0.0,
             )
         )
     return snapshots

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import os
 import sys
 import time
@@ -50,6 +51,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from tandemn_system_data.clients import (
@@ -60,12 +63,14 @@ from tandemn_system_data.clients import (
 )
 from tandemn_system_data.models import GpuMetric, Rank, ResourceMap
 
+from tandemn_orca.dynamo_compiler import router_name
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_PROMETHEUS_URL = "http://localhost:9090"
 
 # Fixed poll cadence for the looping mode (matches the Prometheus scrape rate).
-COLLECT_INTERVAL_SECONDS = 10
+COLLECT_INTERVAL_SECONDS = 5
 
 # Per-GPU instant queries. {gpu} expands to a DCGM label selector pinning one
 # physical GPU. Expressions mirror cloud-setup/EKS/METRICS.md.
@@ -197,6 +202,45 @@ class PrometheusClient:
         return targets
 
 
+@dataclass(frozen=True)
+class RankTelemetrySnapshot:
+    job_id: str
+    rank_id: str
+    active_requests: int
+    pending_requests: int
+    ready_replicas: int
+    observed_at: datetime
+
+
+class RouterTelemetryClient:
+    def __init__(self, url_template: str, token: str, timeout: float = 5.0) -> None:
+        self.url_template = url_template
+        self.token = token
+        self.timeout = timeout
+
+    def push(self, snapshot: RankTelemetrySnapshot) -> None:
+        base_url = self.url_template.format(
+            job_id=snapshot.job_id,
+            router_name=router_name(snapshot.job_id),
+        ).rstrip("/")
+        request = urllib.request.Request(
+            f"{base_url}/internal/telemetry",
+            data=json.dumps(
+                {
+                    **snapshot.__dict__,
+                    "observed_at": snapshot.observed_at.isoformat(),
+                }
+            ).encode(),
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout):
+            pass
+
+
 def _gpu_selector(target: dict[str, str]) -> str:
     """DCGM label selector that pins one GPU; prefer UUID, else instance."""
     if target.get("uuid_label"):
@@ -247,6 +291,7 @@ class WorkerInfo:
         pod_index: int | None = None,
         model_name: str | None = None,
         ttft_target_ms: float | None = None,
+        ready: bool = True,
     ) -> None:
         self.worker_id = worker_id
         self.node_name = node_name
@@ -262,6 +307,7 @@ class WorkerInfo:
         self.gpus_per_node = 1
         self.model_name = model_name
         self.ttft_target_ms = ttft_target_ms
+        self.ready = ready
 
 
 def _model_from_pod(pod: Any) -> str | None:
@@ -327,6 +373,10 @@ class KubeWorkerIndex:
             pod_index = _index(labels.get(_LABEL_POD_INDEX))
             scaling_group_index = _index(labels.get(_LABEL_PCSG_INDEX))
             clique = labels.get(_LABEL_POD_CLIQUE, "")
+            ready = any(
+                condition.type == "Ready" and condition.status == "True"
+                for condition in (getattr(getattr(pod, "status", None), "conditions", None) or [])
+            )
             member_index = None
             if scaling_group_index is not None:
                 if clique.endswith("-ldr"):
@@ -345,6 +395,7 @@ class KubeWorkerIndex:
                 member_index=member_index,
                 pod_index=pod_index,
                 model_name=_model_from_pod(pod),
+                ready=ready,
             )
         return index
 
@@ -419,6 +470,53 @@ def _worker_inference_values(
         else None
     )
     return values
+
+
+def collect_rank_telemetry(
+    prom: PrometheusClient,
+    workers_by_pod: dict[str, WorkerInfo],
+    ranks: list[Rank],
+    observed_at: datetime | None = None,
+) -> list[RankTelemetrySnapshot]:
+    """Aggregate ready runtime replicas into one router snapshot per rank."""
+    observed_at = observed_at or datetime.now(UTC)
+    workers_by_rank: dict[tuple[str, str], list[WorkerInfo]] = {}
+    for worker in workers_by_pod.values():
+        if worker.job_id and worker.rank_id and worker.chain_index is not None:
+            workers_by_rank.setdefault((worker.job_id, worker.rank_id), []).append(worker)
+
+    snapshots = []
+    for rank in ranks:
+        chains: dict[int, list[WorkerInfo]] = {}
+        for worker in workers_by_rank.get((rank.job_id, rank.rank_id), []):
+            assert worker.chain_index is not None
+            chains.setdefault(worker.chain_index, []).append(worker)
+
+        active = pending = ready_replicas = 0
+        for members in chains.values():
+            if len([member for member in members if member.ready]) < members[0].node_count:
+                continue
+            representative = min(members, key=lambda member: member.member_index or 0)
+            selector = f'pod="{representative.worker_id}"'
+            running = prom.query_scalar(WORKER_QUERIES["live_batch_size"].format(worker=selector))
+            waiting = prom.query_scalar(WORKER_QUERIES["depth_req_q"].format(worker=selector))
+            if running is None or waiting is None:
+                continue
+            active += math.ceil(max(0.0, running))
+            pending += math.ceil(max(0.0, waiting))
+            ready_replicas += 1
+
+        snapshots.append(
+            RankTelemetrySnapshot(
+                job_id=rank.job_id,
+                rank_id=rank.rank_id,
+                active_requests=active,
+                pending_requests=pending,
+                ready_replicas=ready_replicas,
+                observed_at=observed_at,
+            )
+        )
+    return snapshots
 
 
 def collect_once(
@@ -582,6 +680,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Prometheus base URL (or TANDEMN_PROMETHEUS_URL)",
     )
     parser.add_argument(
+        "--router-url-template",
+        default=os.getenv("TANDEMN_ROUTER_URL_TEMPLATE"),
+        help="Per-job router URL template with {job_id} and/or {router_name}",
+    )
+    parser.add_argument(
+        "--router-telemetry-token",
+        default=os.getenv("TANDEMN_ROUTER_TELEMETRY_TOKEN"),
+        help="Bearer token shared with job routers",
+    )
+    parser.add_argument(
         "--namespace", default="default", help="Kubernetes namespace of the worker pods"
     )
     parser.add_argument(
@@ -600,6 +708,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, stream=sys.stderr)
     args = parse_args(argv)
+    if args.router_url_template and not args.router_telemetry_token:
+        raise SystemExit("--router-telemetry-token is required with --router-url-template")
 
     prom = PrometheusClient(args.prometheus_url)
     client = PostgresClient()
@@ -609,6 +719,11 @@ def main(argv: list[str] | None = None) -> int:
         ResourceMapStore(client, user_id=args.user_id) if args.user_id is not None else None
     )
     kube = KubeWorkerIndex(namespace=args.namespace)
+    router_telemetry = (
+        RouterTelemetryClient(args.router_url_template, args.router_telemetry_token)
+        if args.router_url_template
+        else None
+    )
 
     for _ in _ticks(args.once):
         workers_by_pod = kube.by_pod()
@@ -617,6 +732,16 @@ def main(argv: list[str] | None = None) -> int:
         job_ids = sorted({w.job_id for w in workers_by_pod.values() if w.job_id})
         ranks = [rank for job_id in job_ids for rank in jobs.active_ranks(job_id)]
         validate_rank_identity(workers_by_pod, ranks)
+        if router_telemetry is not None:
+            for snapshot in collect_rank_telemetry(prom, workers_by_pod, ranks):
+                try:
+                    router_telemetry.push(snapshot)
+                except (urllib.error.URLError, TimeoutError, OSError):
+                    logger.exception(
+                        "router telemetry push failed for job=%s rank=%s",
+                        snapshot.job_id,
+                        snapshot.rank_id,
+                    )
 
         node_names_by_ip, instance_types_by_node = kube.nodes()
         # Re-read per tick: the map is one row and Orca republishes prices.

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -63,8 +63,6 @@ from tandemn_system_data.clients import (
 )
 from tandemn_system_data.models import GpuMetric, Rank, ResourceMap
 
-from tandemn_orca.dynamo_compiler import router_name
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_PROMETHEUS_URL = "http://localhost:9090"
@@ -219,10 +217,7 @@ class RouterTelemetryClient:
         self.timeout = timeout
 
     def push(self, snapshot: RankTelemetrySnapshot) -> None:
-        base_url = self.url_template.format(
-            job_id=snapshot.job_id,
-            router_name=router_name(snapshot.job_id),
-        ).rstrip("/")
+        base_url = self.url_template.format(job_id=snapshot.job_id).rstrip("/")
         request = urllib.request.Request(
             f"{base_url}/internal/telemetry",
             data=json.dumps(
@@ -682,7 +677,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--router-url-template",
         default=os.getenv("TANDEMN_ROUTER_URL_TEMPLATE"),
-        help="Per-job router URL template with {job_id} and/or {router_name}",
+        help="Laptop router URL, optionally templated with {job_id}",
     )
     parser.add_argument(
         "--router-telemetry-token",

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -107,7 +107,12 @@ WORKER_QUERIES: dict[str, str] = {
     "throughput_token_per_sec": "sum(rate(vllm:generation_tokens_total{{{worker}}}[1m]))",
     "live_batch_size": "sum(vllm:num_requests_running{{{worker}}})",
     "depth_req_q": "sum(vllm:num_requests_waiting{{{worker}}})",
-    "kv_cache_util": "max(dynamo_component_gpu_cache_usage_percent{{{worker}}})",
+    # Dynamo worker gauge (0.0-1.0), verified live on Dynamo 1.2.1; the vLLM
+    # passthrough gauge is the fallback if a future Dynamo drops it.
+    "kv_cache_util": (
+        "max(dynamo_component_gpu_cache_usage_percent{{{worker}}} "
+        "or vllm:kv_cache_usage_perc{{{worker}}})"
+    ),
     "kvcache_hit_rate": (
         "sum(rate(vllm:prefix_cache_hits_total{{{worker}}}[5m])) / "
         "sum(rate(vllm:prefix_cache_queries_total{{{worker}}}[5m]))"
@@ -131,6 +136,24 @@ WORKER_QUERIES: dict[str, str] = {
         "sum(rate(vllm:request_decode_time_seconds_sum{{{worker}}}[5m]))"
     ),
 }
+
+# Inputs to derived metrics, not GpuMetric fields themselves (WORKER_QUERIES
+# keys map 1:1 onto row fields; these must stay out of that mapping).
+AUX_WORKER_QUERIES: dict[str, str] = {
+    # Mean requested generation budget of recently completed requests.
+    "requested_max_tokens": (
+        "sum(rate(vllm:request_params_max_tokens_sum{{{worker}}}[5m])) / "
+        "sum(rate(vllm:request_params_max_tokens_count{{{worker}}}[5m]))"
+    ),
+    # Total KV blocks allocated by the engine, verified live on Dynamo 1.2.1
+    # (equals vllm:cache_config_info's num_gpu_blocks). If a future Dynamo
+    # drops it, kv_pressure_score degrades to None and warns once.
+    "kv_total_blocks": "max(dynamo_component_total_blocks{{{worker}}})",
+}
+
+# vLLM V1 default KV block size. Only block-rounds the demand side of
+# kv_pressure_score; capacity is already expressed in blocks.
+KV_BLOCK_SIZE_TOKENS = 16
 
 
 class PrometheusClient:
@@ -443,6 +466,38 @@ def validate_rank_identity(workers_by_pod: dict[str, WorkerInfo], ranks: list[Ra
             worker.ttft_target_ms = float(target)
 
 
+def kv_pressure_score(
+    running: float | None,
+    waiting: float | None,
+    avg_prompt_tokens: float | None,
+    avg_requested_tokens: float | None,
+    kv_total_blocks: float | None,
+    block_size: int = KV_BLOCK_SIZE_TOKENS,
+) -> float | None:
+    """Requested KV demand over engine KV capacity, in block units.
+
+    Mirrors LLMServingSim ``Scheduler.get_kv_pressure_score``: every waiting or
+    running request is charged its full requested final context length,
+    block-rounded, against total KV capacity. Fleet-average lengths stand in
+    for per-request lengths, which Prometheus cannot see.
+    """
+    if running is None or waiting is None:
+        return None
+    if not kv_total_blocks or kv_total_blocks <= 0:
+        return None
+    requests = max(0.0, running) + max(0.0, waiting)
+    if requests == 0:
+        return 0.0
+    if avg_prompt_tokens is None or avg_requested_tokens is None:
+        return None
+    requested_ctx = max(0.0, avg_prompt_tokens) + max(0.0, avg_requested_tokens)
+    blocks_per_request = math.ceil(requested_ctx / block_size)
+    return requests * blocks_per_request / kv_total_blocks
+
+
+_warned_missing_kv_capacity = False
+
+
 def _worker_inference_values(
     prom: PrometheusClient,
     worker: WorkerInfo,
@@ -460,6 +515,31 @@ def _worker_inference_values(
         field: prom.query_scalar(query.format(worker=selector))
         for field, query in WORKER_QUERIES.items()
     }
+
+    aux = {
+        field: prom.query_scalar(query.format(worker=selector))
+        for field, query in AUX_WORKER_QUERIES.items()
+    }
+    if aux["kv_total_blocks"] is None:
+        global _warned_missing_kv_capacity
+        if not _warned_missing_kv_capacity:
+            _warned_missing_kv_capacity = True
+            logger.warning(
+                "dynamo_component_total_blocks returned no data; "
+                "kv_pressure_score will be None until the worker exports KvStats"
+            )
+    requested = aux["requested_max_tokens"]
+    if requested is None:
+        # Engines without request_params_max_tokens: fall back to observed
+        # generation length (expected demand instead of requested demand).
+        requested = values.get("output_length_observed")
+    values["kv_pressure_score"] = kv_pressure_score(
+        values.get("live_batch_size"),
+        values.get("depth_req_q"),
+        values.get("input_length_observed"),
+        requested,
+        aux["kv_total_blocks"],
+    )
 
     throughput = values.get("throughput_token_per_sec")
     values["cost_per_token"] = (
@@ -566,7 +646,7 @@ def collect_once(
     # reuse one query pass.
     worker_cache: dict[str, dict[str, float | None]] = {}
     none_inference: dict[str, float | None] = dict.fromkeys(
-        [*WORKER_QUERIES, "cost_per_token", "slo_margin"]
+        [*WORKER_QUERIES, "kv_pressure_score", "cost_per_token", "slo_margin"]
     )
 
     targets = prom.gpu_targets()

--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -217,7 +217,9 @@ _LABEL_SUBCOMPONENT = "nvidia.com/dynamo-sub-component-type"
 _LABEL_DISCOVERY = "tandemn.com/pods-discovery"
 _LABEL_JOB = "tandemn.com/job-id"
 _LABEL_RANK = "tandemn.com/rank-id"
-_LABEL_CHAIN = "tandemn.com/chain-id"
+_LABEL_PLAN = "tandemn.com/plan-id"
+_LABEL_PCSG_INDEX = "grove.io/podcliquescalinggroup-replica-index"
+_LABEL_POD_INDEX = "grove.io/podclique-pod-index"
 
 # Node label carrying the EC2 instance type (standard on EKS/Karpenter nodes).
 _NODE_LABEL_INSTANCE_TYPE = "node.kubernetes.io/instance-type"
@@ -228,8 +230,8 @@ class WorkerInfo:
 
     Joined to the node it runs on. ``rank_id`` is the ladder rung the chain
     belongs to (shared across the rank's chains); ``chain_id`` is the serving
-    unit (canonical chains.chain_id after ``assign_canonical_chain_ids``, else
-    the pod name); ``worker_id`` is the pod name, kept internally for the
+    unit (canonical chains.chain_id after ``assign_canonical_chain_ids``);
+    ``worker_id`` is the pod name, kept internally for the
     vLLM ``pod=`` selector but not stored. Per-GPU local ranks are resolved
     separately from the DCGM ``gpu`` index.
     """
@@ -241,9 +243,12 @@ class WorkerInfo:
         node_name: str,
         dynamo_namespace: str | None,
         rank_id: str | None,
-        chain_id: str | None,
         role: str | None,
         job_id: str | None = None,
+        plan_id: str | None = None,
+        replica_index: int | None = None,
+        pod_index: int | None = None,
+        chain_id: str | None = None,
         model_name: str | None = None,
         ttft_target_ms: float | None = None,
     ) -> None:
@@ -254,6 +259,9 @@ class WorkerInfo:
         self.chain_id = chain_id
         self.role = role
         self.job_id = job_id
+        self.plan_id = plan_id
+        self.replica_index = replica_index
+        self.pod_index = pod_index
         self.model_name = model_name
         self.ttft_target_ms = ttft_target_ms
 
@@ -266,6 +274,14 @@ def _model_from_pod(pod: Any) -> str | None:
             if arg == "--model":
                 return str(args[i + 1])
     return None
+
+
+def _index(value: str | None) -> int | None:
+    try:
+        parsed = int(value) if value is not None else -1
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
 
 
 class KubeWorkerIndex:
@@ -310,55 +326,56 @@ class KubeWorkerIndex:
         index: dict[str, WorkerInfo] = {}
         for pod in pods:
             labels = pod.metadata.labels or {}
-            # A chain == a worker; fall back to the pod name when Orca did not
-            # stamp an explicit chain-id label. rank_id/job_id (the tandemn.com
-            # labels) are only known when Orca launched the ladder, else None.
-            chain_id = labels.get(_LABEL_CHAIN) or pod.metadata.name
+            pod_index = _index(labels.get(_LABEL_POD_INDEX))
+            replica_index = _index(labels.get(_LABEL_PCSG_INDEX))
+            if replica_index is None:
+                replica_index = pod_index
             index[pod.metadata.name] = WorkerInfo(
                 worker_id=pod.metadata.name,
                 node_name=pod.spec.node_name or "",
                 dynamo_namespace=labels.get(_LABEL_DYN_NS),
                 rank_id=labels.get(_LABEL_RANK),
-                chain_id=chain_id,
                 role=labels.get(_LABEL_SUBCOMPONENT),
                 job_id=labels.get(_LABEL_JOB),
+                plan_id=labels.get(_LABEL_PLAN),
+                replica_index=replica_index,
+                pod_index=pod_index,
                 model_name=_model_from_pod(pod),
             )
         return index
 
 
 def assign_canonical_chain_ids(workers_by_pod: dict[str, WorkerInfo], chains: list[Chain]) -> None:
-    """Overwrite pod-name chain_ids with canonical ``chains.chain_id`` values.
-
-    Chains within a rank are fungible DP replicas, so any pod<->chain bijection
-    is valid; sorting both sides (pods by name, chain rows by chain_id) makes it
-    deterministic. An explicitly labelled chain_id is kept; pods beyond the
-    rank's chain rows keep the pod-name fallback.
-
-    ponytail: the mapping can reshuffle when the pod set changes (a replaced
-    pod may swap chain_ids with a surviving one); fine while chains are
-    fungible, revisit if chain identity ever needs to survive pod churn.
-    """
-    chains_by_id = {chain.chain_id: chain for chain in chains}
-    chain_rows_by_rank: dict[str | None, list[str]] = {}
+    """Resolve canonical chain IDs from plan, rank, and Grove replica index."""
+    by_slot: dict[tuple[str, str, str, int], Chain | None] = {}
     for chain in chains:
-        rank = chain.shape_json.get("rank_id")
-        chain_rows_by_rank.setdefault(rank, []).append(chain.chain_id)
+        rank_id = chain.shape_json.get("rank_id")
+        replica_index = chain.shape_json.get("replica_index")
+        if (
+            not chain.plan_id
+            or not rank_id
+            or not isinstance(replica_index, int)
+            or isinstance(replica_index, bool)
+            or replica_index < 0
+        ):
+            continue
+        key = (chain.job_id, chain.plan_id, str(rank_id), replica_index)
+        by_slot[key] = None if key in by_slot else chain
 
-    workers_by_rank: dict[str | None, list[WorkerInfo]] = {}
     for worker in workers_by_pod.values():
-        # chain_id != pod name means an explicit tandemn.com/chain-id label.
-        if worker.chain_id == worker.worker_id:
-            workers_by_rank.setdefault(worker.rank_id, []).append(worker)
-
-    for rank, workers in workers_by_rank.items():
-        workers.sort(key=lambda w: w.worker_id)
-        rows = sorted(chain_rows_by_rank.get(rank, []))
-        for worker, chain_id in zip(workers, rows, strict=False):
-            worker.chain_id = chain_id
-            target = chains_by_id[chain_id].shape_json.get("target_p99_ttft_ms")
-            if isinstance(target, (int, float)):
-                worker.ttft_target_ms = float(target)
+        worker.chain_id = None
+        if not worker.job_id or not worker.plan_id or not worker.rank_id:
+            continue
+        if worker.replica_index is None:
+            continue
+        key = (worker.job_id, worker.plan_id, worker.rank_id, worker.replica_index)
+        chain = by_slot.get(key)
+        if chain is None:
+            continue
+        worker.chain_id = chain.chain_id
+        target = chain.shape_json.get("target_p99_ttft_ms")
+        if isinstance(target, (int, float)):
+            worker.ttft_target_ms = float(target)
 
 
 def _worker_inference_values(

--- a/src/tandemn_orca/scripts/submit_job.py
+++ b/src/tandemn_orca/scripts/submit_job.py
@@ -5,7 +5,7 @@ existing jobs and Orca transitions them, but neither creates them. New jobs
 start ``waiting``; Koi's next pass may place them.
 
 ``--spec`` is the job's spec_json. It must carry ``model_id`` -- Koi's ladder
-configs do not, and Orca backfills chain shapes from the job spec.
+configs do not, and Orca backfills rank shapes from the job spec.
 
 Online traffic intent is mutually exclusive. A user may submit either:
 
@@ -111,7 +111,7 @@ def normalize_job_spec(spec: dict[str, Any], kind: JobKind) -> dict[str, Any]:
     """Return canonical spec_json with Koi's user-owned X defaults."""
     model_id = spec.get("model_id")
     if not model_id:
-        raise SystemExit("--spec must include model_id (Orca backfills chain shapes from it)")
+        raise SystemExit("--spec must include model_id (Orca backfills rank shapes from it)")
 
     provided_request_rate = _has_any_user_key(spec, REQUEST_RATE_KEYS)
     provided_concurrency = _has_any_user_key(spec, CONCURRENCY_KEYS)
@@ -121,7 +121,7 @@ def normalize_job_spec(spec: dict[str, Any], kind: JobKind) -> dict[str, Any]:
             "concurrency/max_concurrent_streaming"
         )
 
-    features = dict(WORKLOAD_DEFAULTS)
+    features: dict[str, Any] = dict(WORKLOAD_DEFAULTS)
     if isinstance(spec.get("job_features"), dict):
         features.update(_canonical_user_features(spec["job_features"]))
     features.update(_canonical_user_features(spec))

--- a/src/tandemn_orca/tunnels.py
+++ b/src/tandemn_orca/tunnels.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import atexit
+import logging
+import subprocess
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TunnelSpec:
+    job_id: str
+    rank_id: str
+    context: str | None
+    namespace: str
+    service: str
+    local_port: int
+
+
+class PortForwardManager:
+    """Keep desired kubectl port-forwards alive on the control-plane laptop."""
+
+    def __init__(self, *, retry_seconds: float = 2.0, popen: Any = subprocess.Popen) -> None:
+        self.retry_seconds = retry_seconds
+        self.popen = popen
+        self._desired: dict[tuple[str, str], TunnelSpec] = {}
+        self._processes: dict[tuple[str, str], Any] = {}
+        self._lock = threading.Lock()
+        self._wake = threading.Event()
+        self._stopped = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="router-tunnels")
+        self._thread.start()
+        atexit.register(self.close)
+
+    def reconcile(self, job_id: str, specs: list[TunnelSpec]) -> None:
+        desired = {(spec.job_id, spec.rank_id): spec for spec in specs}
+        with self._lock:
+            stale = [key for key in self._desired if key[0] == job_id and key not in desired]
+            for key in stale:
+                self._desired.pop(key, None)
+                self._stop_process(key)
+            self._desired.update(desired)
+        self._wake.set()
+
+    def close(self) -> None:
+        if self._stopped.is_set():
+            return
+        self._stopped.set()
+        self._wake.set()
+        with self._lock:
+            for key in list(self._processes):
+                self._stop_process(key)
+        if threading.current_thread() is not self._thread:
+            self._thread.join(timeout=2)
+
+    def _run(self) -> None:
+        while not self._stopped.is_set():
+            with self._lock:
+                for key, spec in self._desired.items():
+                    process = self._processes.get(key)
+                    if process is None or process.poll() is not None:
+                        self._processes[key] = self._start(spec)
+            self._wake.wait(self.retry_seconds)
+            self._wake.clear()
+
+    def _start(self, spec: TunnelSpec) -> Any:
+        command = ["kubectl"]
+        if spec.context:
+            command.extend(["--context", spec.context])
+        command.extend(
+            [
+                "--namespace",
+                spec.namespace,
+                "port-forward",
+                f"service/{spec.service}",
+                f"{spec.local_port}:8000",
+                "--address",
+                "127.0.0.1",
+            ]
+        )
+        logger.info("starting router tunnel for rank %s on port %s", spec.rank_id, spec.local_port)
+        return self.popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def _stop_process(self, key: tuple[str, str]) -> None:
+        process = self._processes.pop(key, None)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()

--- a/src/tandemn_orca/tunnels.py
+++ b/src/tandemn_orca/tunnels.py
@@ -20,23 +20,42 @@ class TunnelSpec:
     local_port: int
 
 
-class PortForwardManager:
-    """Keep desired kubectl port-forwards alive on the control-plane laptop."""
+@dataclass(frozen=True)
+class RouterSpec:
+    job_id: str
+    binary: str
+    config_path: str
 
-    def __init__(self, *, retry_seconds: float = 2.0, popen: Any = subprocess.Popen) -> None:
+
+class _ProcessSupervisor:
+    """Keep desired subprocesses alive on the control-plane laptop.
+
+    Subclasses provide the desired-state key space and the command for one
+    spec; the supervisor thread restarts anything that exits.
+    """
+
+    def __init__(
+        self, *, retry_seconds: float = 2.0, popen: Any = subprocess.Popen, thread_name: str
+    ) -> None:
         self.retry_seconds = retry_seconds
         self.popen = popen
-        self._desired: dict[tuple[str, str], TunnelSpec] = {}
-        self._processes: dict[tuple[str, str], Any] = {}
+        self._desired: dict[Any, Any] = {}
+        self._processes: dict[Any, Any] = {}
         self._lock = threading.Lock()
         self._wake = threading.Event()
         self._stopped = threading.Event()
-        self._thread = threading.Thread(target=self._run, daemon=True, name="router-tunnels")
+        self._thread = threading.Thread(target=self._run, daemon=True, name=thread_name)
         self._thread.start()
         atexit.register(self.close)
 
-    def reconcile(self, job_id: str, specs: list[TunnelSpec]) -> None:
-        desired = {(spec.job_id, spec.rank_id): spec for spec in specs}
+    def _command(self, spec: Any) -> list[str]:
+        raise NotImplementedError
+
+    def _describe(self, spec: Any) -> str:
+        raise NotImplementedError
+
+    def _replace_job(self, job_id: str, desired: dict[Any, Any]) -> None:
+        """Swap one job's desired specs; stale keys for that job are stopped."""
         with self._lock:
             stale = [key for key in self._desired if key[0] == job_id and key not in desired]
             for key in stale:
@@ -66,7 +85,46 @@ class PortForwardManager:
             self._wake.wait(self.retry_seconds)
             self._wake.clear()
 
-    def _start(self, spec: TunnelSpec) -> Any:
+    def _start(self, spec: Any) -> Any:
+        logger.info("starting %s", self._describe(spec))
+        return self.popen(self._command(spec), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def _stop_process(self, key: Any) -> None:
+        process = self._processes.pop(key, None)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+class PortForwardManager(_ProcessSupervisor):
+    """Keep desired kubectl port-forwards alive, one per (job, rank)."""
+
+    def __init__(self, *, retry_seconds: float = 2.0, popen: Any = subprocess.Popen) -> None:
+        super().__init__(retry_seconds=retry_seconds, popen=popen, thread_name="router-tunnels")
+
+    def reconcile(self, job_id: str, specs: list[TunnelSpec]) -> None:
+        desired = {(spec.job_id, spec.rank_id): spec for spec in specs}
+        with self._lock:
+            # Rank tunnel ports are hashed per rank with no cross-job
+            # coordination; refuse a port another job already holds so its
+            # router config can never point at this job's DGD.
+            claimed = {
+                other.local_port: key[0] for key, other in self._desired.items() if key[0] != job_id
+            }
+            for spec in specs:
+                owner = claimed.get(spec.local_port)
+                if owner is not None:
+                    raise ValueError(
+                        f"tunnel port {spec.local_port} for job {job_id!r} "
+                        f"is already assigned to job {owner!r}"
+                    )
+        self._replace_job(job_id, desired)
+
+    def _command(self, spec: TunnelSpec) -> list[str]:
         command = ["kubectl"]
         if spec.context:
             command.extend(["--context", spec.context])
@@ -81,15 +139,35 @@ class PortForwardManager:
                 "127.0.0.1",
             ]
         )
-        logger.info("starting router tunnel for rank %s on port %s", spec.rank_id, spec.local_port)
-        return self.popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return command
 
-    def _stop_process(self, key: tuple[str, str]) -> None:
-        process = self._processes.pop(key, None)
-        if process is None or process.poll() is not None:
-            return
-        process.terminate()
-        try:
-            process.wait(timeout=2)
-        except subprocess.TimeoutExpired:
-            process.kill()
+    def _describe(self, spec: TunnelSpec) -> str:
+        return f"router tunnel for rank {spec.rank_id} on port {spec.local_port}"
+
+
+class RouterProcessManager(_ProcessSupervisor):
+    """Keep one tandemn-router process alive per active job.
+
+    The router binds the listen_port rendered into its config and reads
+    TANDEMN_ROUTER_TELEMETRY_TOKEN from the inherited environment.
+    """
+
+    def __init__(
+        self, binary: str, *, retry_seconds: float = 2.0, popen: Any = subprocess.Popen
+    ) -> None:
+        self.binary = binary
+        super().__init__(retry_seconds=retry_seconds, popen=popen, thread_name="job-routers")
+
+    def reconcile(self, job_id: str, config_path: str | None) -> None:
+        desired: dict[Any, Any] = {}
+        if config_path is not None:
+            desired[(job_id,)] = RouterSpec(
+                job_id=job_id, binary=self.binary, config_path=config_path
+            )
+        self._replace_job(job_id, desired)
+
+    def _command(self, spec: RouterSpec) -> list[str]:
+        return [spec.binary, "-config", spec.config_path]
+
+    def _describe(self, spec: RouterSpec) -> str:
+        return f"router process for job {spec.job_id}"

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -166,14 +166,9 @@ def test_one_rank_compiles_to_one_pool_with_replica_budget():
 
 def test_router_configmap_matches_router_json_contract():
     rank = _rank("g6e.12xlarge", "L40S")
-    rank.shape_json.update(
-        {
-            "router_endpoint": "https://rank.example.internal",
-            "maximum_requests": 64,
-        }
-    )
+    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
 
-    configmap = render_router_configmap("job_online_001", [rank], "routing")
+    configmap = render_router_configmap("job_online_001", [rank], {rank.rank_id: 256}, "routing")
     config = json.loads(configmap["data"]["router.json"])
 
     assert configmap["metadata"]["namespace"] == "routing"
@@ -188,7 +183,8 @@ def test_router_configmap_matches_router_json_contract():
                 "endpoint": "https://rank.example.internal",
                 "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
                 "enabled": True,
-                "maximum_requests": 64,
+                "max_num_seq": 256,
+                "maximum_requests": 256,
             }
         ],
     }
@@ -196,15 +192,14 @@ def test_router_configmap_matches_router_json_contract():
 
 def test_router_objects_mount_config_and_expose_service():
     rank = _rank("g6e.12xlarge", "L40S")
-    rank.shape_json.update(
-        {
-            "router_endpoint": "https://rank.example.internal",
-            "maximum_requests": 64,
-        }
-    )
+    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
 
     configmap, deployment, service = render_router_objects(
-        "job_online_001", [rank], "registry.example/tandemn-router:test", "routing"
+        "job_online_001",
+        [rank],
+        {rank.rank_id: 256},
+        "registry.example/tandemn-router:test",
+        "routing",
     )
 
     assert configmap["metadata"]["name"] == "tdm-online-001-router-config"

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -92,6 +92,7 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
         expected = {
             "tandemn.com/job-id": "job_online_001",
             "tandemn.com/rank-id": "rank_0",
+            "tandemn.com/plan-id": "plan_1",
         }
         if service_name == "VllmDecodeWorker":
             expected["tandemn.com/pods-discovery"] = "dynamo-worker"

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -11,8 +11,7 @@ from tandemn_orca.dynamo_compiler import (
     node_selector,
     pool_key,
     render_rank_dgd,
-    render_router_configmap,
-    render_router_objects,
+    render_router_config,
     worker_args,
 )
 
@@ -164,14 +163,13 @@ def test_one_rank_compiles_to_one_pool_with_replica_budget():
     assert "pool_key" not in planner_config
 
 
-def test_router_configmap_matches_router_json_contract():
+def test_local_router_config_matches_router_json_contract():
     rank = _rank("g6e.12xlarge", "L40S")
 
-    configmap = render_router_configmap("job_online_001", [rank], {rank.rank_id: 256}, "routing")
-    config = json.loads(configmap["data"]["router.json"])
+    config = render_router_config(
+        "job_online_001", [rank], {rank.rank_id: 256}, {rank.rank_id: 18042}
+    )
 
-    assert configmap["metadata"]["namespace"] == "routing"
-    assert configmap["metadata"]["labels"]["tandemn.com/job-id"] == "job_online_001"
     assert config == {
         "version": "plan_1",
         "job_id": "job_online_001",
@@ -180,7 +178,7 @@ def test_router_configmap_matches_router_json_contract():
             {
                 "id": "tdm-online-001-03a2a00c",
                 "rank_id": rank.rank_id,
-                "endpoint": "http://tdm-online-001-03a2a00c-frontend.routing.svc.cluster.local:8000",
+                "endpoint": "http://127.0.0.1:18042",
                 "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
                 "enabled": True,
                 "max_num_seq": 256,
@@ -188,34 +186,6 @@ def test_router_configmap_matches_router_json_contract():
             }
         ],
     }
-
-
-def test_router_objects_mount_config_and_expose_service():
-    rank = _rank("g6e.12xlarge", "L40S")
-
-    configmap, deployment, service = render_router_objects(
-        "job_online_001",
-        [rank],
-        {rank.rank_id: 256},
-        "registry.example/tandemn-router:test",
-        "routing",
-    )
-
-    assert configmap["metadata"]["name"] == "tdm-online-001-router-config"
-    container = deployment["spec"]["template"]["spec"]["containers"][0]
-    assert container["image"] == "registry.example/tandemn-router:test"
-    assert container["readinessProbe"]["httpGet"]["path"] == "/readyz"
-    assert container["env"][0]["valueFrom"]["secretKeyRef"] == {
-        "name": "tandemn-router-telemetry",
-        "key": "token",
-    }
-    assert container["volumeMounts"] == [
-        {"name": "config", "mountPath": "/config", "readOnly": True}
-    ]
-    assert deployment["spec"]["template"]["spec"]["volumes"] == [
-        {"name": "config", "configMap": {"name": "tdm-online-001-router-config"}}
-    ]
-    assert service["spec"]["ports"] == [{"name": "http", "port": 80, "targetPort": "http"}]
 
 
 def test_rank_id_pools_per_rung():

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -185,6 +185,7 @@ def test_local_router_config_matches_router_json_contract():
                 "enabled": True,
                 "max_num_seq": 256,
                 "maximum_requests": 256,
+                "max_replicas": 1,
             }
         ],
     }

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -3,26 +3,39 @@ from __future__ import annotations
 import json
 
 import pytest
-from tandemn_system_data.models.chain import Chain
-from tandemn_system_data.models.enums import ChainRole
+from tandemn_system_data.models.enums import RankRole
+from tandemn_system_data.models.rank import Rank
 
 from tandemn_orca.dynamo_compiler import (
     compile_job,
-    group_chains,
     node_selector,
     pool_key,
-    render_pool_dgd,
+    render_rank_dgd,
+    render_router_configmap,
+    render_router_objects,
     worker_args,
 )
 
+RANK_IDS = [
+    "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T",
+    "rank_01JBM30YQ7X3WQAR6HF8C2Q9T8",
+    "rank_01JBM31YQ7X3WQAR6HF8C2Q9T8",
+]
 
-def _chain(
-    instance_type: str, gpu_type: str, plan_id: str = "plan_1", rank_id: str = "rank_0"
-) -> Chain:
-    return Chain(
+
+def _rank(
+    instance_type: str,
+    gpu_type: str,
+    plan_id: str = "plan_1",
+    rank_id: str = RANK_IDS[0],
+    n_replicas: int = 1,
+) -> Rank:
+    return Rank(
+        rank_id=rank_id,
         job_id="job_online_001",
         plan_id=plan_id,
-        role=ChainRole.AGGREGATE,
+        role=RankRole.AGGREGATE,
+        n_replicas=n_replicas,
         shape_json={
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "engine_name": "vllm",
@@ -30,7 +43,6 @@ def _chain(
             "gpu_type": gpu_type,
             "gpu_count": 1,
             "count": 1,
-            "rank_id": rank_id,
             "target_p99_ttft_ms": 500.0,
             "target_p99_tpot_ms": 50.0,
             "tp": 1,
@@ -59,20 +71,18 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
     objects = compile_job(
         "job_online_001",
         [
-            _chain("p5.48xlarge", "H100", rank_id="rank_0"),
-            _chain("g6e.12xlarge", "L40S", rank_id="rank_1"),
-            _chain("g5.4xlarge", "A10", rank_id="rank_2"),
+            _rank("p5.48xlarge", "H100", rank_id=RANK_IDS[0]),
+            _rank("g6e.12xlarge", "L40S", rank_id=RANK_IDS[1]),
+            _rank("g5.4xlarge", "A10", rank_id=RANK_IDS[2]),
         ],
     )
     by_name = _objects_by_name(objects)
 
-    assert list(by_name) == [
-        "tdm-online-001-rank-0",
-        "tdm-online-001-rank-1",
-        "tdm-online-001-rank-2",
-    ]
+    assert len(by_name) == 3
 
-    h100 = by_name["tdm-online-001-rank-0"]
+    h100 = next(
+        obj for obj in objects if obj["metadata"]["labels"]["tandemn.com/rank-id"] == RANK_IDS[0]
+    )
     assert list(h100["spec"]["services"]) == [
         "Frontend",
         "LocalRouter",
@@ -87,11 +97,11 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
         "meta-llama/Llama-3.1-8B-Instruct",
     ]
     assert h100["metadata"]["labels"]["tandemn.com/job-id"] == "job_online_001"
-    assert h100["metadata"]["labels"]["tandemn.com/rank-id"] == "rank_0"
+    assert h100["metadata"]["labels"]["tandemn.com/rank-id"] == RANK_IDS[0]
     for service_name, service in h100["spec"]["services"].items():
         expected = {
             "tandemn.com/job-id": "job_online_001",
-            "tandemn.com/rank-id": "rank_0",
+            "tandemn.com/rank-id": RANK_IDS[0],
             "tandemn.com/plan-id": "plan_1",
         }
         if service_name == "VllmDecodeWorker":
@@ -129,14 +139,12 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
     ]
 
 
-def test_duplicate_chains_compile_to_one_pool_with_max_budget():
-    objects = compile_job("job_online_001", [_chain("g6e.12xlarge", "L40S") for _ in range(3)])
+def test_one_rank_compiles_to_one_pool_with_replica_budget():
+    objects = compile_job("job_online_001", [_rank("g6e.12xlarge", "L40S", n_replicas=3)])
     by_name = _objects_by_name(objects)
 
-    assert list(by_name) == [
-        "tdm-online-001-rank-0",
-    ]
-    pool = by_name["tdm-online-001-rank-0"]
+    assert len(by_name) == 1
+    pool = next(iter(by_name.values()))
     planner = pool["spec"]["services"]["Planner"]
     planner_config = json.loads(planner["extraPodSpec"]["mainContainer"]["args"][1])
 
@@ -156,28 +164,78 @@ def test_duplicate_chains_compile_to_one_pool_with_max_budget():
     assert "pool_key" not in planner_config
 
 
+def test_router_configmap_matches_router_json_contract():
+    rank = _rank("g6e.12xlarge", "L40S")
+    rank.shape_json.update(
+        {
+            "router_endpoint": "https://rank.example.internal",
+            "maximum_requests": 64,
+        }
+    )
+
+    configmap = render_router_configmap("job_online_001", [rank], "routing")
+    config = json.loads(configmap["data"]["router.json"])
+
+    assert configmap["metadata"]["namespace"] == "routing"
+    assert configmap["metadata"]["labels"]["tandemn.com/job-id"] == "job_online_001"
+    assert config == {
+        "version": "plan_1",
+        "job_id": "job_online_001",
+        "overflow_threshold": 0.8,
+        "deployments": [
+            {
+                "id": "tdm-online-001-03a2a00c",
+                "endpoint": "https://rank.example.internal",
+                "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
+                "enabled": True,
+                "maximum_requests": 64,
+            }
+        ],
+    }
+
+
+def test_router_objects_mount_config_and_expose_service():
+    rank = _rank("g6e.12xlarge", "L40S")
+    rank.shape_json.update(
+        {
+            "router_endpoint": "https://rank.example.internal",
+            "maximum_requests": 64,
+        }
+    )
+
+    configmap, deployment, service = render_router_objects(
+        "job_online_001", [rank], "registry.example/tandemn-router:test", "routing"
+    )
+
+    assert configmap["metadata"]["name"] == "tdm-online-001-router-config"
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "registry.example/tandemn-router:test"
+    assert container["volumeMounts"] == [
+        {"name": "config", "mountPath": "/config", "readOnly": True}
+    ]
+    assert deployment["spec"]["template"]["spec"]["volumes"] == [
+        {"name": "config", "configMap": {"name": "tdm-online-001-router-config"}}
+    ]
+    assert service["spec"]["ports"] == [{"name": "http", "port": 80, "targetPort": "http"}]
+
+
 def test_rank_id_pools_per_rung():
-    first = _chain("g6e.12xlarge", "L40S")
-    second = _chain("g6e.12xlarge", "L40S")
-    first.shape_json["rank_id"] = "rank_0"
-    second.shape_json["rank_id"] = "rank_1"
+    first = _rank("g6e.12xlarge", "L40S", rank_id=RANK_IDS[0])
+    second = _rank("g6e.12xlarge", "L40S", rank_id=RANK_IDS[1])
 
     objects = compile_job("job_online_001", [first, second])
     by_name = _objects_by_name(objects)
 
     # Same-shape rungs stay separate pools when rank_id is present.
-    assert list(by_name) == [
-        "tdm-online-001-rank-0",
-        "tdm-online-001-rank-1",
-    ]
+    assert len(by_name) == 2
 
 
-def test_compile_job_requires_rank_id():
-    chain = _chain("g6e.12xlarge", "L40S")
-    del chain.shape_json["rank_id"]
-
-    with pytest.raises(ValueError, match="rank_id"):
-        compile_job("job_online_001", [chain])
+def test_compile_job_rejects_duplicate_rank_ids():
+    with pytest.raises(ValueError, match="duplicate rank_id"):
+        compile_job(
+            "job_online_001",
+            [_rank("g6e.12xlarge", "L40S"), _rank("g6e.12xlarge", "L40S")],
+        )
 
 
 def test_worker_args_maps_tp_and_pp():
@@ -194,19 +252,18 @@ def test_worker_args_omits_pp_when_absent():
     assert "--pipeline-parallel-size" not in args
 
 
-def test_pool_key_and_selector_are_from_chain_shape():
-    chain = _chain("g5.4xlarge", "A10")
+def test_pool_key_and_selector_are_from_rank_shape():
+    rank = _rank("g5.4xlarge", "A10")
 
-    assert pool_key(chain) == "rank-0-g5-4xlarge-a10"
-    assert list(group_chains([chain])) == ["rank-0-g5-4xlarge-a10"]
-    assert node_selector(chain.shape_json) == {
+    assert pool_key(rank) == f"{RANK_IDS[0].replace('_', '-')}-g5-4xlarge-a10".lower()
+    assert node_selector(rank.shape_json) == {
         "node.kubernetes.io/instance-type": "g5.4xlarge",
         "karpenter.sh/capacity-type": "reserved",
     }
 
 
 def test_worker_args_adds_quantization_and_spec_decoding_flags():
-    shape = dict(_chain("p5.48xlarge", "H100").shape_json)
+    shape = dict(_rank("p5.48xlarge", "H100").shape_json)
     shape.update(
         {
             "weight_quantization_method": "awq",
@@ -227,19 +284,19 @@ def test_worker_args_adds_quantization_and_spec_decoding_flags():
     assert args[args.index("--spec-tokens") + 1] == "4"
 
 
-def test_single_node_chain_has_no_multinode_block():
-    chain = _chain("g6.xlarge", "L4")
-    dgd = render_pool_dgd("job_1", pool_key(chain), [chain], "default")
+def test_single_node_rank_has_no_multinode_block():
+    rank = _rank("g6.xlarge", "L4")
+    dgd = render_rank_dgd("job_1", rank, "default")
     worker = dgd["spec"]["services"]["VllmDecodeWorker"]
 
     assert "multinode" not in worker
     assert worker["resources"] == {"requests": {"gpu": "1"}, "limits": {"gpu": "1"}}
 
 
-def test_multinode_chain_splits_gpus_per_node():
-    chain = _chain("g6.xlarge", "L4")
-    chain.shape_json.update({"count": 2, "node_count": 2, "tp": 1, "pp": 2})
-    dgd = render_pool_dgd("job_1", pool_key(chain), [chain], "default")
+def test_multinode_rank_splits_gpus_per_node():
+    rank = _rank("g6.xlarge", "L4")
+    rank.shape_json.update({"count": 2, "node_count": 2, "tp": 1, "pp": 2})
+    dgd = render_rank_dgd("job_1", rank, "default")
     worker = dgd["spec"]["services"]["VllmDecodeWorker"]
 
     assert worker["multinode"] == {"nodeCount": 2}
@@ -250,7 +307,7 @@ def test_multinode_chain_splits_gpus_per_node():
 
 
 def test_multinode_uneven_gpu_split_raises():
-    chain = _chain("g6.xlarge", "L4")
-    chain.shape_json.update({"count": 3, "node_count": 2})
+    rank = _rank("g6.xlarge", "L4")
+    rank.shape_json.update({"count": 3, "node_count": 2})
     with pytest.raises(ValueError, match="does not divide evenly"):
-        render_pool_dgd("job_1", pool_key(chain), [chain], "default")
+        render_rank_dgd("job_1", rank, "default")

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -12,6 +12,7 @@ from tandemn_orca.dynamo_compiler import (
     pool_key,
     render_rank_dgd,
     render_router_config,
+    router_listen_port,
     worker_args,
 )
 
@@ -173,6 +174,7 @@ def test_local_router_config_matches_router_json_contract():
     assert config == {
         "version": "plan_1",
         "job_id": "job_online_001",
+        "listen_port": router_listen_port("job_online_001"),
         "overflow_threshold": 0.8,
         "deployments": [
             {

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -16,7 +16,9 @@ from tandemn_orca.dynamo_compiler import (
 )
 
 
-def _chain(instance_type: str, gpu_type: str, plan_id: str = "plan_1") -> Chain:
+def _chain(
+    instance_type: str, gpu_type: str, plan_id: str = "plan_1", rank_id: str = "rank_0"
+) -> Chain:
     return Chain(
         job_id="job_online_001",
         plan_id=plan_id,
@@ -28,6 +30,7 @@ def _chain(instance_type: str, gpu_type: str, plan_id: str = "plan_1") -> Chain:
             "gpu_type": gpu_type,
             "gpu_count": 1,
             "count": 1,
+            "rank_id": rank_id,
             "target_p99_ttft_ms": 500.0,
             "target_p99_tpot_ms": 50.0,
             "tp": 1,
@@ -56,20 +59,20 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
     objects = compile_job(
         "job_online_001",
         [
-            _chain("p5.48xlarge", "H100"),
-            _chain("g6e.12xlarge", "L40S"),
-            _chain("g5.4xlarge", "A10"),
+            _chain("p5.48xlarge", "H100", rank_id="rank_0"),
+            _chain("g6e.12xlarge", "L40S", rank_id="rank_1"),
+            _chain("g5.4xlarge", "A10", rank_id="rank_2"),
         ],
     )
     by_name = _objects_by_name(objects)
 
     assert list(by_name) == [
-        "tdm-online-001-c1c7dc72",
-        "tdm-online-001-0dfb3ae9",
-        "tdm-online-001-9a5f4df3",
+        "tdm-online-001-rank-0",
+        "tdm-online-001-rank-1",
+        "tdm-online-001-rank-2",
     ]
 
-    h100 = by_name["tdm-online-001-c1c7dc72"]
+    h100 = by_name["tdm-online-001-rank-0"]
     assert list(h100["spec"]["services"]) == [
         "Frontend",
         "LocalRouter",
@@ -83,6 +86,16 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
         "--model-name",
         "meta-llama/Llama-3.1-8B-Instruct",
     ]
+    assert h100["metadata"]["labels"]["tandemn.com/job-id"] == "job_online_001"
+    assert h100["metadata"]["labels"]["tandemn.com/rank-id"] == "rank_0"
+    for service_name, service in h100["spec"]["services"].items():
+        expected = {
+            "tandemn.com/job-id": "job_online_001",
+            "tandemn.com/rank-id": "rank_0",
+        }
+        if service_name == "VllmDecodeWorker":
+            expected["tandemn.com/pods-discovery"] = "dynamo-worker"
+        assert service["extraPodMetadata"] == {"labels": expected}
     worker = h100["spec"]["services"]["VllmDecodeWorker"]
     assert worker["extraPodSpec"]["nodeSelector"] == {
         "node.kubernetes.io/instance-type": "p5.48xlarge",
@@ -120,9 +133,9 @@ def test_duplicate_chains_compile_to_one_pool_with_max_budget():
     by_name = _objects_by_name(objects)
 
     assert list(by_name) == [
-        "tdm-online-001-0dfb3ae9",
+        "tdm-online-001-rank-0",
     ]
-    pool = by_name["tdm-online-001-0dfb3ae9"]
+    pool = by_name["tdm-online-001-rank-0"]
     planner = pool["spec"]["services"]["Planner"]
     planner_config = json.loads(planner["extraPodSpec"]["mainContainer"]["args"][1])
 
@@ -142,7 +155,7 @@ def test_duplicate_chains_compile_to_one_pool_with_max_budget():
     assert "pool_key" not in planner_config
 
 
-def test_rank_id_pools_per_rung_and_labels_worker_pods():
+def test_rank_id_pools_per_rung():
     first = _chain("g6e.12xlarge", "L40S")
     second = _chain("g6e.12xlarge", "L40S")
     first.shape_json["rank_id"] = "rank_0"
@@ -156,10 +169,14 @@ def test_rank_id_pools_per_rung_and_labels_worker_pods():
         "tdm-online-001-rank-0",
         "tdm-online-001-rank-1",
     ]
-    worker = by_name["tdm-online-001-rank-0"]["spec"]["services"]["VllmDecodeWorker"]
-    assert worker["extraPodMetadata"] == {
-        "labels": {"tandemn.ai/job-id": "job_online_001", "tandemn.ai/rank-id": "rank_0"}
-    }
+
+
+def test_compile_job_requires_rank_id():
+    chain = _chain("g6e.12xlarge", "L40S")
+    del chain.shape_json["rank_id"]
+
+    with pytest.raises(ValueError, match="rank_id"):
+        compile_job("job_online_001", [chain])
 
 
 def test_worker_args_maps_tp_and_pp():
@@ -179,8 +196,8 @@ def test_worker_args_omits_pp_when_absent():
 def test_pool_key_and_selector_are_from_chain_shape():
     chain = _chain("g5.4xlarge", "A10")
 
-    assert pool_key(chain) == "aggregate-g5-4xlarge-a10"
-    assert list(group_chains([chain])) == ["aggregate-g5-4xlarge-a10"]
+    assert pool_key(chain) == "rank-0-g5-4xlarge-a10"
+    assert list(group_chains([chain])) == ["rank-0-g5-4xlarge-a10"]
     assert node_selector(chain.shape_json) == {
         "node.kubernetes.io/instance-type": "g5.4xlarge",
         "karpenter.sh/capacity-type": "reserved",

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -166,7 +166,6 @@ def test_one_rank_compiles_to_one_pool_with_replica_budget():
 
 def test_router_configmap_matches_router_json_contract():
     rank = _rank("g6e.12xlarge", "L40S")
-    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
 
     configmap = render_router_configmap("job_online_001", [rank], {rank.rank_id: 256}, "routing")
     config = json.loads(configmap["data"]["router.json"])
@@ -181,7 +180,7 @@ def test_router_configmap_matches_router_json_contract():
             {
                 "id": "tdm-online-001-03a2a00c",
                 "rank_id": rank.rank_id,
-                "endpoint": "https://rank.example.internal",
+                "endpoint": "http://tdm-online-001-03a2a00c-frontend.routing.svc.cluster.local:8000",
                 "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
                 "enabled": True,
                 "max_num_seq": 256,
@@ -193,7 +192,6 @@ def test_router_configmap_matches_router_json_contract():
 
 def test_router_objects_mount_config_and_expose_service():
     rank = _rank("g6e.12xlarge", "L40S")
-    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
 
     configmap, deployment, service = render_router_objects(
         "job_online_001",

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -180,6 +180,7 @@ def test_router_configmap_matches_router_json_contract():
         "deployments": [
             {
                 "id": "tdm-online-001-03a2a00c",
+                "rank_id": rank.rank_id,
                 "endpoint": "https://rank.example.internal",
                 "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
                 "enabled": True,
@@ -205,6 +206,11 @@ def test_router_objects_mount_config_and_expose_service():
     assert configmap["metadata"]["name"] == "tdm-online-001-router-config"
     container = deployment["spec"]["template"]["spec"]["containers"][0]
     assert container["image"] == "registry.example/tandemn-router:test"
+    assert container["readinessProbe"]["httpGet"]["path"] == "/readyz"
+    assert container["env"][0]["valueFrom"]["secretKeyRef"] == {
+        "name": "tandemn-router-telemetry",
+        "key": "token",
+    }
     assert container["volumeMounts"] == [
         {"name": "config", "mountPath": "/config", "readOnly": True}
     ]

--- a/tests/test_dynamo_kubernetes.py
+++ b/tests/test_dynamo_kubernetes.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 from kubernetes.client.rest import ApiException
 
 from tandemn_orca.dynamo_kubernetes import (
@@ -17,50 +15,12 @@ from tandemn_orca.dynamo_kubernetes import (
 )
 
 
-def _configmap(name: str = "router-config") -> dict:
-    return {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": name}}
-
-
 def _dgd(name: str = "pool") -> dict:
     return {
         "apiVersion": "nvidia.com/v1alpha1",
         "kind": "DynamoGraphDeployment",
         "metadata": {"name": name},
     }
-
-
-def _deployment(name: str = "router") -> dict:
-    return {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": name}}
-
-
-def _service(name: str = "router") -> dict:
-    return {"apiVersion": "v1", "kind": "Service", "metadata": {"name": name}}
-
-
-class FakeCore:
-    def __init__(self) -> None:
-        self.applied: list[tuple] = []
-        self.deleted: list[tuple] = []
-
-    def list_namespaced_config_map(self, namespace, label_selector):
-        self.configmap_selector = (namespace, label_selector)
-        return SimpleNamespace(items=[SimpleNamespace(metadata=SimpleNamespace(name="cm"))])
-
-    def list_namespaced_service(self, namespace, label_selector):
-        self.service_selector = (namespace, label_selector)
-        return SimpleNamespace(items=[SimpleNamespace(metadata=SimpleNamespace(name="svc"))])
-
-    def patch_namespaced_config_map(self, *args, **kwargs):
-        self.applied.append((args, kwargs))
-
-    def delete_namespaced_config_map(self, *args):
-        self.deleted.append(args)
-
-    def patch_namespaced_service(self, *args, **kwargs):
-        self.applied.append((args, kwargs))
-
-    def delete_namespaced_service(self, *args):
-        self.deleted.append(args)
 
 
 class FakeCustom:
@@ -79,114 +39,50 @@ class FakeCustom:
         self.deleted.append(args)
 
 
-class FakeApps:
-    def __init__(self) -> None:
-        self.applied: list[tuple] = []
-        self.deleted: list[tuple] = []
-
-    def patch_namespaced_deployment(self, *args, **kwargs):
-        self.applied.append((args, kwargs))
-
-    def list_namespaced_deployment(self, namespace, label_selector):
-        self.selector = (namespace, label_selector)
-        return SimpleNamespace(items=[SimpleNamespace(metadata=SimpleNamespace(name="deploy"))])
-
-    def delete_namespaced_deployment(self, *args):
-        self.deleted.append(args)
-
-
 def test_object_key_and_selector():
     assert object_key(_dgd("x")) == ("DynamoGraphDeployment", "x")
     assert job_selector("job_1") == "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1"
 
 
-def test_list_job_objects_reads_all_managed_resources():
-    core = FakeCore()
+def test_list_job_objects_reads_dgds():
     custom = FakeCustom()
-    apps = FakeApps()
-    client = DynamoKubernetesClient("ns", core=core, custom=custom, apps=apps)
+    client = DynamoKubernetesClient("ns", custom=custom)
 
-    assert client.list_job_objects("job_1") == {
-        ("ConfigMap", "cm"),
-        ("Service", "svc"),
-        ("Deployment", "deploy"),
-        ("DynamoGraphDeployment", "dgd"),
-    }
-    selector = ("ns", "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1")
-    assert core.configmap_selector == selector
-    assert core.service_selector == selector
-    assert apps.selector == selector
+    assert client.list_job_objects("job_1") == {("DynamoGraphDeployment", "dgd")}
     assert custom.selector == (
         (GROUP, VERSION, "ns", DGD_PLURAL),
         {"label_selector": "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1"},
     )
 
 
-def test_apply_many_uses_server_side_apply_for_supported_objects():
-    core = FakeCore()
+def test_apply_many_uses_server_side_apply():
     custom = FakeCustom()
-    apps = FakeApps()
-    client = DynamoKubernetesClient("ns", core=core, custom=custom, apps=apps)
+    client = DynamoKubernetesClient("ns", custom=custom)
 
-    assert client.apply_many(
-        [_configmap("cm"), _dgd("dgd"), _deployment("router"), _service("router")]
-    ) == {
-        ("ConfigMap", "cm"),
-        ("DynamoGraphDeployment", "dgd"),
-        ("Deployment", "router"),
-        ("Service", "router"),
-    }
-
-    assert core.applied == [
-        (
-            ("cm", "ns", _configmap("cm")),
-            {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
-        ),
-        (
-            ("router", "ns", _service("router")),
-            {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
-        ),
-    ]
+    assert client.apply_many([_dgd("dgd")]) == {("DynamoGraphDeployment", "dgd")}
     assert custom.applied == [
         (
             (GROUP, VERSION, "ns", DGD_PLURAL, "dgd", _dgd("dgd")),
             {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
         )
     ]
-    assert apps.applied == [
-        (
-            ("router", "ns", _deployment("router")),
-            {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
-        )
-    ]
 
 
-def test_delete_many_deletes_supported_objects():
-    core = FakeCore()
+def test_delete_many_deletes_dgds():
     custom = FakeCustom()
-    apps = FakeApps()
-    client = DynamoKubernetesClient("ns", core=core, custom=custom, apps=apps)
+    client = DynamoKubernetesClient("ns", custom=custom)
 
-    client.delete_many(
-        {
-            ("ConfigMap", "cm"),
-            ("DynamoGraphDeployment", "dgd"),
-            ("Deployment", "router"),
-            ("Service", "router"),
-        }
-    )
+    client.delete_many({("DynamoGraphDeployment", "dgd")})
 
-    assert core.deleted == [("cm", "ns"), ("router", "ns")]
     assert custom.deleted == [(GROUP, VERSION, "ns", DGD_PLURAL, "dgd")]
-    assert apps.deleted == [("router", "ns")]
 
 
 def test_delete_ignores_not_found():
-    class MissingCore(FakeCore):
-        def delete_namespaced_config_map(self, *args):
+    class MissingCustom(FakeCustom):
+        def delete_namespaced_custom_object(self, *args):
             raise ApiException(status=404)
 
-    DynamoKubernetesClient("ns", core=MissingCore(), custom=FakeCustom()).delete("ConfigMap", "cm")
+    DynamoKubernetesClient("ns", custom=MissingCustom()).delete("DynamoGraphDeployment", "dgd")
 
 
 def test_load_kube_client_falls_back_to_kubeconfig(monkeypatch):
@@ -203,11 +99,9 @@ def test_load_kube_client_falls_back_to_kubeconfig(monkeypatch):
         "tandemn_orca.dynamo_kubernetes.config.load_kube_config",
         lambda: calls.append("kubeconfig"),
     )
-    monkeypatch.setattr("tandemn_orca.dynamo_kubernetes.client.CoreV1Api", lambda: FakeCore())
     monkeypatch.setattr(
         "tandemn_orca.dynamo_kubernetes.client.CustomObjectsApi", lambda: FakeCustom()
     )
-    monkeypatch.setattr("tandemn_orca.dynamo_kubernetes.client.AppsV1Api", lambda: FakeApps())
 
     loaded = load_kube_client("ns")
 
@@ -222,21 +116,11 @@ def test_load_kube_client_uses_explicit_context(monkeypatch):
         lambda **kwargs: api_client,
     )
     monkeypatch.setattr(
-        "tandemn_orca.dynamo_kubernetes.client.CoreV1Api",
-        lambda loaded: ("core", loaded),
-    )
-    monkeypatch.setattr(
         "tandemn_orca.dynamo_kubernetes.client.CustomObjectsApi",
         lambda loaded: ("custom", loaded),
     )
-    monkeypatch.setattr(
-        "tandemn_orca.dynamo_kubernetes.client.AppsV1Api",
-        lambda loaded: ("apps", loaded),
-    )
 
-    loaded = load_kube_client("routing", "/config/control", "control")
+    loaded = load_kube_client("serving", context="cloud-region")
 
-    assert loaded.namespace == "routing"
-    assert loaded.core == ("core", api_client)
+    assert loaded.namespace == "serving"
     assert loaded.custom == ("custom", api_client)
-    assert loaded.apps == ("apps", api_client)

--- a/tests/test_dynamo_kubernetes.py
+++ b/tests/test_dynamo_kubernetes.py
@@ -63,7 +63,7 @@ class FakeCustom:
 
 def test_object_key_and_selector():
     assert object_key(_dgd("x")) == ("DynamoGraphDeployment", "x")
-    assert job_selector("job_1") == "tandemn.ai/managed-by=orca,tandemn.ai/job-id=job_1"
+    assert job_selector("job_1") == "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1"
 
 
 def test_list_job_objects_reads_configmaps_and_dgds():
@@ -75,10 +75,10 @@ def test_list_job_objects_reads_configmaps_and_dgds():
         ("ConfigMap", "cm"),
         ("DynamoGraphDeployment", "dgd"),
     }
-    assert core.selector == ("ns", "tandemn.ai/managed-by=orca,tandemn.ai/job-id=job_1")
+    assert core.selector == ("ns", "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1")
     assert custom.selector == (
         (GROUP, VERSION, "ns", DGD_PLURAL),
-        {"label_selector": "tandemn.ai/managed-by=orca,tandemn.ai/job-id=job_1"},
+        {"label_selector": "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1"},
     )
 
 

--- a/tests/test_dynamo_kubernetes.py
+++ b/tests/test_dynamo_kubernetes.py
@@ -43,8 +43,12 @@ class FakeCore:
         self.deleted: list[tuple] = []
 
     def list_namespaced_config_map(self, namespace, label_selector):
-        self.selector = (namespace, label_selector)
+        self.configmap_selector = (namespace, label_selector)
         return SimpleNamespace(items=[SimpleNamespace(metadata=SimpleNamespace(name="cm"))])
+
+    def list_namespaced_service(self, namespace, label_selector):
+        self.service_selector = (namespace, label_selector)
+        return SimpleNamespace(items=[SimpleNamespace(metadata=SimpleNamespace(name="svc"))])
 
     def patch_namespaced_config_map(self, *args, **kwargs):
         self.applied.append((args, kwargs))
@@ -83,6 +87,10 @@ class FakeApps:
     def patch_namespaced_deployment(self, *args, **kwargs):
         self.applied.append((args, kwargs))
 
+    def list_namespaced_deployment(self, namespace, label_selector):
+        self.selector = (namespace, label_selector)
+        return SimpleNamespace(items=[SimpleNamespace(metadata=SimpleNamespace(name="deploy"))])
+
     def delete_namespaced_deployment(self, *args):
         self.deleted.append(args)
 
@@ -92,16 +100,22 @@ def test_object_key_and_selector():
     assert job_selector("job_1") == "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1"
 
 
-def test_list_job_objects_reads_configmaps_and_dgds():
+def test_list_job_objects_reads_all_managed_resources():
     core = FakeCore()
     custom = FakeCustom()
-    client = DynamoKubernetesClient("ns", core=core, custom=custom)
+    apps = FakeApps()
+    client = DynamoKubernetesClient("ns", core=core, custom=custom, apps=apps)
 
     assert client.list_job_objects("job_1") == {
         ("ConfigMap", "cm"),
+        ("Service", "svc"),
+        ("Deployment", "deploy"),
         ("DynamoGraphDeployment", "dgd"),
     }
-    assert core.selector == ("ns", "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1")
+    selector = ("ns", "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1")
+    assert core.configmap_selector == selector
+    assert core.service_selector == selector
+    assert apps.selector == selector
     assert custom.selector == (
         (GROUP, VERSION, "ns", DGD_PLURAL),
         {"label_selector": "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1"},

--- a/tests/test_dynamo_kubernetes.py
+++ b/tests/test_dynamo_kubernetes.py
@@ -29,6 +29,14 @@ def _dgd(name: str = "pool") -> dict:
     }
 
 
+def _deployment(name: str = "router") -> dict:
+    return {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": name}}
+
+
+def _service(name: str = "router") -> dict:
+    return {"apiVersion": "v1", "kind": "Service", "metadata": {"name": name}}
+
+
 class FakeCore:
     def __init__(self) -> None:
         self.applied: list[tuple] = []
@@ -42,6 +50,12 @@ class FakeCore:
         self.applied.append((args, kwargs))
 
     def delete_namespaced_config_map(self, *args):
+        self.deleted.append(args)
+
+    def patch_namespaced_service(self, *args, **kwargs):
+        self.applied.append((args, kwargs))
+
+    def delete_namespaced_service(self, *args):
         self.deleted.append(args)
 
 
@@ -58,6 +72,18 @@ class FakeCustom:
         self.applied.append((args, kwargs))
 
     def delete_namespaced_custom_object(self, *args):
+        self.deleted.append(args)
+
+
+class FakeApps:
+    def __init__(self) -> None:
+        self.applied: list[tuple] = []
+        self.deleted: list[tuple] = []
+
+    def patch_namespaced_deployment(self, *args, **kwargs):
+        self.applied.append((args, kwargs))
+
+    def delete_namespaced_deployment(self, *args):
         self.deleted.append(args)
 
 
@@ -85,22 +111,37 @@ def test_list_job_objects_reads_configmaps_and_dgds():
 def test_apply_many_uses_server_side_apply_for_supported_objects():
     core = FakeCore()
     custom = FakeCustom()
-    client = DynamoKubernetesClient("ns", core=core, custom=custom)
+    apps = FakeApps()
+    client = DynamoKubernetesClient("ns", core=core, custom=custom, apps=apps)
 
-    assert client.apply_many([_configmap("cm"), _dgd("dgd")]) == {
+    assert client.apply_many(
+        [_configmap("cm"), _dgd("dgd"), _deployment("router"), _service("router")]
+    ) == {
         ("ConfigMap", "cm"),
         ("DynamoGraphDeployment", "dgd"),
+        ("Deployment", "router"),
+        ("Service", "router"),
     }
 
     assert core.applied == [
         (
             ("cm", "ns", _configmap("cm")),
             {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
-        )
+        ),
+        (
+            ("router", "ns", _service("router")),
+            {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
+        ),
     ]
     assert custom.applied == [
         (
             (GROUP, VERSION, "ns", DGD_PLURAL, "dgd", _dgd("dgd")),
+            {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
+        )
+    ]
+    assert apps.applied == [
+        (
+            ("router", "ns", _deployment("router")),
             {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
         )
     ]
@@ -109,12 +150,21 @@ def test_apply_many_uses_server_side_apply_for_supported_objects():
 def test_delete_many_deletes_supported_objects():
     core = FakeCore()
     custom = FakeCustom()
-    client = DynamoKubernetesClient("ns", core=core, custom=custom)
+    apps = FakeApps()
+    client = DynamoKubernetesClient("ns", core=core, custom=custom, apps=apps)
 
-    client.delete_many({("ConfigMap", "cm"), ("DynamoGraphDeployment", "dgd")})
+    client.delete_many(
+        {
+            ("ConfigMap", "cm"),
+            ("DynamoGraphDeployment", "dgd"),
+            ("Deployment", "router"),
+            ("Service", "router"),
+        }
+    )
 
-    assert core.deleted == [("cm", "ns")]
+    assert core.deleted == [("cm", "ns"), ("router", "ns")]
     assert custom.deleted == [(GROUP, VERSION, "ns", DGD_PLURAL, "dgd")]
+    assert apps.deleted == [("router", "ns")]
 
 
 def test_delete_ignores_not_found():
@@ -143,8 +193,36 @@ def test_load_kube_client_falls_back_to_kubeconfig(monkeypatch):
     monkeypatch.setattr(
         "tandemn_orca.dynamo_kubernetes.client.CustomObjectsApi", lambda: FakeCustom()
     )
+    monkeypatch.setattr("tandemn_orca.dynamo_kubernetes.client.AppsV1Api", lambda: FakeApps())
 
     loaded = load_kube_client("ns")
 
     assert loaded.namespace == "ns"
     assert calls == ["incluster", "kubeconfig"]
+
+
+def test_load_kube_client_uses_explicit_context(monkeypatch):
+    api_client = object()
+    monkeypatch.setattr(
+        "tandemn_orca.dynamo_kubernetes.config.new_client_from_config",
+        lambda **kwargs: api_client,
+    )
+    monkeypatch.setattr(
+        "tandemn_orca.dynamo_kubernetes.client.CoreV1Api",
+        lambda loaded: ("core", loaded),
+    )
+    monkeypatch.setattr(
+        "tandemn_orca.dynamo_kubernetes.client.CustomObjectsApi",
+        lambda loaded: ("custom", loaded),
+    )
+    monkeypatch.setattr(
+        "tandemn_orca.dynamo_kubernetes.client.AppsV1Api",
+        lambda loaded: ("apps", loaded),
+    )
+
+    loaded = load_kube_client("routing", "/config/control", "control")
+
+    assert loaded.namespace == "routing"
+    assert loaded.core == ("core", api_client)
+    assert loaded.custom == ("custom", api_client)
+    assert loaded.apps == ("apps", api_client)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tandemn_orca.dynamo_compiler import (
+    ROUTER_LISTEN_PORT_BASE,
+    ROUTER_LISTEN_PORT_SPAN,
+    router_listen_port,
+)
+from tandemn_orca.scripts.endpoint import resolve_endpoint
+
+
+def test_router_listen_port_is_stable_and_in_range():
+    first = router_listen_port("job_01ABC")
+    assert first == router_listen_port("job_01ABC")
+    assert ROUTER_LISTEN_PORT_BASE <= first < ROUTER_LISTEN_PORT_BASE + ROUTER_LISTEN_PORT_SPAN
+    assert first != router_listen_port("job_01XYZ")
+
+
+def test_resolve_endpoint_reads_listen_port(tmp_path):
+    (tmp_path / "job_1.json").write_text(json.dumps({"job_id": "job_1", "listen_port": 28123}))
+
+    assert resolve_endpoint("job_1", tmp_path) == "http://127.0.0.1:28123"
+
+
+def test_resolve_endpoint_derives_port_for_old_configs(tmp_path):
+    (tmp_path / "job_1.json").write_text(json.dumps({"job_id": "job_1"}))
+
+    assert resolve_endpoint("job_1", tmp_path) == f"http://127.0.0.1:{router_listen_port('job_1')}"
+
+
+def test_resolve_endpoint_fails_without_config(tmp_path):
+    with pytest.raises(SystemExit, match="no router config"):
+        resolve_endpoint("job_missing", tmp_path)
+
+
+def test_resolve_endpoint_rejects_invalid_port(tmp_path):
+    (tmp_path / "job_1.json").write_text(json.dumps({"job_id": "job_1", "listen_port": -5}))
+
+    with pytest.raises(SystemExit, match="invalid listen_port"):
+        resolve_endpoint("job_1", tmp_path)

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -15,29 +15,44 @@ from tandemn_orca.scripts.gpu_metrics_collector import (
 )
 
 
-def test_worker_index_uses_discovery_and_com_identity_labels():
-    pod = SimpleNamespace(
-        metadata=SimpleNamespace(
-            name="worker-1",
-            labels={
-                "tandemn.com/job-id": "job_1",
-                "tandemn.com/rank-id": "rank_0",
-                "tandemn.com/pods-discovery": "dynamo-worker",
+def test_worker_index_uses_single_and_multinode_grove_indexes():
+    def pod(name, labels):
+        return SimpleNamespace(
+            metadata=SimpleNamespace(
+                name=name,
+                labels={
+                    "tandemn.com/job-id": "job_1",
+                    "tandemn.com/rank-id": "rank_0",
+                    "tandemn.com/plan-id": "plan_1",
+                    "tandemn.com/pods-discovery": "dynamo-worker",
+                    **labels,
+                },
+            ),
+            spec=SimpleNamespace(node_name="node-1", containers=[]),
+        )
+
+    pods = [
+        pod("single", {"grove.io/podclique-pod-index": "1"}),
+        pod(
+            "multi",
+            {
+                "grove.io/podcliquescalinggroup-replica-index": "2",
+                "grove.io/podclique-pod-index": "0",
             },
         ),
-        spec=SimpleNamespace(node_name="node-1", containers=[]),
-    )
+    ]
 
     class Core:
         def list_namespaced_pod(self, namespace, label_selector):
             self.query = namespace, label_selector
-            return SimpleNamespace(items=[pod])
+            return SimpleNamespace(items=pods)
 
     core = Core()
-    worker = KubeWorkerIndex(core=core).by_pod()["worker-1"]
+    workers = KubeWorkerIndex(core=core).by_pod()
 
     assert core.query == ("default", "tandemn.com/pods-discovery=dynamo-worker")
-    assert (worker.job_id, worker.rank_id) == ("job_1", "rank_0")
+    assert (workers["single"].plan_id, workers["single"].replica_index) == ("plan_1", 1)
+    assert (workers["multi"].replica_index, workers["multi"].pod_index) == (2, 0)
 
 
 class FakeProm:
@@ -129,54 +144,76 @@ def test_collect_once_attributes_owned_and_unowned_gpus():
     assert idle.cost_per_token is None
 
 
-def _worker(pod: str, rank_id: str | None, chain_id: str | None = None) -> WorkerInfo:
+def _worker(
+    pod: str,
+    replica_index: int | None,
+    *,
+    rank_id: str = "rank_0",
+    plan_id: str = "plan_1",
+) -> WorkerInfo:
     return WorkerInfo(
         worker_id=pod,
         node_name="node-1",
         dynamo_namespace="ns",
         rank_id=rank_id,
-        chain_id=chain_id or pod,
         role="decode",
+        job_id="job_1",
+        plan_id=plan_id,
+        replica_index=replica_index,
     )
 
 
-def _chain(chain_id: str, rank_id: str | None) -> Chain:
-    shape: dict = {"count": 1, "target_p99_ttft_ms": 500.0}
-    if rank_id is not None:
-        shape["rank_id"] = rank_id
-    return Chain(chain_id=chain_id, job_id="job_1", role=ChainRole.DECODE, shape_json=shape)
+def _chain(
+    chain_id: str,
+    replica_index: int,
+    *,
+    rank_id: str = "rank_0",
+    plan_id: str = "plan_1",
+) -> Chain:
+    return Chain(
+        chain_id=chain_id,
+        job_id="job_1",
+        plan_id=plan_id,
+        role=ChainRole.DECODE,
+        shape_json={
+            "count": 1,
+            "rank_id": rank_id,
+            "replica_index": replica_index,
+            "target_p99_ttft_ms": 500.0,
+        },
+    )
 
 
-def test_assign_canonical_chain_ids_maps_pods_within_rank():
+def test_assign_canonical_chain_ids_maps_exact_grove_slots():
     workers = {
-        "pod-b": _worker("pod-b", "decode-0"),
-        "pod-a": _worker("pod-a", "decode-0"),
-        "pod-c": _worker("pod-c", "decode-1"),
-        # Explicitly labelled chain_id must be kept.
-        "pod-d": _worker("pod-d", "decode-1", chain_id="chain_explicit"),
+        "single-0": _worker("single-0", 0),
+        "single-1": _worker("single-1", 1),
+        "multi-leader": _worker("multi-leader", 2),
+        "multi-worker": _worker("multi-worker", 2),
     }
     chains = [
-        _chain("chain_2", "decode-0"),
-        _chain("chain_1", "decode-0"),
-        _chain("chain_3", "decode-1"),
-        _chain("chain_4", "decode-1"),
+        _chain("chain_2", 2),
+        _chain("chain_0", 0),
+        _chain("chain_1", 1),
     ]
     assign_canonical_chain_ids(workers, chains)
 
-    # Deterministic: sorted pods onto sorted chain ids, per rank.
-    assert workers["pod-a"].chain_id == "chain_1"
-    assert workers["pod-b"].chain_id == "chain_2"
-    assert workers["pod-c"].chain_id == "chain_3"
-    assert workers["pod-d"].chain_id == "chain_explicit"
-    # The chain's SLA target rides along for slo_margin.
-    assert workers["pod-a"].ttft_target_ms == 500.0
+    assert workers["single-0"].chain_id == "chain_0"
+    assert workers["single-1"].chain_id == "chain_1"
+    assert workers["multi-leader"].chain_id == "chain_2"
+    assert workers["multi-worker"].chain_id == "chain_2"
+    assert workers["single-0"].ttft_target_ms == 500.0
 
 
-def test_assign_canonical_chain_ids_keeps_pod_name_when_rows_run_out():
-    workers = {"pod-a": _worker("pod-a", "decode-0"), "pod-b": _worker("pod-b", "decode-0")}
-    assign_canonical_chain_ids(workers, [_chain("chain_1", "decode-0")])
-    assert workers["pod-a"].chain_id == "chain_1"
-    assert workers["pod-b"].chain_id == "pod-b"
+def test_assign_canonical_chain_ids_fails_closed():
+    workers = {
+        "missing": _worker("missing", None),
+        "outside": _worker("outside", 9),
+        "old-plan": _worker("old-plan", 0, plan_id="plan_old"),
+        "duplicate": _worker("duplicate", 0),
+    }
+    assign_canonical_chain_ids(workers, [_chain("chain_0", 0), _chain("chain_dup", 0)])
+    assert all(worker.chain_id is None for worker in workers.values())
 
 
 def test_resolve_instance_price_per_hour_from_resource_map():

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -15,6 +15,7 @@ from tandemn_orca.scripts.gpu_metrics_collector import (
     WorkerInfo,
     collect_once,
     collect_rank_telemetry,
+    local_ranks_for_workers,
     resolve_instance_price_per_hour,
     validate_rank_identity,
 )
@@ -72,6 +73,23 @@ def test_worker_index_uses_single_and_multinode_grove_indexes():
         workers["multi-worker"].member_index,
     ) == (None, 0, 1)
     assert (workers["multi-leader"].chain_index, workers["multi-worker"].chain_index) == (2, 2)
+
+
+def test_worker_index_uses_explicit_kube_context(monkeypatch):
+    api_client = object()
+    core = object()
+    monkeypatch.setattr(
+        "kubernetes.config.new_client_from_config",
+        lambda **kwargs: api_client if kwargs == {"context": "gke-central"} else None,
+    )
+    monkeypatch.setattr(
+        "kubernetes.client.CoreV1Api",
+        lambda loaded: core if loaded is api_client else None,
+    )
+
+    index = KubeWorkerIndex(context="gke-central")
+
+    assert index._core is core
 
 
 class FakeProm:
@@ -292,6 +310,14 @@ def test_collect_rank_telemetry_deduplicates_multinode_members():
             observed_at=observed_at,
         )
     ]
+
+
+def test_local_ranks_for_workers_excludes_remote_cluster_ranks():
+    local = _rank(1, rank_id="rank_local")
+    remote = _rank(1, rank_id="rank_remote")
+    workers = {"local-pod": _worker("local-pod", 0, rank_id="rank_local")}
+
+    assert local_ranks_for_workers([local, remote], workers) == [local]
 
 
 def test_router_telemetry_client_posts_authenticated_json(monkeypatch):

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -286,7 +286,12 @@ def test_validate_rank_identity_accepts_grove_slots_in_replica_range():
 def test_collect_rank_telemetry_deduplicates_multinode_members():
     class Prom:
         def query_scalar(self, query):
-            return 3.0 if "num_requests_running" in query else 1.0
+            if "num_requests_running" in query:
+                return 3.0
+            if "gpu_cache_usage_percent" in query:
+                # Distinct per chain: the snapshot must carry the rank-level mean.
+                return 0.3 if "chain-0" in query else 0.5
+            return 1.0
 
     workers = {}
     for chain_index in range(3):
@@ -309,6 +314,7 @@ def test_collect_rank_telemetry_deduplicates_multinode_members():
             pending_requests=2,
             ready_replicas=2,
             observed_at=observed_at,
+            kv_cache_util=0.4,
         )
     ]
 
@@ -353,6 +359,7 @@ def test_router_telemetry_client_posts_authenticated_json(monkeypatch):
     assert request.full_url == "http://127.0.0.1:18080/internal/telemetry"
     assert request.headers["Authorization"] == "Bearer secret"
     assert json.loads(request.data)["pending_requests"] == 1
+    assert json.loads(request.data)["kv_cache_util"] == 0.0
     assert timeout == 5.0
 
 

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 from tandemn_system_data.models import Rank, RankRole, ResourceMap
 
 from tandemn_orca.scripts.gpu_metrics_collector import (
     KubeWorkerIndex,
+    RankTelemetrySnapshot,
+    RouterTelemetryClient,
     WorkerInfo,
     collect_once,
+    collect_rank_telemetry,
     resolve_instance_price_per_hour,
     validate_rank_identity,
 )
@@ -257,6 +262,71 @@ def test_validate_rank_identity_accepts_grove_slots_in_replica_range():
     assert workers["multi-leader"].chain_index == 2
     assert workers["multi-worker"].chain_index == 2
     assert workers["single-0"].ttft_target_ms == 500.0
+
+
+def test_collect_rank_telemetry_deduplicates_multinode_members():
+    class Prom:
+        def query_scalar(self, query):
+            return 3.0 if "num_requests_running" in query else 1.0
+
+    workers = {}
+    for chain_index in range(3):
+        for member_index in range(2):
+            worker = _worker(f"chain-{chain_index}-member-{member_index}", chain_index)
+            worker.member_index = member_index
+            worker.node_count = 2
+            worker.ready = chain_index < 2 or member_index == 0
+            workers[worker.worker_id] = worker
+    rank = _rank(3)
+    observed_at = datetime(2026, 8, 4, tzinfo=UTC)
+
+    snapshots = collect_rank_telemetry(Prom(), workers, [rank], observed_at)
+
+    assert snapshots == [
+        RankTelemetrySnapshot(
+            job_id="job_1",
+            rank_id="rank_0",
+            active_requests=6,
+            pending_requests=2,
+            ready_replicas=2,
+            observed_at=observed_at,
+        )
+    ]
+
+
+def test_router_telemetry_client_posts_authenticated_json(monkeypatch):
+    requests = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def urlopen(request, timeout):
+        requests.append((request, timeout))
+        return Response()
+
+    monkeypatch.setattr(
+        "tandemn_orca.scripts.gpu_metrics_collector.urllib.request.urlopen", urlopen
+    )
+    snapshot = RankTelemetrySnapshot(
+        job_id="job_1",
+        rank_id="rank_0",
+        active_requests=2,
+        pending_requests=1,
+        ready_replicas=1,
+        observed_at=datetime(2026, 8, 4, tzinfo=UTC),
+    )
+
+    RouterTelemetryClient("http://{router_name}.routing.svc", "secret").push(snapshot)
+
+    request, timeout = requests[0]
+    assert request.full_url == "http://tdm-1-router.routing.svc/internal/telemetry"
+    assert request.headers["Authorization"] == "Bearer secret"
+    assert json.loads(request.data)["pending_requests"] == 1
+    assert timeout == 5.0
 
 
 def test_validate_rank_identity_fails_closed():

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -364,12 +364,15 @@ def test_validate_rank_identity_fails_closed():
         "wrong-rank": _worker("wrong-rank", 0, rank_id="rank_other"),
         "bad-member": _worker("bad-member", 0),
     }
+    workers["old-plan"].member_index = 0
     workers["bad-member"].member_index = 2
     rank = _rank(2)
     rank.shape_json.update({"count": 2, "node_count": 2})
     validate_rank_identity(workers, [rank])
-    assert all(worker.chain_index is None for worker in workers.values())
-    assert all(worker.job_id is None and worker.rank_id is None for worker in workers.values())
+    assert workers["old-plan"].chain_index == 0
+    for name in ("missing", "outside", "negative", "wrong-rank", "bad-member"):
+        assert workers[name].chain_index is None
+        assert workers[name].job_id is None and workers[name].rank_id is None
 
 
 def test_resolve_instance_price_per_hour_from_resource_map():

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from tandemn_system_data.models import Chain, ChainRole, ResourceMap
+from tandemn_system_data.models import Rank, RankRole, ResourceMap
 
 from tandemn_orca.scripts.gpu_metrics_collector import (
     KubeWorkerIndex,
     WorkerInfo,
-    assign_canonical_chain_ids,
     collect_once,
     resolve_instance_price_per_hour,
+    validate_rank_identity,
 )
 
 
@@ -34,9 +34,18 @@ def test_worker_index_uses_single_and_multinode_grove_indexes():
     pods = [
         pod("single", {"grove.io/podclique-pod-index": "1"}),
         pod(
-            "multi",
+            "multi-leader",
             {
                 "grove.io/podcliquescalinggroup-replica-index": "2",
+                "grove.io/podclique": "rank-0-vllmdecodeworker-2-vllmdecodeworker-ldr",
+                "grove.io/podclique-pod-index": "0",
+            },
+        ),
+        pod(
+            "multi-worker",
+            {
+                "grove.io/podcliquescalinggroup-replica-index": "2",
+                "grove.io/podclique": "rank-0-vllmdecodeworker-2-vllmdecodeworker-wkr",
                 "grove.io/podclique-pod-index": "0",
             },
         ),
@@ -51,8 +60,13 @@ def test_worker_index_uses_single_and_multinode_grove_indexes():
     workers = KubeWorkerIndex(core=core).by_pod()
 
     assert core.query == ("default", "tandemn.com/pods-discovery=dynamo-worker")
-    assert (workers["single"].plan_id, workers["single"].replica_index) == ("plan_1", 1)
-    assert (workers["multi"].replica_index, workers["multi"].pod_index) == (2, 0)
+    assert (workers["single"].plan_id, workers["single"].chain_index) == ("plan_1", 1)
+    assert (
+        workers["single"].member_index,
+        workers["multi-leader"].member_index,
+        workers["multi-worker"].member_index,
+    ) == (None, 0, 1)
+    assert (workers["multi-leader"].chain_index, workers["multi-worker"].chain_index) == (2, 2)
 
 
 class FakeProm:
@@ -95,9 +109,10 @@ def test_collect_once_attributes_owned_and_unowned_gpus():
         node_name="node-1",
         dynamo_namespace="ns",
         rank_id="rank_0",
-        chain_id="chain-1",
+        chain_index=1,
         role="decode",
         job_id="job_1",
+        plan_id="plan_1",
         model_name="Qwen/Qwen3-0.6B",
         ttft_target_ms=500.0,
     )
@@ -114,7 +129,7 @@ def test_collect_once_attributes_owned_and_unowned_gpus():
     owned = by_uuid["GPU-a"]
     assert owned.job_id == "job_1"
     assert owned.rank_id == "rank_0"
-    assert owned.chain_id == "chain-1"
+    assert owned.chain_index == 1
     assert owned.role == "decode"
     assert owned.node_name == "node-1"
     assert owned.instance_type == "g6.12xlarge"
@@ -123,16 +138,16 @@ def test_collect_once_attributes_owned_and_unowned_gpus():
     assert owned.local_rank == "0"
     assert by_uuid["GPU-b"].local_rank == "1"
     assert owned.throughput_token_per_sec == 1.5
-    # Instance $/hr over the chain's throughput, repeated on each GPU row.
+    # Instance $/hr over the replica's throughput, repeated on each GPU row.
     assert owned.cost_per_token == 3.6 / (1.5 * 3600)
     assert by_uuid["GPU-b"].cost_per_token == owned.cost_per_token
-    # slo_margin from the worker's chain-shape TTFT target.
+    # slo_margin from the rank-shape TTFT target.
     assert owned.slo_margin == (500.0 - 1.5) / 500.0
 
     idle = by_uuid["GPU-idle"]
     assert idle.job_id is None
     assert idle.rank_id is None
-    assert idle.chain_id is None
+    assert idle.chain_index is None
     assert idle.local_rank is None
     assert idle.role is None
     assert idle.node_name == "node-1"
@@ -144,9 +159,55 @@ def test_collect_once_attributes_owned_and_unowned_gpus():
     assert idle.cost_per_token is None
 
 
+def test_multinode_local_rank_and_cost_cover_the_full_chain():
+    class MultiNodeProm(FakeProm):
+        def gpu_targets(self):
+            return [
+                {
+                    "gpu_uuid": f"GPU-{member}",
+                    "uuid_label": f"GPU-{member}",
+                    "instance": f"10.0.0.{member + 1}:9400",
+                    "gpu_index": "0",
+                    "owner_pod": f"worker-{member}",
+                }
+                for member in range(2)
+            ]
+
+    workers = {
+        f"worker-{member}": WorkerInfo(
+            worker_id=f"worker-{member}",
+            node_name=f"node-{member}",
+            dynamo_namespace="ns",
+            rank_id="rank_0",
+            chain_index=0,
+            member_index=member,
+            role="decode",
+            job_id="job_1",
+            plan_id="plan_1",
+        )
+        for member in range(2)
+    }
+    rank = _rank(1)
+    rank.shape_json.update({"count": 2, "node_count": 2})
+    validate_rank_identity(workers, [rank])
+
+    samples = collect_once(
+        MultiNodeProm(),
+        workers,
+        instance_types_by_node={"node-0": "gpu.small", "node-1": "gpu.large"},
+        prices_by_instance_type={"gpu.small": 2.0, "gpu.large": 3.0},
+    )
+    by_uuid = {sample.gpu_uuid: sample for sample in samples}
+
+    assert by_uuid["GPU-0"].local_rank == "0"
+    assert by_uuid["GPU-1"].local_rank == "1"
+    assert by_uuid["GPU-0"].cost_per_token == 5.0 / (1.5 * 3600)
+    assert by_uuid["GPU-1"].cost_per_token == by_uuid["GPU-0"].cost_per_token
+
+
 def _worker(
     pod: str,
-    replica_index: int | None,
+    chain_index: int | None,
     *,
     rank_id: str = "rank_0",
     plan_id: str = "plan_1",
@@ -159,61 +220,60 @@ def _worker(
         role="decode",
         job_id="job_1",
         plan_id=plan_id,
-        replica_index=replica_index,
+        chain_index=chain_index,
     )
 
 
-def _chain(
-    chain_id: str,
-    replica_index: int,
+def _rank(
+    n_replicas: int,
     *,
     rank_id: str = "rank_0",
     plan_id: str = "plan_1",
-) -> Chain:
-    return Chain(
-        chain_id=chain_id,
+) -> Rank:
+    return Rank(
+        rank_id=rank_id,
         job_id="job_1",
         plan_id=plan_id,
-        role=ChainRole.DECODE,
+        role=RankRole.DECODE,
+        n_replicas=n_replicas,
         shape_json={
             "count": 1,
-            "rank_id": rank_id,
-            "replica_index": replica_index,
             "target_p99_ttft_ms": 500.0,
         },
     )
 
 
-def test_assign_canonical_chain_ids_maps_exact_grove_slots():
+def test_validate_rank_identity_accepts_grove_slots_in_replica_range():
     workers = {
         "single-0": _worker("single-0", 0),
         "single-1": _worker("single-1", 1),
         "multi-leader": _worker("multi-leader", 2),
         "multi-worker": _worker("multi-worker", 2),
     }
-    chains = [
-        _chain("chain_2", 2),
-        _chain("chain_0", 0),
-        _chain("chain_1", 1),
-    ]
-    assign_canonical_chain_ids(workers, chains)
+    validate_rank_identity(workers, [_rank(3)])
 
-    assert workers["single-0"].chain_id == "chain_0"
-    assert workers["single-1"].chain_id == "chain_1"
-    assert workers["multi-leader"].chain_id == "chain_2"
-    assert workers["multi-worker"].chain_id == "chain_2"
+    assert workers["single-0"].chain_index == 0
+    assert workers["single-1"].chain_index == 1
+    assert workers["multi-leader"].chain_index == 2
+    assert workers["multi-worker"].chain_index == 2
     assert workers["single-0"].ttft_target_ms == 500.0
 
 
-def test_assign_canonical_chain_ids_fails_closed():
+def test_validate_rank_identity_fails_closed():
     workers = {
         "missing": _worker("missing", None),
         "outside": _worker("outside", 9),
+        "negative": _worker("negative", -1),
         "old-plan": _worker("old-plan", 0, plan_id="plan_old"),
-        "duplicate": _worker("duplicate", 0),
+        "wrong-rank": _worker("wrong-rank", 0, rank_id="rank_other"),
+        "bad-member": _worker("bad-member", 0),
     }
-    assign_canonical_chain_ids(workers, [_chain("chain_0", 0), _chain("chain_dup", 0)])
-    assert all(worker.chain_id is None for worker in workers.values())
+    workers["bad-member"].member_index = 2
+    rank = _rank(2)
+    rank.shape_json.update({"count": 2, "node_count": 2})
+    validate_rank_identity(workers, [rank])
+    assert all(worker.chain_index is None for worker in workers.values())
+    assert all(worker.job_id is None and worker.rank_id is None for worker in workers.values())
 
 
 def test_resolve_instance_price_per_hour_from_resource_map():

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -15,8 +15,10 @@ from tandemn_orca.scripts.gpu_metrics_collector import (
     RankTelemetrySnapshot,
     RouterTelemetryClient,
     WorkerInfo,
+    _worker_inference_values,
     collect_once,
     collect_rank_telemetry,
+    kv_pressure_score,
     local_ranks_for_workers,
     resolve_instance_price_per_hour,
     validate_rank_identity,
@@ -443,3 +445,64 @@ def test_resolve_instance_price_per_hour_from_resource_map():
     assert resolve_instance_price_per_hour(resource_map, "g6.xlarge") is None
     assert resolve_instance_price_per_hour(resource_map, "p5.48xlarge") is None
     assert resolve_instance_price_per_hour(resource_map, None) is None
+
+
+def test_kv_pressure_score_matches_simulator_ratio():
+    # 5 requests, each block-rounded to ceil((100 + 60) / 16) = 10 blocks,
+    # against 200 total KV blocks: 50 / 200.
+    assert kv_pressure_score(2.0, 3.0, 100.0, 60.0, 200.0) == 0.25
+
+
+def test_kv_pressure_score_zero_requests_is_zero_without_lengths():
+    assert kv_pressure_score(0.0, 0.0, None, None, 200.0) == 0.0
+
+
+def test_kv_pressure_score_missing_inputs_return_none():
+    assert kv_pressure_score(2.0, 3.0, 100.0, 60.0, None) is None
+    assert kv_pressure_score(2.0, 3.0, 100.0, 60.0, 0.0) is None
+    assert kv_pressure_score(2.0, 3.0, None, 60.0, 200.0) is None
+    assert kv_pressure_score(2.0, 3.0, 100.0, None, 200.0) is None
+    assert kv_pressure_score(None, 3.0, 100.0, 60.0, 200.0) is None
+
+
+class _KvPressureProm:
+    """Answers each derived-metric input by a distinctive query fragment."""
+
+    def __init__(self, *, max_tokens: float | None = 60.0):
+        self.max_tokens = max_tokens
+
+    def query_scalar(self, query: str):
+        if "request_params_max_tokens" in query:
+            return self.max_tokens
+        if "num_requests_running" in query:
+            return 2.0
+        if "num_requests_waiting" in query:
+            return 3.0
+        if "request_prompt_tokens" in query:
+            return 100.0
+        if "request_generation_tokens" in query:
+            return 60.0
+        if "dynamo_component_total_blocks" in query:
+            return 200.0
+        return None
+
+
+def test_worker_inference_values_compute_simulator_style_kv_pressure():
+    values = _worker_inference_values(
+        _KvPressureProm(),
+        _worker("worker-pod-1", 0),
+        price_per_hour=None,
+        ttft_target_ms=None,
+    )
+    assert values["kv_pressure_score"] == 0.25
+
+
+def test_kv_pressure_falls_back_to_observed_generation_length():
+    # Without request_params_max_tokens, output_length_observed (60) stands in.
+    values = _worker_inference_values(
+        _KvPressureProm(max_tokens=None),
+        _worker("worker-pod-1", 0),
+        price_per_hour=None,
+        ttft_target_ms=None,
+    )
+    assert values["kv_pressure_score"] == 0.25

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -10,6 +10,7 @@ from tandemn_system_data.models import Rank, RankRole, ResourceMap
 
 from tandemn_orca.scripts.gpu_metrics_collector import (
     KubeWorkerIndex,
+    PrometheusClient,
     RankTelemetrySnapshot,
     RouterTelemetryClient,
     WorkerInfo,
@@ -353,6 +354,20 @@ def test_router_telemetry_client_posts_authenticated_json(monkeypatch):
     assert request.headers["Authorization"] == "Bearer secret"
     assert json.loads(request.data)["pending_requests"] == 1
     assert timeout == 5.0
+
+
+def test_prometheus_client_treats_connection_reset_as_missing_data(monkeypatch):
+    def reset(*args, **kwargs):
+        raise ConnectionResetError
+
+    monkeypatch.setattr(
+        "tandemn_orca.scripts.gpu_metrics_collector.urllib.request.urlopen",
+        reset,
+    )
+    client = PrometheusClient("http://prometheus")
+
+    assert client.query_scalar("up") is None
+    assert client.gpu_targets() == []
 
 
 def test_validate_rank_identity_fails_closed():

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 from tandemn_system_data.models import Rank, RankRole, ResourceMap
 
+from tandemn_orca.dynamo_compiler import router_listen_port
 from tandemn_orca.scripts.gpu_metrics_collector import (
     KubeWorkerIndex,
     PrometheusClient,
@@ -361,6 +362,11 @@ def test_router_telemetry_client_posts_authenticated_json(monkeypatch):
     assert json.loads(request.data)["pending_requests"] == 1
     assert json.loads(request.data)["kv_cache_util"] == 0.0
     assert timeout == 5.0
+
+    RouterTelemetryClient(None, "secret").push(snapshot)
+    derived, _ = requests[1]
+    port = router_listen_port("job_1")
+    assert derived.full_url == f"http://127.0.0.1:{port}/internal/telemetry"
 
 
 def test_prometheus_client_treats_connection_reset_as_missing_data(monkeypatch):

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -2,14 +2,42 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from tandemn_system_data.models import Chain, ChainRole, ResourceMap
 
 from tandemn_orca.scripts.gpu_metrics_collector import (
+    KubeWorkerIndex,
     WorkerInfo,
     assign_canonical_chain_ids,
     collect_once,
     resolve_instance_price_per_hour,
 )
+
+
+def test_worker_index_uses_discovery_and_com_identity_labels():
+    pod = SimpleNamespace(
+        metadata=SimpleNamespace(
+            name="worker-1",
+            labels={
+                "tandemn.com/job-id": "job_1",
+                "tandemn.com/rank-id": "rank_0",
+                "tandemn.com/pods-discovery": "dynamo-worker",
+            },
+        ),
+        spec=SimpleNamespace(node_name="node-1", containers=[]),
+    )
+
+    class Core:
+        def list_namespaced_pod(self, namespace, label_selector):
+            self.query = namespace, label_selector
+            return SimpleNamespace(items=[pod])
+
+    core = Core()
+    worker = KubeWorkerIndex(core=core).by_pod()["worker-1"]
+
+    assert core.query == ("default", "tandemn.com/pods-discovery=dynamo-worker")
+    assert (worker.job_id, worker.rank_id) == ("job_1", "rank_0")
 
 
 class FakeProm:

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -320,10 +320,10 @@ def test_router_telemetry_client_posts_authenticated_json(monkeypatch):
         observed_at=datetime(2026, 8, 4, tzinfo=UTC),
     )
 
-    RouterTelemetryClient("http://{router_name}.routing.svc", "secret").push(snapshot)
+    RouterTelemetryClient("http://127.0.0.1:18080", "secret").push(snapshot)
 
     request, timeout = requests[0]
-    assert request.full_url == "http://tdm-1-router.routing.svc/internal/telemetry"
+    assert request.full_url == "http://127.0.0.1:18080/internal/telemetry"
     assert request.headers["Authorization"] == "Bearer secret"
     assert json.loads(request.data)["pending_requests"] == 1
     assert timeout == 5.0

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -121,17 +121,28 @@ def test_dynamo_launcher_teardown_deletes_job_objects():
     assert k8s.deleted_jobs == ["job_online_001"]
 
 
+class FakeRouters:
+    def __init__(self):
+        self.calls = []
+
+    def reconcile(self, job_id, config_path):
+        self.calls.append((job_id, config_path))
+
+
 def test_dynamo_launcher_writes_and_deletes_local_router_config(tmp_path):
     workload = FakeK8s()
     rank = _rank()
+    routers = FakeRouters()
     launcher = MultiClusterLauncher(
         {"default": DynamoLauncher(k8s=workload)},
         router_config_dir=str(tmp_path),
         model_catalogs=_catalog(),
         default_cluster="default",
+        routers=routers,
     )
 
     launcher.reconcile("job_online_001", [rank])
+    assert routers.calls == [("job_online_001", str(tmp_path / "job_online_001.json"))]
 
     assert [obj["kind"] for obj in workload.applied[0]] == ["DynamoGraphDeployment"]
     config_path = tmp_path / "job_online_001.json"
@@ -147,6 +158,7 @@ def test_dynamo_launcher_writes_and_deletes_local_router_config(tmp_path):
     launcher.teardown_job("job_online_001")
     assert workload.deleted_jobs == ["job_online_001"]
     assert not config_path.exists()
+    assert routers.calls[-1] == ("job_online_001", None)
 
 
 def test_dynamo_launcher_does_not_write_config_when_apply_fails(tmp_path):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -121,12 +121,9 @@ def test_dynamo_launcher_teardown_deletes_job_objects():
 
 def test_dynamo_launcher_publishes_and_deletes_router_config():
     workload = FakeK8s()
-    routing = FakeK8s(namespace="routing")
     rank = _rank()
-    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
     launcher = DynamoLauncher(
         k8s=workload,
-        router_k8s=routing,
         router_image="registry.example/tandemn-router:test",
         model_catalogs=_catalog(),
     )
@@ -134,38 +131,33 @@ def test_dynamo_launcher_publishes_and_deletes_router_config():
     launcher.reconcile("job_online_001", [rank])
     launcher.teardown_job("job_online_001")
 
-    assert [obj["kind"] for obj in routing.applied[0]] == [
+    assert [obj["kind"] for obj in workload.applied[0]] == [
+        "DynamoGraphDeployment",
         "ConfigMap",
         "Deployment",
         "Service",
     ]
-    assert all(obj["metadata"]["namespace"] == "routing" for obj in routing.applied[0])
-    router_config = routing.applied[0][0]["data"]["router.json"]
+    router_config = workload.applied[0][1]["data"]["router.json"]
     assert '"max_num_seq":256' in router_config
     assert '"maximum_requests":256' in router_config
+    assert (
+        '"endpoint":"http://tdm-online-001-03a2a00c-frontend.default.svc.cluster.local:8000"'
+        in router_config
+    )
     worker_args = workload.applied[0][0]["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"][
         "mainContainer"
     ]["args"]
     assert "--max-num-seqs" not in worker_args
-    assert routing.deleted == [
-        {
-            ("ConfigMap", "tdm-online-001-router-config"),
-            ("Deployment", "tdm-online-001-router"),
-            ("Service", "tdm-online-001-router"),
-        }
-    ]
+    assert workload.deleted_jobs == ["job_online_001"]
 
 
 def test_dynamo_launcher_keeps_stale_when_router_publish_fails():
-    workload = FakeK8s()
-    routing = FakeK8s(namespace="routing", apply_error=RuntimeError("publish"))
+    workload = FakeK8s(apply_error=RuntimeError("publish"))
     rank = _rank()
-    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
 
     with pytest.raises(ReconcileError, match="publish"):
         DynamoLauncher(
             k8s=workload,
-            router_k8s=routing,
             router_image="registry.example/tandemn-router:test",
             model_catalogs=_catalog(),
         ).reconcile("job_online_001", [rank])
@@ -176,12 +168,10 @@ def test_dynamo_launcher_keeps_stale_when_router_publish_fails():
 def test_dynamo_launcher_rejects_missing_catalog_before_workload_apply():
     workload = FakeK8s()
     rank = _rank()
-    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
 
     with pytest.raises(ModelCatalogError, match=r"ModelCatalog.*is missing"):
         DynamoLauncher(
             k8s=workload,
-            router_k8s=FakeK8s(namespace="routing"),
             router_image="registry.example/tandemn-router:test",
             model_catalogs=FakeCatalogs(),
         ).reconcile("job_online_001", [rank])
@@ -199,7 +189,6 @@ def test_dynamo_launcher_rejects_missing_catalog_before_workload_apply():
 def test_dynamo_launcher_rejects_invalid_gpu_capacity(entries, message):
     workload = FakeK8s()
     rank = _rank()
-    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
     catalogs = FakeCatalogs(
         ModelCatalog(model_id="meta-llama/Llama-3.1-8B-Instruct", max_num_seq=entries)
     )
@@ -207,7 +196,6 @@ def test_dynamo_launcher_rejects_invalid_gpu_capacity(entries, message):
     with pytest.raises(ModelCatalogError, match=message):
         DynamoLauncher(
             k8s=workload,
-            router_k8s=FakeK8s(namespace="routing"),
             router_image="registry.example/tandemn-router:test",
             model_catalogs=catalogs,
         ).reconcile("job_online_001", [rank])

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -7,7 +7,12 @@ from tandemn_system_data.models import ModelCatalog
 from tandemn_system_data.models.enums import RankRole
 from tandemn_system_data.models.rank import Rank
 
-from tandemn_orca.launcher import DynamoLauncher, ModelCatalogError, ReconcileError
+from tandemn_orca.launcher import (
+    DynamoLauncher,
+    ModelCatalogError,
+    MultiClusterLauncher,
+    ReconcileError,
+)
 
 RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
 
@@ -119,10 +124,11 @@ def test_dynamo_launcher_teardown_deletes_job_objects():
 def test_dynamo_launcher_writes_and_deletes_local_router_config(tmp_path):
     workload = FakeK8s()
     rank = _rank()
-    launcher = DynamoLauncher(
-        k8s=workload,
+    launcher = MultiClusterLauncher(
+        {"default": DynamoLauncher(k8s=workload)},
         router_config_dir=str(tmp_path),
         model_catalogs=_catalog(),
+        default_cluster="default",
     )
 
     launcher.reconcile("job_online_001", [rank])
@@ -148,10 +154,11 @@ def test_dynamo_launcher_does_not_write_config_when_apply_fails(tmp_path):
     rank = _rank()
 
     with pytest.raises(ReconcileError, match="publish"):
-        DynamoLauncher(
-            k8s=workload,
+        MultiClusterLauncher(
+            {"default": DynamoLauncher(k8s=workload)},
             router_config_dir=str(tmp_path),
             model_catalogs=_catalog(),
+            default_cluster="default",
         ).reconcile("job_online_001", [rank])
 
     assert workload.deleted == []
@@ -163,10 +170,11 @@ def test_dynamo_launcher_rejects_missing_catalog_before_workload_apply(tmp_path)
     rank = _rank()
 
     with pytest.raises(ModelCatalogError, match=r"ModelCatalog.*is missing"):
-        DynamoLauncher(
-            k8s=workload,
+        MultiClusterLauncher(
+            {"default": DynamoLauncher(k8s=workload)},
             router_config_dir=str(tmp_path),
             model_catalogs=FakeCatalogs(),
+            default_cluster="default",
         ).reconcile("job_online_001", [rank])
 
     assert workload.applied == []
@@ -187,10 +195,44 @@ def test_dynamo_launcher_rejects_invalid_gpu_capacity(entries, message, tmp_path
     )
 
     with pytest.raises(ModelCatalogError, match=message):
-        DynamoLauncher(
-            k8s=workload,
+        MultiClusterLauncher(
+            {"default": DynamoLauncher(k8s=workload)},
             router_config_dir=str(tmp_path),
             model_catalogs=catalogs,
+            default_cluster="default",
         ).reconcile("job_online_001", [rank])
 
     assert workload.applied == []
+
+
+def test_multi_cluster_launcher_groups_ranks_by_cloud_region(tmp_path):
+    aws = FakeK8s()
+    gcp = FakeK8s()
+    aws_rank = _rank()
+    gcp_rank = aws_rank.model_copy(
+        deep=True,
+        update={"rank_id": "rank_01JBM30YQ7X3WQAR6HF8C2Q9T8"},
+    )
+    gcp_rank.shape_json["env"] = ["on_demand", "gcp", "us-central1", "a", "L40S"]
+    launcher = MultiClusterLauncher(
+        {
+            "aws|us-east-2": DynamoLauncher(k8s=aws, context="aws-context"),
+            "gcp|us-central1": DynamoLauncher(k8s=gcp, context="gcp-context"),
+        },
+        router_config_dir=str(tmp_path),
+        model_catalogs=_catalog(),
+    )
+
+    launcher.reconcile("job_online_001", [aws_rank, gcp_rank])
+
+    assert [obj["metadata"]["labels"]["tandemn.com/rank-id"] for obj in aws.applied[0]] == [
+        aws_rank.rank_id
+    ]
+    assert [obj["metadata"]["labels"]["tandemn.com/rank-id"] for obj in gcp.applied[0]] == [
+        gcp_rank.rank_id
+    ]
+    config = json.loads((tmp_path / "job_online_001.json").read_text())
+    assert {deployment["rank_id"] for deployment in config["deployments"]} == {
+        aws_rank.rank_id,
+        gcp_rank.rank_id,
+    }

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -19,6 +19,7 @@ def _chain() -> Chain:
             "gpu_type": "L40S",
             "gpu_count": 1,
             "count": 1,
+            "rank_id": "rank_0",
             "target_p99_ttft_ms": 500.0,
             "target_p99_tpot_ms": 50.0,
             "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
@@ -61,7 +62,7 @@ def test_dynamo_launcher_applies_desired_and_deletes_stale():
 
     applied_names = {obj["metadata"]["name"] for obj in k8s.applied[0]}
     assert k8s.job_id == "job_online_001"
-    assert applied_names == {"tdm-online-001-0dfb3ae9"}
+    assert applied_names == {"tdm-online-001-rank-0"}
     assert k8s.deleted == [
         {("ConfigMap", "stale-config"), ("DynamoGraphDeployment", "job-online-001-aggregate-old")}
     ]

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -214,6 +214,15 @@ def test_multi_cluster_launcher_groups_ranks_by_cloud_region(tmp_path):
         update={"rank_id": "rank_01JBM30YQ7X3WQAR6HF8C2Q9T8"},
     )
     gcp_rank.shape_json["env"] = ["on_demand", "gcp", "us-central1", "a", "L40S"]
+
+    class Tunnels:
+        def __init__(self):
+            self.calls = []
+
+        def reconcile(self, job_id, specs):
+            self.calls.append((job_id, specs))
+
+    tunnels = Tunnels()
     launcher = MultiClusterLauncher(
         {
             "aws|us-east-2": DynamoLauncher(k8s=aws, context="aws-context"),
@@ -221,6 +230,7 @@ def test_multi_cluster_launcher_groups_ranks_by_cloud_region(tmp_path):
         },
         router_config_dir=str(tmp_path),
         model_catalogs=_catalog(),
+        tunnels=tunnels,
     )
 
     launcher.reconcile("job_online_001", [aws_rank, gcp_rank])
@@ -235,4 +245,9 @@ def test_multi_cluster_launcher_groups_ranks_by_cloud_region(tmp_path):
     assert {deployment["rank_id"] for deployment in config["deployments"]} == {
         aws_rank.rank_id,
         gcp_rank.rank_id,
+    }
+    specs = tunnels.calls[0][1]
+    assert {(spec.context, spec.service) for spec in specs} == {
+        ("aws-context", "tdm-online-001-03a2a00c-frontend"),
+        ("gcp-context", "tdm-online-001-efd9077e-frontend"),
     }

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pytest
+from tandemn_system_data.models import ModelCatalog
 from tandemn_system_data.models.enums import RankRole
 from tandemn_system_data.models.rank import Rank
 
-from tandemn_orca.launcher import DynamoLauncher, ReconcileError
+from tandemn_orca.launcher import DynamoLauncher, ModelCatalogError, ReconcileError
 
 RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
 
@@ -60,6 +61,24 @@ class FakeK8s:
         self.deleted_jobs.append(job_id)
 
 
+class FakeCatalogs:
+    def __init__(self, catalog=None) -> None:
+        self.catalog = catalog
+
+    def get(self, model_id):
+        self.model_id = model_id
+        return self.catalog
+
+
+def _catalog() -> FakeCatalogs:
+    return FakeCatalogs(
+        ModelCatalog(
+            model_id="meta-llama/Llama-3.1-8B-Instruct",
+            max_num_seq=[{"gpu_type": "L40S", "value": 256}],
+        )
+    )
+
+
 def test_dynamo_launcher_applies_desired_and_deletes_stale():
     k8s = FakeK8s()
     DynamoLauncher(k8s=k8s).reconcile("job_online_001", [_rank()])
@@ -104,13 +123,12 @@ def test_dynamo_launcher_publishes_and_deletes_router_config():
     workload = FakeK8s()
     routing = FakeK8s(namespace="routing")
     rank = _rank()
-    rank.shape_json.update(
-        {"router_endpoint": "https://rank.example.internal", "maximum_requests": 64}
-    )
+    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
     launcher = DynamoLauncher(
         k8s=workload,
         router_k8s=routing,
         router_image="registry.example/tandemn-router:test",
+        model_catalogs=_catalog(),
     )
 
     launcher.reconcile("job_online_001", [rank])
@@ -122,6 +140,13 @@ def test_dynamo_launcher_publishes_and_deletes_router_config():
         "Service",
     ]
     assert all(obj["metadata"]["namespace"] == "routing" for obj in routing.applied[0])
+    router_config = routing.applied[0][0]["data"]["router.json"]
+    assert '"max_num_seq":256' in router_config
+    assert '"maximum_requests":256' in router_config
+    worker_args = workload.applied[0][0]["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert "--max-num-seqs" not in worker_args
     assert routing.deleted == [
         {
             ("ConfigMap", "tdm-online-001-router-config"),
@@ -135,15 +160,56 @@ def test_dynamo_launcher_keeps_stale_when_router_publish_fails():
     workload = FakeK8s()
     routing = FakeK8s(namespace="routing", apply_error=RuntimeError("publish"))
     rank = _rank()
-    rank.shape_json.update(
-        {"router_endpoint": "https://rank.example.internal", "maximum_requests": 64}
-    )
+    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
 
     with pytest.raises(ReconcileError, match="publish"):
         DynamoLauncher(
             k8s=workload,
             router_k8s=routing,
             router_image="registry.example/tandemn-router:test",
+            model_catalogs=_catalog(),
         ).reconcile("job_online_001", [rank])
 
     assert workload.deleted == []
+
+
+def test_dynamo_launcher_rejects_missing_catalog_before_workload_apply():
+    workload = FakeK8s()
+    rank = _rank()
+    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
+
+    with pytest.raises(ModelCatalogError, match=r"ModelCatalog.*is missing"):
+        DynamoLauncher(
+            k8s=workload,
+            router_k8s=FakeK8s(namespace="routing"),
+            router_image="registry.example/tandemn-router:test",
+            model_catalogs=FakeCatalogs(),
+        ).reconcile("job_online_001", [rank])
+
+    assert workload.applied == []
+
+
+@pytest.mark.parametrize(
+    ("entries", "message"),
+    [
+        ([], "exactly one entry"),
+        ([{"gpu_type": "L40S", "value": 0}], "positive integer"),
+    ],
+)
+def test_dynamo_launcher_rejects_invalid_gpu_capacity(entries, message):
+    workload = FakeK8s()
+    rank = _rank()
+    rank.shape_json["router_endpoint"] = "https://rank.example.internal"
+    catalogs = FakeCatalogs(
+        ModelCatalog(model_id="meta-llama/Llama-3.1-8B-Instruct", max_num_seq=entries)
+    )
+
+    with pytest.raises(ModelCatalogError, match=message):
+        DynamoLauncher(
+            k8s=workload,
+            router_k8s=FakeK8s(namespace="routing"),
+            router_image="registry.example/tandemn-router:test",
+            model_catalogs=catalogs,
+        ).reconcile("job_online_001", [rank])
+
+    assert workload.applied == []

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 from tandemn_system_data.models import ModelCatalog
 from tandemn_system_data.models.enums import RankRole
@@ -42,10 +44,7 @@ class FakeK8s:
 
     def list_job_objects(self, job_id):
         self.job_id = job_id
-        return {
-            ("ConfigMap", "stale-config"),
-            ("DynamoGraphDeployment", "job-online-001-aggregate-old"),
-        }
+        return {("DynamoGraphDeployment", "job-online-001-aggregate-old")}
 
     def apply_many(self, objects):
         self.applied.append(objects)
@@ -86,9 +85,7 @@ def test_dynamo_launcher_applies_desired_and_deletes_stale():
     applied_names = {obj["metadata"]["name"] for obj in k8s.applied[0]}
     assert k8s.job_id == "job_online_001"
     assert len(applied_names) == 1
-    assert k8s.deleted == [
-        {("ConfigMap", "stale-config"), ("DynamoGraphDeployment", "job-online-001-aggregate-old")}
-    ]
+    assert k8s.deleted == [{("DynamoGraphDeployment", "job-online-001-aggregate-old")}]
 
 
 def test_dynamo_launcher_keeps_stale_when_apply_fails():
@@ -119,60 +116,56 @@ def test_dynamo_launcher_teardown_deletes_job_objects():
     assert k8s.deleted_jobs == ["job_online_001"]
 
 
-def test_dynamo_launcher_publishes_and_deletes_router_config():
+def test_dynamo_launcher_writes_and_deletes_local_router_config(tmp_path):
     workload = FakeK8s()
     rank = _rank()
     launcher = DynamoLauncher(
         k8s=workload,
-        router_image="registry.example/tandemn-router:test",
+        router_config_dir=str(tmp_path),
         model_catalogs=_catalog(),
     )
 
     launcher.reconcile("job_online_001", [rank])
-    launcher.teardown_job("job_online_001")
 
-    assert [obj["kind"] for obj in workload.applied[0]] == [
-        "DynamoGraphDeployment",
-        "ConfigMap",
-        "Deployment",
-        "Service",
-    ]
-    router_config = workload.applied[0][1]["data"]["router.json"]
-    assert '"max_num_seq":256' in router_config
-    assert '"maximum_requests":256' in router_config
-    assert (
-        '"endpoint":"http://tdm-online-001-03a2a00c-frontend.default.svc.cluster.local:8000"'
-        in router_config
-    )
+    assert [obj["kind"] for obj in workload.applied[0]] == ["DynamoGraphDeployment"]
+    config_path = tmp_path / "job_online_001.json"
+    router_config = json.loads(config_path.read_text())
+    deployment = router_config["deployments"][0]
+    assert deployment["max_num_seq"] == 256
+    assert deployment["maximum_requests"] == 256
+    assert deployment["endpoint"].startswith("http://127.0.0.1:")
     worker_args = workload.applied[0][0]["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"][
         "mainContainer"
     ]["args"]
     assert "--max-num-seqs" not in worker_args
+    launcher.teardown_job("job_online_001")
     assert workload.deleted_jobs == ["job_online_001"]
+    assert not config_path.exists()
 
 
-def test_dynamo_launcher_keeps_stale_when_router_publish_fails():
+def test_dynamo_launcher_does_not_write_config_when_apply_fails(tmp_path):
     workload = FakeK8s(apply_error=RuntimeError("publish"))
     rank = _rank()
 
     with pytest.raises(ReconcileError, match="publish"):
         DynamoLauncher(
             k8s=workload,
-            router_image="registry.example/tandemn-router:test",
+            router_config_dir=str(tmp_path),
             model_catalogs=_catalog(),
         ).reconcile("job_online_001", [rank])
 
     assert workload.deleted == []
+    assert not (tmp_path / "job_online_001.json").exists()
 
 
-def test_dynamo_launcher_rejects_missing_catalog_before_workload_apply():
+def test_dynamo_launcher_rejects_missing_catalog_before_workload_apply(tmp_path):
     workload = FakeK8s()
     rank = _rank()
 
     with pytest.raises(ModelCatalogError, match=r"ModelCatalog.*is missing"):
         DynamoLauncher(
             k8s=workload,
-            router_image="registry.example/tandemn-router:test",
+            router_config_dir=str(tmp_path),
             model_catalogs=FakeCatalogs(),
         ).reconcile("job_online_001", [rank])
 
@@ -186,7 +179,7 @@ def test_dynamo_launcher_rejects_missing_catalog_before_workload_apply():
         ([{"gpu_type": "L40S", "value": 0}], "positive integer"),
     ],
 )
-def test_dynamo_launcher_rejects_invalid_gpu_capacity(entries, message):
+def test_dynamo_launcher_rejects_invalid_gpu_capacity(entries, message, tmp_path):
     workload = FakeK8s()
     rank = _rank()
     catalogs = FakeCatalogs(
@@ -196,7 +189,7 @@ def test_dynamo_launcher_rejects_invalid_gpu_capacity(entries, message):
     with pytest.raises(ModelCatalogError, match=message):
         DynamoLauncher(
             k8s=workload,
-            router_image="registry.example/tandemn-router:test",
+            router_config_dir=str(tmp_path),
             model_catalogs=catalogs,
         ).reconcile("job_online_001", [rank])
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import pytest
-from tandemn_system_data.models.chain import Chain
-from tandemn_system_data.models.enums import ChainRole
+from tandemn_system_data.models.enums import RankRole
+from tandemn_system_data.models.rank import Rank
 
 from tandemn_orca.launcher import DynamoLauncher, ReconcileError
 
+RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
 
-def _chain() -> Chain:
-    return Chain(
+
+def _rank() -> Rank:
+    return Rank(
+        rank_id=RANK_ID,
         job_id="job_online_001",
         plan_id="plan_1",
-        role=ChainRole.AGGREGATE,
+        role=RankRole.AGGREGATE,
+        n_replicas=1,
         shape_json={
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "engine_name": "vllm",
@@ -19,7 +23,6 @@ def _chain() -> Chain:
             "gpu_type": "L40S",
             "gpu_count": 1,
             "count": 1,
-            "rank_id": "rank_0",
             "target_p99_ttft_ms": 500.0,
             "target_p99_tpot_ms": 50.0,
             "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
@@ -28,7 +31,8 @@ def _chain() -> Chain:
 
 
 class FakeK8s:
-    def __init__(self, *, apply_error=None, delete_error=None) -> None:
+    def __init__(self, *, namespace="default", apply_error=None, delete_error=None) -> None:
+        self.namespace = namespace
         self.apply_error = apply_error
         self.delete_error = delete_error
         self.applied: list[list[dict]] = []
@@ -58,34 +62,35 @@ class FakeK8s:
 
 def test_dynamo_launcher_applies_desired_and_deletes_stale():
     k8s = FakeK8s()
-    DynamoLauncher(k8s=k8s).reconcile("job_online_001", [_chain()])
+    DynamoLauncher(k8s=k8s).reconcile("job_online_001", [_rank()])
 
     applied_names = {obj["metadata"]["name"] for obj in k8s.applied[0]}
     assert k8s.job_id == "job_online_001"
-    assert applied_names == {"tdm-online-001-rank-0"}
+    assert len(applied_names) == 1
     assert k8s.deleted == [
         {("ConfigMap", "stale-config"), ("DynamoGraphDeployment", "job-online-001-aggregate-old")}
     ]
 
 
-def test_dynamo_launcher_deletes_stale_even_when_apply_fails():
+def test_dynamo_launcher_keeps_stale_when_apply_fails():
     k8s = FakeK8s(apply_error=RuntimeError("boom"))
 
     with pytest.raises(ReconcileError) as error:
-        DynamoLauncher(k8s=k8s).reconcile("job_online_001", [_chain()])
+        DynamoLauncher(k8s=k8s).reconcile("job_online_001", [_rank()])
 
     assert isinstance(error.value.apply_error, RuntimeError)
     assert error.value.delete_error is None
-    assert k8s.deleted
+    assert k8s.deleted == []
 
 
-def test_dynamo_launcher_reports_apply_and_delete_errors():
-    k8s = FakeK8s(apply_error=RuntimeError("apply"), delete_error=RuntimeError("delete"))
+def test_dynamo_launcher_reports_delete_error_after_apply():
+    k8s = FakeK8s(delete_error=RuntimeError("delete"))
 
     with pytest.raises(ReconcileError) as error:
-        DynamoLauncher(k8s=k8s).reconcile("job_online_001", [_chain()])
+        DynamoLauncher(k8s=k8s).reconcile("job_online_001", [_rank()])
 
-    assert str(error.value) == "apply failed: apply; delete failed: delete"
+    assert error.value.apply_error is None
+    assert str(error.value) == "delete failed: delete"
 
 
 def test_dynamo_launcher_teardown_deletes_job_objects():
@@ -93,3 +98,52 @@ def test_dynamo_launcher_teardown_deletes_job_objects():
     DynamoLauncher(k8s=k8s).teardown_job("job_online_001")
 
     assert k8s.deleted_jobs == ["job_online_001"]
+
+
+def test_dynamo_launcher_publishes_and_deletes_router_config():
+    workload = FakeK8s()
+    routing = FakeK8s(namespace="routing")
+    rank = _rank()
+    rank.shape_json.update(
+        {"router_endpoint": "https://rank.example.internal", "maximum_requests": 64}
+    )
+    launcher = DynamoLauncher(
+        k8s=workload,
+        router_k8s=routing,
+        router_image="registry.example/tandemn-router:test",
+    )
+
+    launcher.reconcile("job_online_001", [rank])
+    launcher.teardown_job("job_online_001")
+
+    assert [obj["kind"] for obj in routing.applied[0]] == [
+        "ConfigMap",
+        "Deployment",
+        "Service",
+    ]
+    assert all(obj["metadata"]["namespace"] == "routing" for obj in routing.applied[0])
+    assert routing.deleted == [
+        {
+            ("ConfigMap", "tdm-online-001-router-config"),
+            ("Deployment", "tdm-online-001-router"),
+            ("Service", "tdm-online-001-router"),
+        }
+    ]
+
+
+def test_dynamo_launcher_keeps_stale_when_router_publish_fails():
+    workload = FakeK8s()
+    routing = FakeK8s(namespace="routing", apply_error=RuntimeError("publish"))
+    rank = _rank()
+    rank.shape_json.update(
+        {"router_endpoint": "https://rank.example.internal", "maximum_requests": 64}
+    )
+
+    with pytest.raises(ReconcileError, match="publish"):
+        DynamoLauncher(
+            k8s=workload,
+            router_k8s=routing,
+            router_image="registry.example/tandemn-router:test",
+        ).reconcile("job_online_001", [rank])
+
+    assert workload.deleted == []

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -32,20 +32,21 @@ class FailingOnceOrca(FakeOrca):
 class FakeLauncher:
     instances: ClassVar[list[FakeLauncher]] = []
 
-    def __init__(
-        self,
-        namespace: str,
-        router_config_dir=None,
-        router_port_base=18000,
-        router_port_span=10000,
-        model_catalogs=None,
-    ) -> None:
+    def __init__(self, namespace: str, k8s=None, context=None) -> None:
         self.namespace = namespace
-        self.router_config_dir = router_config_dir
-        self.router_port_base = router_port_base
-        self.router_port_span = router_port_span
-        self.model_catalogs = model_catalogs
+        self.k8s = k8s
+        self.context = context
         FakeLauncher.instances.append(self)
+
+
+class FakeMultiClusterLauncher:
+    instances: ClassVar[list[FakeMultiClusterLauncher]] = []
+
+    def __init__(self, launchers, **kwargs) -> None:
+        self.launchers = launchers
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        FakeMultiClusterLauncher.instances.append(self)
 
 
 class FakeRefresher:
@@ -67,10 +68,13 @@ class FakeRefresher:
 def _patch_runner(monkeypatch, orca_cls=FakeOrca):
     FakeOrca.instances.clear()
     FakeLauncher.instances.clear()
+    FakeMultiClusterLauncher.instances.clear()
     FakeRefresher.instances.clear()
     sleeps: list[float] = []
     monkeypatch.setattr(mod, "PostgresClient", lambda: "client")
     monkeypatch.setattr(mod, "DynamoLauncher", FakeLauncher)
+    monkeypatch.setattr(mod, "MultiClusterLauncher", FakeMultiClusterLauncher)
+    monkeypatch.setattr(mod, "load_kube_client", lambda *args, **kwargs: (args, kwargs))
     monkeypatch.setattr(mod, "ModelCatalogStore", lambda client: ("catalogs", client))
     monkeypatch.setattr(mod, "CapacityRefresher", FakeRefresher)
     monkeypatch.setattr(mod, "Orca", orca_cls)
@@ -85,7 +89,8 @@ def test_main_once_uses_dynamo_launcher(monkeypatch):
 
     assert FakeLauncher.instances[0].namespace == "koi"
     assert FakeOrca.instances[0].client == "client"
-    assert FakeOrca.instances[0].launcher is FakeLauncher.instances[0]
+    assert FakeOrca.instances[0].launcher is FakeMultiClusterLauncher.instances[0]
+    assert FakeMultiClusterLauncher.instances[0].default_cluster == "default"
     assert FakeOrca.instances[0].applied_users == ["default"]
     assert FakeRefresher.instances[0].client == "client"
     assert FakeRefresher.instances[0].regions == [
@@ -132,9 +137,35 @@ def test_main_enables_local_router_config(monkeypatch):
     )
 
     assert FakeLauncher.instances[0].namespace == "serving"
-    assert FakeLauncher.instances[0].router_config_dir == "/tmp/router-configs"
-    assert FakeLauncher.instances[0].router_port_base == 20000
-    assert FakeLauncher.instances[0].model_catalogs == ("catalogs", "client")
+    multi = FakeMultiClusterLauncher.instances[0]
+    assert multi.router_config_dir == "/tmp/router-configs"
+    assert multi.router_port_base == 20000
+    assert multi.model_catalogs == ("catalogs", "client")
+
+
+def test_main_maps_cloud_regions_to_kube_contexts(monkeypatch, tmp_path):
+    _patch_runner(monkeypatch)
+    contexts = tmp_path / "contexts.json"
+    contexts.write_text('{"aws|us-east-1":"eks-east","gcp|us-central1":"gke-central"}')
+
+    mod.main(
+        [
+            "--user-id",
+            "default",
+            "--cluster-contexts",
+            str(contexts),
+            "--once",
+        ]
+    )
+
+    multi = FakeMultiClusterLauncher.instances[0]
+    assert set(multi.launchers) == {"aws|us-east-1", "gcp|us-central1"}
+    assert [launcher.context for launcher in FakeLauncher.instances] == [
+        "eks-east",
+        "gke-central",
+    ]
+    assert FakeLauncher.instances[0].k8s == (("default",), {"context": "eks-east"})
+    assert multi.default_cluster is None
 
 
 def test_main_requires_user_id(monkeypatch):

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -14,11 +14,16 @@ class FakeOrca:
         self.client = client
         self.launcher = launcher
         self.applied_users: list[str] = []
+        self.reconciled_users: list[str] = []
         FakeOrca.instances.append(self)
 
     def apply_pending(self, user_id: str) -> int:
         self.applied_users.append(user_id)
         return 1
+
+    def reconcile_running(self, user_id: str) -> int:
+        self.reconciled_users.append(user_id)
+        return 0
 
 
 class FailingOnceOrca(FakeOrca):
@@ -93,6 +98,7 @@ def test_main_once_uses_dynamo_launcher(monkeypatch):
     assert FakeOrca.instances[0].launcher is FakeMultiClusterLauncher.instances[0]
     assert FakeMultiClusterLauncher.instances[0].default_cluster == "default"
     assert FakeOrca.instances[0].applied_users == ["default"]
+    assert FakeOrca.instances[0].reconciled_users == ["default"]
     assert FakeRefresher.instances[0].client == "client"
     assert FakeRefresher.instances[0].regions == [
         "us-east-1",

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -114,7 +114,7 @@ def test_main_once_uses_dynamo_launcher(monkeypatch):
         "us-west-1",
         "us-west-2",
     ]
-    assert FakeRefresher.instances[0].calls == [True, False]
+    assert FakeRefresher.instances[0].calls == [True]
 
 
 def test_main_uses_env_defaults(monkeypatch):

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -70,6 +70,14 @@ class FakeRefresher:
         return True
 
 
+class FakeTunnels:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
 def _patch_runner(monkeypatch, orca_cls=FakeOrca):
     FakeOrca.instances.clear()
     FakeLauncher.instances.clear()
@@ -81,7 +89,7 @@ def _patch_runner(monkeypatch, orca_cls=FakeOrca):
     monkeypatch.setattr(mod, "MultiClusterLauncher", FakeMultiClusterLauncher)
     monkeypatch.setattr(mod, "load_kube_client", lambda *args, **kwargs: (args, kwargs))
     monkeypatch.setattr(mod, "ModelCatalogStore", lambda client: ("catalogs", client))
-    monkeypatch.setattr(mod, "PortForwardManager", lambda: "tunnels")
+    monkeypatch.setattr(mod, "PortForwardManager", FakeTunnels)
     monkeypatch.setattr(mod, "CapacityRefresher", FakeRefresher)
     monkeypatch.setattr(mod, "Orca", orca_cls)
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: sleeps.append(seconds))
@@ -148,7 +156,8 @@ def test_main_enables_local_router_config(monkeypatch):
     assert multi.router_config_dir == "/tmp/router-configs"
     assert multi.router_port_base == 20000
     assert multi.model_catalogs == ("catalogs", "client")
-    assert multi.tunnels == "tunnels"
+    assert isinstance(multi.tunnels, FakeTunnels)
+    assert multi.tunnels.closed
 
 
 def test_main_maps_cloud_regions_to_kube_contexts(monkeypatch, tmp_path):

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -178,6 +178,14 @@ def test_main_requires_user_id(monkeypatch):
         mod.main(["--once"])
 
 
+def test_main_can_skip_capacity_refresh(monkeypatch):
+    _patch_runner(monkeypatch)
+
+    mod.main(["--user-id", "default", "--skip-capacity-refresh", "--once"])
+
+    assert FakeRefresher.instances[0].calls == []
+
+
 def test_runner_logs_error_and_retries(monkeypatch):
     sleeps = _patch_runner(monkeypatch, FailingOnceOrca)
 

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -32,8 +32,10 @@ class FailingOnceOrca(FakeOrca):
 class FakeLauncher:
     instances: ClassVar[list[FakeLauncher]] = []
 
-    def __init__(self, namespace: str) -> None:
+    def __init__(self, namespace: str, router_k8s=None, router_image=None) -> None:
         self.namespace = namespace
+        self.router_k8s = router_k8s
+        self.router_image = router_image
         FakeLauncher.instances.append(self)
 
 
@@ -60,6 +62,7 @@ def _patch_runner(monkeypatch, orca_cls=FakeOrca):
     sleeps: list[float] = []
     monkeypatch.setattr(mod, "PostgresClient", lambda: "client")
     monkeypatch.setattr(mod, "DynamoLauncher", FakeLauncher)
+    monkeypatch.setattr(mod, "load_kube_client", lambda *args: ("router-k8s", args))
     monkeypatch.setattr(mod, "CapacityRefresher", FakeRefresher)
     monkeypatch.setattr(mod, "Orca", orca_cls)
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: sleeps.append(seconds))
@@ -100,6 +103,32 @@ def test_main_uses_env_defaults(monkeypatch):
     assert args.interval_seconds == 7
     assert args.aws_regions == "us-west-2,us-east-2"
     assert args.capacity_refresh_seconds == 12
+
+
+def test_main_wires_router_control_plane_client(monkeypatch):
+    _patch_runner(monkeypatch)
+
+    mod.main(
+        [
+            "--user-id",
+            "default",
+            "--router-namespace",
+            "routing",
+            "--router-kubeconfig",
+            "/config/control",
+            "--router-context",
+            "control",
+            "--router-image",
+            "registry.example/tandemn-router:test",
+            "--once",
+        ]
+    )
+
+    assert FakeLauncher.instances[0].router_k8s == (
+        "router-k8s",
+        ("routing", "/config/control", "control"),
+    )
+    assert FakeLauncher.instances[0].router_image == "registry.example/tandemn-router:test"
 
 
 def test_main_requires_user_id(monkeypatch):

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -32,10 +32,13 @@ class FailingOnceOrca(FakeOrca):
 class FakeLauncher:
     instances: ClassVar[list[FakeLauncher]] = []
 
-    def __init__(self, namespace: str, router_k8s=None, router_image=None) -> None:
+    def __init__(
+        self, namespace: str, router_k8s=None, router_image=None, model_catalogs=None
+    ) -> None:
         self.namespace = namespace
         self.router_k8s = router_k8s
         self.router_image = router_image
+        self.model_catalogs = model_catalogs
         FakeLauncher.instances.append(self)
 
 
@@ -63,6 +66,7 @@ def _patch_runner(monkeypatch, orca_cls=FakeOrca):
     monkeypatch.setattr(mod, "PostgresClient", lambda: "client")
     monkeypatch.setattr(mod, "DynamoLauncher", FakeLauncher)
     monkeypatch.setattr(mod, "load_kube_client", lambda *args: ("router-k8s", args))
+    monkeypatch.setattr(mod, "ModelCatalogStore", lambda client: ("catalogs", client))
     monkeypatch.setattr(mod, "CapacityRefresher", FakeRefresher)
     monkeypatch.setattr(mod, "Orca", orca_cls)
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: sleeps.append(seconds))
@@ -129,6 +133,7 @@ def test_main_wires_router_control_plane_client(monkeypatch):
         ("routing", "/config/control", "control"),
     )
     assert FakeLauncher.instances[0].router_image == "registry.example/tandemn-router:test"
+    assert FakeLauncher.instances[0].model_catalogs == ("catalogs", "client")
 
 
 def test_main_requires_user_id(monkeypatch):

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -76,6 +76,7 @@ def _patch_runner(monkeypatch, orca_cls=FakeOrca):
     monkeypatch.setattr(mod, "MultiClusterLauncher", FakeMultiClusterLauncher)
     monkeypatch.setattr(mod, "load_kube_client", lambda *args, **kwargs: (args, kwargs))
     monkeypatch.setattr(mod, "ModelCatalogStore", lambda client: ("catalogs", client))
+    monkeypatch.setattr(mod, "PortForwardManager", lambda: "tunnels")
     monkeypatch.setattr(mod, "CapacityRefresher", FakeRefresher)
     monkeypatch.setattr(mod, "Orca", orca_cls)
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: sleeps.append(seconds))
@@ -141,6 +142,7 @@ def test_main_enables_local_router_config(monkeypatch):
     assert multi.router_config_dir == "/tmp/router-configs"
     assert multi.router_port_base == 20000
     assert multi.model_catalogs == ("catalogs", "client")
+    assert multi.tunnels == "tunnels"
 
 
 def test_main_maps_cloud_regions_to_kube_contexts(monkeypatch, tmp_path):

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -32,9 +32,18 @@ class FailingOnceOrca(FakeOrca):
 class FakeLauncher:
     instances: ClassVar[list[FakeLauncher]] = []
 
-    def __init__(self, namespace: str, router_image=None, model_catalogs=None) -> None:
+    def __init__(
+        self,
+        namespace: str,
+        router_config_dir=None,
+        router_port_base=18000,
+        router_port_span=10000,
+        model_catalogs=None,
+    ) -> None:
         self.namespace = namespace
-        self.router_image = router_image
+        self.router_config_dir = router_config_dir
+        self.router_port_base = router_port_base
+        self.router_port_span = router_port_span
         self.model_catalogs = model_catalogs
         FakeLauncher.instances.append(self)
 
@@ -105,7 +114,7 @@ def test_main_uses_env_defaults(monkeypatch):
     assert args.capacity_refresh_seconds == 12
 
 
-def test_main_enables_colocated_router(monkeypatch):
+def test_main_enables_local_router_config(monkeypatch):
     _patch_runner(monkeypatch)
 
     mod.main(
@@ -114,14 +123,17 @@ def test_main_enables_colocated_router(monkeypatch):
             "default",
             "--namespace",
             "serving",
-            "--router-image",
-            "registry.example/tandemn-router:test",
+            "--router-config-dir",
+            "/tmp/router-configs",
+            "--router-port-base",
+            "20000",
             "--once",
         ]
     )
 
     assert FakeLauncher.instances[0].namespace == "serving"
-    assert FakeLauncher.instances[0].router_image == "registry.example/tandemn-router:test"
+    assert FakeLauncher.instances[0].router_config_dir == "/tmp/router-configs"
+    assert FakeLauncher.instances[0].router_port_base == 20000
     assert FakeLauncher.instances[0].model_catalogs == ("catalogs", "client")
 
 

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -32,11 +32,8 @@ class FailingOnceOrca(FakeOrca):
 class FakeLauncher:
     instances: ClassVar[list[FakeLauncher]] = []
 
-    def __init__(
-        self, namespace: str, router_k8s=None, router_image=None, model_catalogs=None
-    ) -> None:
+    def __init__(self, namespace: str, router_image=None, model_catalogs=None) -> None:
         self.namespace = namespace
-        self.router_k8s = router_k8s
         self.router_image = router_image
         self.model_catalogs = model_catalogs
         FakeLauncher.instances.append(self)
@@ -65,7 +62,6 @@ def _patch_runner(monkeypatch, orca_cls=FakeOrca):
     sleeps: list[float] = []
     monkeypatch.setattr(mod, "PostgresClient", lambda: "client")
     monkeypatch.setattr(mod, "DynamoLauncher", FakeLauncher)
-    monkeypatch.setattr(mod, "load_kube_client", lambda *args: ("router-k8s", args))
     monkeypatch.setattr(mod, "ModelCatalogStore", lambda client: ("catalogs", client))
     monkeypatch.setattr(mod, "CapacityRefresher", FakeRefresher)
     monkeypatch.setattr(mod, "Orca", orca_cls)
@@ -109,29 +105,22 @@ def test_main_uses_env_defaults(monkeypatch):
     assert args.capacity_refresh_seconds == 12
 
 
-def test_main_wires_router_control_plane_client(monkeypatch):
+def test_main_enables_colocated_router(monkeypatch):
     _patch_runner(monkeypatch)
 
     mod.main(
         [
             "--user-id",
             "default",
-            "--router-namespace",
-            "routing",
-            "--router-kubeconfig",
-            "/config/control",
-            "--router-context",
-            "control",
+            "--namespace",
+            "serving",
             "--router-image",
             "registry.example/tandemn-router:test",
             "--once",
         ]
     )
 
-    assert FakeLauncher.instances[0].router_k8s == (
-        "router-k8s",
-        ("routing", "/config/control", "control"),
-    )
+    assert FakeLauncher.instances[0].namespace == "serving"
     assert FakeLauncher.instances[0].router_image == "registry.example/tandemn-router:test"
     assert FakeLauncher.instances[0].model_catalogs == ("catalogs", "client")
 

--- a/tests/test_orca_smoke.py
+++ b/tests/test_orca_smoke.py
@@ -161,11 +161,9 @@ def test_ladder_to_chains_skips_malformed():
         },
     ]
     chains = ladder_to_chains(ladder, job_id="j", plan_id="p")
-    assert len(chains) == 2
+    assert len(chains) == 1
     assert chains[0].role == ChainRole.AGGREGATE
-    # rank_id comes from Koi's ladder entry; entries without one carry none.
-    assert "rank_id" not in chains[0].shape_json
-    assert chains[1].shape_json["rank_id"] == "rank_7"
+    assert chains[0].shape_json["rank_id"] == "rank_7"
 
 
 def test_ladder_to_chains_backfills_launch_fields():
@@ -173,6 +171,7 @@ def test_ladder_to_chains_backfills_launch_fields():
     ladder = [
         {
             "role": "aggregate",
+            "rank_id": "rank_0",
             "env": ["on_demand", "aws", "us-east-1", "use1-az1", "L4"],
             "config": {"gpu_count": 2, "instance_type": "g6.12xlarge", "tp": 2},
         }

--- a/tests/test_orca_smoke.py
+++ b/tests/test_orca_smoke.py
@@ -93,6 +93,13 @@ class FakeJobStore:
             if rank.job_id == job_id and rank.status in (RankStatus.LAUNCHING, RankStatus.RUNNING)
         ]
 
+    def running_jobs(self, user_id):
+        return [
+            SimpleNamespace(job=SimpleNamespace(job_id=job_id), ranks=self.active_ranks(job_id))
+            for job_id, status in self.job_statuses.items()
+            if status is JobStatus.RUNNING
+        ]
+
     def set_rank_status(self, rank_id, to, expected, *, reason_code=None):
         self.rank_status.append((rank_id, to, list(expected), reason_code))
         rank = self.rows.get(rank_id)
@@ -513,6 +520,28 @@ def test_keep_and_defer_are_noops(monkeypatch):
     assert orca._jobs.launched == []
     assert orca._jobs.rank_status == []
     assert orca._launcher.torn_down_jobs == []
+
+
+def test_reconcile_running_restores_active_rank(monkeypatch):
+    rank = Rank(
+        rank_id=RANK_ID,
+        job_id="job_B",
+        plan_id="plan_1",
+        role=RankRole.AGGREGATE,
+        status=RankStatus.RUNNING,
+        shape_json={"count": 1},
+        n_replicas=1,
+    )
+    orca = _build_orca(
+        monkeypatch,
+        [],
+        active=[rank],
+        job_statuses={"job_B": JobStatus.RUNNING},
+    )
+
+    assert orca.reconcile_running("user_1") == 1
+    assert orca._launcher.reconciled[0][0] == "job_B"
+    assert [restored.rank_id for restored in orca._launcher.reconciled[0][1]] == [RANK_ID]
 
 
 def test_preempt_tears_down_and_pauses(monkeypatch):

--- a/tests/test_orca_smoke.py
+++ b/tests/test_orca_smoke.py
@@ -21,6 +21,7 @@ from tandemn_system_data.models.plan import Plan, PlanAction
 from tandemn_system_data.models.rank import Rank
 
 import tandemn_orca.orca as orca_mod
+from tandemn_orca.launcher import ModelCatalogError
 from tandemn_orca.orca import Orca, ladder_to_ranks
 
 RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
@@ -59,6 +60,8 @@ class FakeJobStore:
         self.rank_status: list[tuple[str, RankStatus, list[RankStatus], str | None]] = []
         self.rows = {rank.rank_id: rank.model_copy(deep=True) for rank in active or []}
         self.job_statuses = dict(job_statuses or {})
+        self.failures: list[tuple[str, str, str]] = []
+        self.errors: dict[str, str | None] = {}
 
     def transition(self, job_id, to, expected, *, finish_reason=None):
         self.transitions.append((job_id, to, list(expected)))
@@ -97,6 +100,18 @@ class FakeJobStore:
             return False
         self.rows[rank_id] = rank.model_copy(update={"status": to, "reason_code": reason_code})
         return True
+
+    def fail(self, job_id, expected, *, finish_reason, error_message):
+        if self.job_statuses.get(job_id) not in expected:
+            return False
+        self.job_statuses[job_id] = JobStatus.FINISHED
+        self.failures.append((job_id, finish_reason, error_message))
+        self.errors[job_id] = error_message
+        return True
+
+    def set_error(self, job_id, error_message):
+        self.errors[job_id] = error_message
+        return job_id in self.job_statuses
 
 
 class FakePlanStore:
@@ -375,6 +390,56 @@ def test_place_failure_restores_previous_job_status(monkeypatch, previous_status
         ("job_B", previous_status, [JobStatus.RUNNING]),
     ]
     assert orca._jobs.rows[RANK_ID].status is RankStatus.FAILED
+
+
+def test_place_catalog_failure_finishes_job_with_visible_error(monkeypatch):
+    plan = Plan(
+        user_id="user_1",
+        actions=[PlanAction(job_id="job_B", type=ActionType.PLACE, ladder=EXPLICIT_LADDER)],
+    )
+    orca = _build_orca(monkeypatch, [plan])
+    message = "ModelCatalog 'model' field 'max_num_seq' is missing for gpu_type 'L40S'"
+
+    def fail_catalog(*_):
+        raise ModelCatalogError(message)
+
+    orca._launcher.reconcile = fail_catalog
+
+    assert orca.apply_pending("user_1") == 1
+
+    assert orca._jobs.job_statuses["job_B"] is JobStatus.FINISHED
+    assert orca._jobs.failures == [("job_B", ReasonCode.MODEL_CATALOG_INVALID, message)]
+    assert orca._jobs.rows[RANK_ID].reason_code == ReasonCode.MODEL_CATALOG_INVALID
+
+
+def test_swap_catalog_failure_keeps_running_job_and_records_error(monkeypatch):
+    old_rank = Rank(
+        rank_id=OLD_RANK_ID,
+        job_id="job_F",
+        plan_id="plan_prev",
+        role=RankRole.AGGREGATE,
+        status=RankStatus.RUNNING,
+        shape_json={"count": 1},
+        n_replicas=1,
+    )
+    plan = Plan(
+        user_id="user_1",
+        actions=[PlanAction(job_id="job_F", type=ActionType.SWAP, ladder=EXPLICIT_LADDER)],
+    )
+    orca = _build_orca(monkeypatch, [plan], active=[old_rank])
+    message = "ModelCatalog 'model' is missing"
+
+    def fail_catalog(*_):
+        raise ModelCatalogError(message)
+
+    orca._launcher.reconcile = fail_catalog
+
+    assert orca.apply_pending("user_1") == 1
+
+    assert orca._jobs.job_statuses["job_F"] is JobStatus.RUNNING
+    assert orca._jobs.errors["job_F"] == message
+    assert orca._jobs.rows[OLD_RANK_ID] == old_rank
+    assert orca._jobs.rows[RANK_ID].reason_code == ReasonCode.MODEL_CATALOG_INVALID
 
 
 def test_swap_reuses_rank_with_new_replica_count_and_stops_removed_rank(monkeypatch):

--- a/tests/test_orca_smoke.py
+++ b/tests/test_orca_smoke.py
@@ -108,6 +108,7 @@ def test_ladder_to_chains_expands_replicas():
     roles = [c.role for c in chains]
     assert roles == [ChainRole.AGGREGATE, ChainRole.AGGREGATE, ChainRole.AGGREGATE]
     assert all(c.job_id == "job_B" and c.plan_id == "plan_1" for c in chains)
+    assert [c.shape_json["replica_index"] for c in chains] == [0, 1, 2]
 
 
 def test_ladder_to_chains_accepts_explicit_koi_rank():
@@ -133,6 +134,7 @@ def test_ladder_to_chains_accepts_explicit_koi_rank():
         "cp": 1,
         "count": 1,
         "rank_id": "rank_0",
+        "replica_index": 0,
         "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
         "mechanism_id": "queueing_under_burst",
         "predicted_y": {"p99_ttft_ms": 120.0},

--- a/tests/test_orca_smoke.py
+++ b/tests/test_orca_smoke.py
@@ -1,30 +1,36 @@
 """Smoke test for the Orca apply-plan loop (place + swap).
 
 No Postgres: fake JobStore/PlanStore record the calls the loop makes, so
-we can assert each action type drives the right transition, chain
+we can assert each action type drives the right transition, rank
 launches, teardown, and that plans get marked applied once.
 """
 
 from __future__ import annotations
 
-from tandemn_system_data.models.chain import Chain
+from types import SimpleNamespace
+
+import pytest
 from tandemn_system_data.models.enums import (
     ActionType,
-    ChainRole,
-    ChainStatus,
-    JobKind,
     JobStatus,
+    RankRole,
+    RankStatus,
+    ReasonCode,
 )
-from tandemn_system_data.models.job import ChainAllocation, Job, RunningJob
 from tandemn_system_data.models.plan import Plan, PlanAction
+from tandemn_system_data.models.rank import Rank
 
 import tandemn_orca.orca as orca_mod
-from tandemn_orca.orca import Orca, ladder_to_chains
+from tandemn_orca.orca import Orca, ladder_to_ranks
+
+RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
+OLD_RANK_ID = "rank_01JBM30YQ7X3WQAR6HF8C2Q9T8"
+NEW_RANK_ID = "rank_01JBM31YQ7X3WQAR6HF8C2Q9T8"
 
 EXPLICIT_LADDER = [
     {
         "role": "aggregate",
-        "rank_id": "rank_0",
+        "rank_id": RANK_ID,
         "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
         "config": {
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
@@ -43,28 +49,53 @@ EXPLICIT_LADDER = [
 
 
 class FakeJobStore:
-    def __init__(self, running: list[RunningJob] | None = None) -> None:
+    def __init__(
+        self,
+        active: list[Rank] | None = None,
+        job_statuses: dict[str, JobStatus] | None = None,
+    ) -> None:
         self.transitions: list[tuple[str, JobStatus, list[JobStatus]]] = []
-        self.launched: list[Chain] = []
-        self.chain_status: list[tuple[str, ChainStatus, list[ChainStatus]]] = []
-        self._running = running or []
+        self.launched: list[Rank] = []
+        self.rank_status: list[tuple[str, RankStatus, list[RankStatus], str | None]] = []
+        self.rows = {rank.rank_id: rank.model_copy(deep=True) for rank in active or []}
+        self.job_statuses = dict(job_statuses or {})
 
     def transition(self, job_id, to, expected, *, finish_reason=None):
         self.transitions.append((job_id, to, list(expected)))
+        if self.job_statuses.get(job_id) not in expected:
+            return False
+        self.job_statuses[job_id] = to
         return True
 
     def get(self, job_id):
-        return None
+        status = self.job_statuses.get(job_id)
+        return SimpleNamespace(spec_json={}, status=status) if status else None
 
-    def launch_chains(self, chains):
-        self.launched.extend(chains)
-        return chains
+    def launch_ranks(self, ranks):
+        self.launched.extend(ranks)
+        for rank in ranks:
+            existing = self.rows.get(rank.rank_id)
+            if existing and existing.job_id != rank.job_id:
+                raise ValueError(f"rank {rank.rank_id} already belongs to another job")
+            self.rows[rank.rank_id] = rank.model_copy(
+                deep=True,
+                update={"created_at": existing.created_at} if existing else {},
+            )
+        return ranks
 
-    def running_jobs(self, user_id):
-        return list(self._running)
+    def active_ranks(self, job_id):
+        return [
+            rank.model_copy(deep=True)
+            for rank in self.rows.values()
+            if rank.job_id == job_id and rank.status in (RankStatus.LAUNCHING, RankStatus.RUNNING)
+        ]
 
-    def set_chain_status(self, chain_id, to, expected):
-        self.chain_status.append((chain_id, to, list(expected)))
+    def set_rank_status(self, rank_id, to, expected, *, reason_code=None):
+        self.rank_status.append((rank_id, to, list(expected), reason_code))
+        rank = self.rows.get(rank_id)
+        if rank is None or rank.status not in expected:
+            return False
+        self.rows[rank_id] = rank.model_copy(update={"status": to, "reason_code": reason_code})
         return True
 
 
@@ -83,36 +114,48 @@ class FakePlanStore:
 
 class FakeLauncher:
     def __init__(self) -> None:
-        self.reconciled: list[tuple[str, list[Chain]]] = []
+        self.reconciled: list[tuple[str, list[Rank]]] = []
         self.torn_down_jobs: list[str] = []
 
-    def reconcile(self, job_id, chains):
-        self.reconciled.append((job_id, list(chains)))
+    def reconcile(self, job_id, ranks):
+        self.reconciled.append((job_id, list(ranks)))
 
     def teardown_job(self, job_id):
         self.torn_down_jobs.append(job_id)
 
 
-def _build_orca(monkeypatch, plans, running=None):
-    monkeypatch.setattr(orca_mod, "JobStore", lambda client: FakeJobStore(running))
+def _build_orca(monkeypatch, plans, active=None, job_statuses=None):
+    inferred_statuses = {
+        action.job_id: (
+            JobStatus.RUNNING
+            if action.type in (ActionType.SWAP, ActionType.PREEMPT)
+            else JobStatus.WAITING
+        )
+        for plan in plans
+        for action in plan.actions
+    }
+    inferred_statuses.update(job_statuses or {})
+    monkeypatch.setattr(
+        orca_mod,
+        "JobStore",
+        lambda client: FakeJobStore(active, inferred_statuses),
+    )
     monkeypatch.setattr(orca_mod, "PlanStore", lambda client: FakePlanStore(plans))
     return Orca(client=object(), launcher=FakeLauncher())
 
 
-# ----- ladder_to_chains ------------------------------------------------------
+# ----- ladder_to_ranks -------------------------------------------------------
 
 
-def test_ladder_to_chains_expands_replicas():
-    chains = ladder_to_chains(EXPLICIT_LADDER, job_id="job_B", plan_id="plan_1")
-    assert len(chains) == 3
-    roles = [c.role for c in chains]
-    assert roles == [ChainRole.AGGREGATE, ChainRole.AGGREGATE, ChainRole.AGGREGATE]
-    assert all(c.job_id == "job_B" and c.plan_id == "plan_1" for c in chains)
-    assert [c.shape_json["replica_index"] for c in chains] == [0, 1, 2]
+def test_ladder_to_ranks_keeps_replicas_on_one_rank():
+    ranks = ladder_to_ranks(EXPLICIT_LADDER, job_id="job_B", plan_id="plan_1")
+    assert len(ranks) == 1
+    assert ranks[0].role == RankRole.AGGREGATE
+    assert (ranks[0].job_id, ranks[0].plan_id, ranks[0].n_replicas) == ("job_B", "plan_1", 3)
 
 
-def test_ladder_to_chains_accepts_explicit_koi_rank():
-    chains = ladder_to_chains(
+def test_ladder_to_ranks_accepts_explicit_koi_rank():
+    ranks = ladder_to_ranks(
         EXPLICIT_LADDER,
         job_id="job_online_001",
         plan_id="plan_1",
@@ -120,9 +163,10 @@ def test_ladder_to_chains_accepts_explicit_koi_rank():
         target_p99_tpot_ms=50.0,
     )
 
-    assert len(chains) == 3
-    assert all(c.role == ChainRole.AGGREGATE for c in chains)
-    assert chains[0].shape_json == {
+    assert len(ranks) == 1
+    assert ranks[0].rank_id == RANK_ID
+    assert ranks[0].role == RankRole.AGGREGATE
+    assert ranks[0].shape_json == {
         "model_id": "meta-llama/Llama-3.1-8B-Instruct",
         "engine_name": "vllm",
         "instance_type": "g6e.12xlarge",
@@ -133,8 +177,6 @@ def test_ladder_to_chains_accepts_explicit_koi_rank():
         "ep": 1,
         "cp": 1,
         "count": 1,
-        "rank_id": "rank_0",
-        "replica_index": 0,
         "env": ["reserved", "aws", "us-east-2", "use2-az3", "L40S"],
         "mechanism_id": "queueing_under_burst",
         "predicted_y": {"p99_ttft_ms": 120.0},
@@ -144,7 +186,7 @@ def test_ladder_to_chains_accepts_explicit_koi_rank():
     }
 
 
-def test_ladder_to_chains_skips_malformed():
+def test_ladder_to_ranks_skips_malformed():
     ok_config = {"gpu_count": 1, "instance_type": "g6.xlarge", "model_id": "m"}
     ladder = [
         {"role": "aggregate", "env": ["reserved", "aws", "r", "z", "L4"], "config": ok_config},
@@ -152,44 +194,69 @@ def test_ladder_to_chains_skips_malformed():
         {"role": "aggregate", "config": {"gpu_count": 0}},  # non-positive -> skip
         {"role": "bogus", "config": dict(ok_config)},  # bad role -> skip
         {"role": "aggregate", "config": dict(ok_config), "n_replicas": 0},  # bad replicas
+        {"role": "aggregate", "rank_id": "rank_7", "config": dict(ok_config)},
         "not-a-dict",  # skip
         # no instance_type -> unlaunchable -> skip
         {"role": "aggregate", "config": {"gpu_count": 1, "model_id": "m", "gpu_type": "L4"}},
         {
             "role": "aggregate",
-            "rank_id": "rank_7",
+            "rank_id": RANK_ID,
             "env": ["reserved", "aws", "r", "z", "L4"],
             "config": dict(ok_config),
         },
     ]
-    chains = ladder_to_chains(ladder, job_id="j", plan_id="p")
-    assert len(chains) == 1
-    assert chains[0].role == ChainRole.AGGREGATE
-    assert chains[0].shape_json["rank_id"] == "rank_7"
+    ranks = ladder_to_ranks(ladder, job_id="j", plan_id="p")
+    assert len(ranks) == 1
+    assert ranks[0].role == RankRole.AGGREGATE
+    assert ranks[0].rank_id == RANK_ID
 
 
-def test_ladder_to_chains_backfills_launch_fields():
+def test_ladder_to_ranks_backfills_launch_fields():
     """gpu_type from env[4], model_id from the job spec, engine_name default."""
     ladder = [
         {
             "role": "aggregate",
-            "rank_id": "rank_0",
+            "rank_id": RANK_ID,
             "env": ["on_demand", "aws", "us-east-1", "use1-az1", "L4"],
             "config": {"gpu_count": 2, "instance_type": "g6.12xlarge", "tp": 2},
         }
     ]
-    chains = ladder_to_chains(
+    ranks = ladder_to_ranks(
         ladder, job_id="j", plan_id="p", job_spec={"model_id": "Qwen/Qwen3-0.6B"}
     )
-    assert len(chains) == 1
-    shape = chains[0].shape_json
+    assert len(ranks) == 1
+    shape = ranks[0].shape_json
     assert shape["gpu_type"] == "L4"
     assert shape["model_id"] == "Qwen/Qwen3-0.6B"
     assert shape["engine_name"] == "vllm"
 
 
-def test_ladder_to_chains_none():
-    assert ladder_to_chains(None, job_id="j", plan_id="p") == []
+def test_ladder_to_ranks_none():
+    assert ladder_to_ranks(None, job_id="j", plan_id="p") == []
+
+
+def test_ladder_to_ranks_rejects_duplicate_rank_ids():
+    with pytest.raises(ValueError, match="duplicate rank_id"):
+        ladder_to_ranks([EXPLICIT_LADDER[0], EXPLICIT_LADDER[0]], job_id="j", plan_id="p")
+
+
+def test_duplicate_place_ranks_do_not_transition_or_persist(monkeypatch):
+    plan = Plan(
+        user_id="user_1",
+        actions=[
+            PlanAction(
+                job_id="job_B",
+                type=ActionType.PLACE,
+                ladder=[EXPLICIT_LADDER[0], EXPLICIT_LADDER[0]],
+            )
+        ],
+    )
+    orca = _build_orca(monkeypatch, [plan])
+
+    assert orca.apply_pending("user_1") == 1
+    assert orca._jobs.transitions == []
+    assert orca._jobs.rows == {}
+    assert orca._launcher.reconciled == []
 
 
 # ----- apply loop ------------------------------------------------------------
@@ -216,41 +283,154 @@ def test_place_transitions_and_launches(monkeypatch):
         ("job_B", JobStatus.RUNNING, [JobStatus.WAITING, JobStatus.PAUSED]),
     ]
     # rows recorded in the store AND workers brought up via the launcher
-    assert len(orca._jobs.launched) == 3
+    assert len(orca._jobs.launched) == 1
     assert len(orca._launcher.reconciled) == 1
     assert orca._launcher.reconciled[0][0] == "job_B"
-    assert len(orca._launcher.reconciled[0][1]) == 3
+    assert len(orca._launcher.reconciled[0][1]) == 1
     assert orca._jobs.launched[0].shape_json["target_p99_ttft_ms"] == 500.0
     assert orca._jobs.launched[0].shape_json["target_p99_tpot_ms"] == 50.0
+    assert orca._jobs.rank_status == [(RANK_ID, RankStatus.RUNNING, [RankStatus.LAUNCHING], None)]
 
 
 def test_swap_launches_new_and_tears_down_old(monkeypatch):
-    job = Job(job_id="job_F", user_id="user_1", kind=JobKind.ONLINE, status=JobStatus.RUNNING)
-    old_chain = ChainAllocation(
-        chain_id="chain_old",
+    old_rank = Rank(
+        rank_id=OLD_RANK_ID,
+        job_id="job_F",
         plan_id="plan_prev",
-        role=ChainRole.PREFILL,
-        status=ChainStatus.RUNNING,
+        role=RankRole.PREFILL,
+        status=RankStatus.RUNNING,
         shape_json={"gpu": "H100", "count": 8},
+        n_replicas=1,
     )
-    running = [RunningJob(job=job, chains=[old_chain])]
     plan = Plan(
         user_id="user_1",
         actions=[PlanAction(job_id="job_F", type=ActionType.SWAP, ladder=EXPLICIT_LADDER)],
     )
-    orca = _build_orca(monkeypatch, [plan], running=running)
+    orca = _build_orca(monkeypatch, [plan], active=[old_rank])
 
     assert orca.apply_pending("user_1") == 1
     # swap does not transition the job (stays running)
     assert orca._jobs.transitions == []
     # new ladder launched (rows + workers)
-    assert len(orca._jobs.launched) == 3
-    assert len(orca._launcher.reconciled[0][1]) == 3
+    assert len(orca._jobs.launched) == 1
+    assert len(orca._launcher.reconciled[0][1]) == 1
     # stale DGDs are deleted by reconcile diff; swap only marks old rows stopped.
     assert orca._launcher.torn_down_jobs == []
-    assert orca._jobs.chain_status == [
-        ("chain_old", ChainStatus.STOPPED, [ChainStatus.LAUNCHING, ChainStatus.RUNNING]),
+    assert orca._jobs.rank_status == [
+        (RANK_ID, RankStatus.RUNNING, [RankStatus.LAUNCHING], None),
+        (OLD_RANK_ID, RankStatus.STOPPED, [RankStatus.LAUNCHING, RankStatus.RUNNING], None),
     ]
+
+
+def test_swap_failure_restores_reused_rank_and_fails_only_new_rank(monkeypatch):
+    reused_rank = Rank(
+        rank_id=RANK_ID,
+        job_id="job_F",
+        plan_id="plan_prev",
+        role=RankRole.PREFILL,
+        status=RankStatus.RUNNING,
+        shape_json={"count": 2, "old": True},
+        n_replicas=1,
+    )
+    ladder = [
+        EXPLICIT_LADDER[0],
+        {**EXPLICIT_LADDER[0], "rank_id": NEW_RANK_ID},
+    ]
+    plan = Plan(
+        user_id="user_1",
+        actions=[PlanAction(job_id="job_F", type=ActionType.SWAP, ladder=ladder)],
+    )
+    orca = _build_orca(monkeypatch, [plan], active=[reused_rank])
+
+    def fail_reconcile(job_id, ranks):
+        raise RuntimeError("boom")
+
+    orca._launcher.reconcile = fail_reconcile
+
+    assert orca.apply_pending("user_1") == 1
+    assert orca._jobs.rows[RANK_ID] == reused_rank
+    assert orca._jobs.rows[NEW_RANK_ID].status is RankStatus.FAILED
+    assert orca._jobs.rank_status == [
+        (NEW_RANK_ID, RankStatus.FAILED, [RankStatus.LAUNCHING], ReasonCode.LAUNCH_FAILED)
+    ]
+
+
+@pytest.mark.parametrize("previous_status", [JobStatus.WAITING, JobStatus.PAUSED])
+def test_place_failure_restores_previous_job_status(monkeypatch, previous_status):
+    plan = Plan(
+        user_id="user_1",
+        actions=[PlanAction(job_id="job_B", type=ActionType.PLACE, ladder=EXPLICIT_LADDER)],
+    )
+    orca = _build_orca(monkeypatch, [plan], job_statuses={"job_B": previous_status})
+
+    def fail_reconcile(job_id, ranks):
+        raise RuntimeError("boom")
+
+    orca._launcher.reconcile = fail_reconcile
+
+    assert orca.apply_pending("user_1") == 1
+    assert orca._jobs.job_statuses["job_B"] is previous_status
+    assert orca._jobs.transitions == [
+        ("job_B", JobStatus.RUNNING, [JobStatus.WAITING, JobStatus.PAUSED]),
+        ("job_B", previous_status, [JobStatus.RUNNING]),
+    ]
+    assert orca._jobs.rows[RANK_ID].status is RankStatus.FAILED
+
+
+def test_swap_reuses_rank_with_new_replica_count_and_stops_removed_rank(monkeypatch):
+    reused_rank = Rank(
+        rank_id=RANK_ID,
+        job_id="job_F",
+        plan_id="plan_prev",
+        role=RankRole.AGGREGATE,
+        status=RankStatus.RUNNING,
+        shape_json={"count": 1},
+        n_replicas=1,
+    )
+    removed_rank = Rank(
+        rank_id=OLD_RANK_ID,
+        job_id="job_F",
+        plan_id="plan_prev",
+        role=RankRole.PREFILL,
+        status=RankStatus.RUNNING,
+        shape_json={"count": 2},
+        n_replicas=2,
+    )
+    plan = Plan(
+        user_id="user_1",
+        actions=[PlanAction(job_id="job_F", type=ActionType.SWAP, ladder=EXPLICIT_LADDER)],
+    )
+    orca = _build_orca(monkeypatch, [plan], active=[reused_rank, removed_rank])
+
+    assert orca.apply_pending("user_1") == 1
+    assert orca._jobs.launched[0].rank_id == RANK_ID
+    assert orca._jobs.launched[0].n_replicas == 3
+    assert orca._jobs.rows[RANK_ID].n_replicas == 3
+    assert orca._jobs.rows[RANK_ID].status is RankStatus.RUNNING
+    assert orca._jobs.rank_status == [
+        (RANK_ID, RankStatus.RUNNING, [RankStatus.RUNNING], None),
+        (OLD_RANK_ID, RankStatus.STOPPED, [RankStatus.LAUNCHING, RankStatus.RUNNING], None),
+    ]
+
+
+def test_swap_without_launchable_rank_keeps_old_rank(monkeypatch):
+    old_rank = Rank(
+        rank_id=OLD_RANK_ID,
+        job_id="job_F",
+        plan_id="plan_prev",
+        role=RankRole.AGGREGATE,
+        status=RankStatus.RUNNING,
+        shape_json={"count": 1},
+        n_replicas=1,
+    )
+    plan = Plan(
+        user_id="user_1",
+        actions=[PlanAction(job_id="job_F", type=ActionType.SWAP, ladder=[])],
+    )
+    orca = _build_orca(monkeypatch, [plan], active=[old_rank])
+
+    assert orca.apply_pending("user_1") == 1
+    assert orca._jobs.rank_status == []
 
 
 def test_keep_and_defer_are_noops(monkeypatch):
@@ -266,55 +446,61 @@ def test_keep_and_defer_are_noops(monkeypatch):
     assert orca.apply_pending("user_1") == 1
     assert orca._jobs.transitions == []
     assert orca._jobs.launched == []
-    assert orca._jobs.chain_status == []
+    assert orca._jobs.rank_status == []
     assert orca._launcher.torn_down_jobs == []
 
 
 def test_preempt_tears_down_and_pauses(monkeypatch):
-    job = Job(job_id="job_E", user_id="user_1", kind=JobKind.ONLINE, status=JobStatus.RUNNING)
-    chain = ChainAllocation(
-        chain_id="chain_live",
+    rank = Rank(
+        rank_id=OLD_RANK_ID,
+        job_id="job_E",
         plan_id="plan_prev",
-        role=ChainRole.AGGREGATE,
-        status=ChainStatus.RUNNING,
+        role=RankRole.AGGREGATE,
+        status=RankStatus.RUNNING,
         shape_json={"gpu": "L4", "count": 1},
+        n_replicas=1,
     )
     plan = Plan(
         user_id="user_1",
         actions=[PlanAction(job_id="job_E", type=ActionType.PREEMPT)],
     )
-    orca = _build_orca(monkeypatch, [plan], running=[RunningJob(job=job, chains=[chain])])
+    orca = _build_orca(monkeypatch, [plan], active=[rank])
 
     assert orca.apply_pending("user_1") == 1
     assert orca._launcher.torn_down_jobs == ["job_E"]
-    assert orca._jobs.chain_status == [
-        ("chain_live", ChainStatus.STOPPED, [ChainStatus.LAUNCHING, ChainStatus.RUNNING]),
+    assert orca._jobs.rank_status == [
+        (OLD_RANK_ID, RankStatus.STOPPED, [RankStatus.LAUNCHING, RankStatus.RUNNING], None),
     ]
     assert orca._jobs.transitions == [("job_E", JobStatus.PAUSED, [JobStatus.RUNNING])]
 
 
 def test_bad_action_does_not_wedge_the_plan(monkeypatch):
     """An action that raises is logged and skipped; the plan is still applied."""
+    good_ladder = [{**EXPLICIT_LADDER[0], "rank_id": NEW_RANK_ID}]
     plan = Plan(
         user_id="user_1",
         actions=[
             PlanAction(job_id="job_bad", type=ActionType.PLACE, ladder=EXPLICIT_LADDER),
-            PlanAction(job_id="job_good", type=ActionType.PLACE, ladder=EXPLICIT_LADDER),
+            PlanAction(job_id="job_good", type=ActionType.PLACE, ladder=good_ladder),
         ],
     )
     orca = _build_orca(monkeypatch, [plan])
     original = orca._launcher.reconcile
 
-    def explode_for_bad_job(job_id, chains):
+    def explode_for_bad_job(job_id, ranks):
         if job_id == "job_bad":
             raise RuntimeError("boom")
-        original(job_id, chains)
+        original(job_id, ranks)
 
     orca._launcher.reconcile = explode_for_bad_job
 
     assert orca.apply_pending("user_1") == 1
     assert orca._plans.applied == [plan.plan_id]
     assert [job for job, _ in orca._launcher.reconciled] == ["job_good"]
+    assert orca._jobs.rank_status == [
+        (RANK_ID, RankStatus.FAILED, [RankStatus.LAUNCHING], ReasonCode.LAUNCH_FAILED),
+        (NEW_RANK_ID, RankStatus.RUNNING, [RankStatus.LAUNCHING], None),
+    ]
 
 
 def test_apply_pending_no_plans(monkeypatch):

--- a/tests/test_tunnels.py
+++ b/tests/test_tunnels.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import threading
+
+from tandemn_orca.tunnels import PortForwardManager, TunnelSpec
+
+
+class FakeProcess:
+    def __init__(self) -> None:
+        self.running = True
+        self.terminated = False
+
+    def poll(self):
+        return None if self.running else 0
+
+    def terminate(self):
+        self.terminated = True
+        self.running = False
+
+    def wait(self, timeout):
+        return 0
+
+    def kill(self):
+        self.running = False
+
+
+def test_port_forward_manager_starts_and_stops_rank_tunnel():
+    started = threading.Event()
+    calls = []
+
+    def popen(command, **kwargs):
+        process = FakeProcess()
+        calls.append((command, kwargs, process))
+        started.set()
+        return process
+
+    manager = PortForwardManager(retry_seconds=0.01, popen=popen)
+    spec = TunnelSpec(
+        job_id="job_1",
+        rank_id="rank_1",
+        context="eks-east",
+        namespace="default",
+        service="dgd-frontend",
+        local_port=18042,
+    )
+    try:
+        manager.reconcile("job_1", [spec])
+        assert started.wait(timeout=1)
+        assert calls[0][0] == [
+            "kubectl",
+            "--context",
+            "eks-east",
+            "--namespace",
+            "default",
+            "port-forward",
+            "service/dgd-frontend",
+            "18042:8000",
+            "--address",
+            "127.0.0.1",
+        ]
+
+        manager.reconcile("job_1", [])
+        assert calls[0][2].terminated
+    finally:
+        manager.close()

--- a/tests/test_tunnels.py
+++ b/tests/test_tunnels.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import threading
 
-from tandemn_orca.tunnels import PortForwardManager, TunnelSpec
+import pytest
+
+from tandemn_orca.tunnels import PortForwardManager, RouterProcessManager, TunnelSpec
 
 
 class FakeProcess:
@@ -61,5 +63,59 @@ def test_port_forward_manager_starts_and_stops_rank_tunnel():
 
         manager.reconcile("job_1", [])
         assert calls[0][2].terminated
+    finally:
+        manager.close()
+
+
+def _spec(job_id: str, rank_id: str, port: int) -> TunnelSpec:
+    return TunnelSpec(
+        job_id=job_id,
+        rank_id=rank_id,
+        context=None,
+        namespace="default",
+        service=f"{rank_id}-frontend",
+        local_port=port,
+    )
+
+
+def test_port_forward_manager_rejects_cross_job_port_conflict():
+    manager = PortForwardManager(retry_seconds=0.01, popen=lambda *a, **k: FakeProcess())
+    try:
+        manager.reconcile("job_1", [_spec("job_1", "rank_1", 18042)])
+
+        with pytest.raises(ValueError, match="already assigned to job 'job_1'"):
+            manager.reconcile("job_2", [_spec("job_2", "rank_2", 18042)])
+
+        # The same job re-claiming its own port is a no-op, not a conflict.
+        manager.reconcile("job_1", [_spec("job_1", "rank_1", 18042)])
+        # And the port frees up once the first job releases it.
+        manager.reconcile("job_1", [])
+        manager.reconcile("job_2", [_spec("job_2", "rank_2", 18042)])
+    finally:
+        manager.close()
+
+
+def test_router_process_manager_starts_and_stops_job_router():
+    started = threading.Event()
+    calls = []
+
+    def popen(command, **kwargs):
+        process = FakeProcess()
+        calls.append((command, process))
+        started.set()
+        return process
+
+    manager = RouterProcessManager("/usr/local/bin/tandemn-router", retry_seconds=0.01, popen=popen)
+    try:
+        manager.reconcile("job_1", "/tmp/router-configs/job_1.json")
+        assert started.wait(timeout=1)
+        assert calls[0][0] == [
+            "/usr/local/bin/tandemn-router",
+            "-config",
+            "/tmp/router-configs/job_1.json",
+        ]
+
+        manager.reconcile("job_1", None)
+        assert calls[0][1].terminated
     finally:
         manager.close()


### PR DESCRIPTION
## Summary
19 commits of orca work on top of `feat/orca`, in four themes:

- **Rank-native architecture**: standardize Dynamo pod identity labels, map Grove replicas to canonical chains, and reconcile rank-native workloads and routers — including across multiple kube contexts
- **Router integration**: colocate job routers with DGDs, write laptop router configs, derive router capacity from the model catalog, push live rank telemetry and KV utilization to routers, and derive per-job router endpoints from deterministic listen ports
- **Process supervision** (new): extract a `_ProcessSupervisor` base from `PortForwardManager` and add `RouterProcessManager` so orca keeps one `tandemn-router` process alive per active job (`--router-binary`); tunnel ports claimed by another job are now rejected
- **Lifecycle & telemetry fixes**: restore running jobs on startup, apply pending plans before restore, clean up tunnels on termination, tolerate Prometheus tunnel resets, scope collector telemetry to kube context, validate telemetry by persistent rank, allow skipping capacity refresh

## Testing
- `ruff check src tests` — clean
- `pytest -m "not integration"` — 102 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)