### PR TITLE
feat(orca): fail ranks whose DGD reports no ready replica

### DIFF
--- a/src/tandemn_orca/dynamo_kubernetes.py
+++ b/src/tandemn_orca/dynamo_kubernetes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from kubernetes import client, config
@@ -16,6 +17,11 @@ GROUP = "nvidia.com"
 VERSION = "v1alpha1"
 DGD_PLURAL = "dynamographdeployments"
 
+# The Python client defaults to no timeout, so a blackholed API server would
+# block Orca's single-threaded poll loop forever -- stalling plan application,
+# not just the call that hung.
+REQUEST_TIMEOUT_SECONDS = 10
+
 
 def load_kube_client(
     namespace: str = "default",
@@ -27,6 +33,7 @@ def load_kube_client(
         return DynamoKubernetesClient(
             namespace,
             custom=client.CustomObjectsApi(api_client),
+            core=client.CoreV1Api(api_client),
         )
     try:
         config.load_incluster_config()
@@ -48,18 +55,48 @@ class DynamoKubernetesClient:
         self,
         namespace: str = "default",
         custom: Any = None,
+        core: Any = None,
     ) -> None:
         self.namespace = namespace
         self.custom = custom or client.CustomObjectsApi()
+        self._core = core
+
+    @property
+    def core(self) -> Any:
+        if self._core is None:
+            self._core = client.CoreV1Api()
+        return self._core
 
     def list_job_objects(self, job_id: str) -> set[ObjectKey]:
-        selector = job_selector(job_id)
-        dgds = self.custom.list_namespaced_custom_object(
-            GROUP, VERSION, self.namespace, DGD_PLURAL, label_selector=selector
-        ).get("items", [])
         return {
-            *(("DynamoGraphDeployment", item["metadata"]["name"]) for item in dgds),
+            ("DynamoGraphDeployment", item["metadata"]["name"]) for item in self.job_dgds(job_id)
         }
+
+    def job_dgds(self, job_id: str) -> list[dict[str, Any]]:
+        """Every DGD Orca owns for a job, status included."""
+        return self.custom.list_namespaced_custom_object(
+            GROUP,
+            VERSION,
+            self.namespace,
+            DGD_PLURAL,
+            label_selector=job_selector(job_id),
+            _request_timeout=REQUEST_TIMEOUT_SECONDS,
+        ).get("items", [])
+
+    def rank_pods(self, job_id: str, rank_id: str) -> list[dict[str, Any]]:
+        """Pods backing one rank, for reading why its containers died.
+
+        Raw JSON, not the typed model: the generated client's ``to_dict()``
+        renames keys to snake_case, and every other object here keeps the
+        API server's camelCase.
+        """
+        response = self.core.list_namespaced_pod(
+            self.namespace,
+            label_selector=f"tandemn.com/job-id={job_id},tandemn.com/rank-id={rank_id}",
+            _preload_content=False,
+            _request_timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        return json.loads(response.data).get("items", [])
 
     def apply_many(self, objects: list[dict[str, Any]]) -> set[ObjectKey]:
         for obj in objects:
@@ -79,6 +116,7 @@ class DynamoKubernetesClient:
                 field_manager=FIELD_MANAGER,
                 force=True,
                 _content_type=APPLY,
+                _request_timeout=REQUEST_TIMEOUT_SECONDS,
             )
             return
         raise ValueError(f"unsupported Kubernetes object kind: {kind}")
@@ -94,7 +132,12 @@ class DynamoKubernetesClient:
         try:
             if kind == "DynamoGraphDeployment":
                 self.custom.delete_namespaced_custom_object(
-                    GROUP, VERSION, self.namespace, DGD_PLURAL, name
+                    GROUP,
+                    VERSION,
+                    self.namespace,
+                    DGD_PLURAL,
+                    name,
+                    _request_timeout=REQUEST_TIMEOUT_SECONDS,
                 )
                 return
             raise ValueError(f"unsupported Kubernetes object kind: {kind}")

--- a/src/tandemn_orca/launcher.py
+++ b/src/tandemn_orca/launcher.py
@@ -114,6 +114,10 @@ class DynamoLauncher:
     def teardown_job(self, job_id: str) -> None:
         self.k8s.delete_all_for_job(job_id)
 
+    def k8s_for_rank(self, rank: Rank) -> DynamoKubernetesClient:
+        """Cluster client that owns this rank's objects."""
+        return self.k8s
+
     def _delete_stale(self, stale: set[ObjectKey]) -> None:
         delete_error = _call(self.k8s.delete_many, stale)
         if delete_error:
@@ -195,6 +199,14 @@ class MultiClusterLauncher:
                         pool_dgd_name(job_id, rank),
                         ports[rank.rank_id],
                     )
+
+    def k8s_for_rank(self, rank: Rank) -> DynamoKubernetesClient:
+        """Cluster client that owns this rank's objects."""
+        key = self.default_cluster or _rank_cluster_key(rank)
+        launcher = self.launchers.get(key)
+        if launcher is None:
+            raise ValueError(f"no kube context configured for rank environment {key!r}")
+        return launcher.k8s
 
     def teardown_job(self, job_id: str) -> None:
         for launcher in self.launchers.values():

--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -32,6 +32,7 @@ import os
 import re
 import signal
 import time
+from dataclasses import replace
 from typing import Any
 
 from tandemn_system_data.clients import JobStore, ModelCatalogStore, PlanStore, PostgresClient
@@ -47,6 +48,14 @@ from tandemn_orca.launcher import (
     MultiClusterLauncher,
     NoopLauncher,
 )
+from tandemn_orca.rank_health import (
+    RankHealth,
+    Verdict,
+    dgd_by_rank_id,
+    rank_health,
+    termination_reason_code,
+)
+from tandemn_orca.router_health import RankHealthPublisher
 from tandemn_orca.scripts.resource_map_from_aws import CapacityRefresher, parse_region_csv
 from tandemn_orca.tunnels import PortForwardManager, RouterProcessManager
 
@@ -154,11 +163,25 @@ def _parse_role(role_name: object) -> RankRole | None:
 class Orca:
     """One instance per process, sharing a PostgresClient with the stores."""
 
-    def __init__(self, client: PostgresClient, launcher: Launcher | None = None) -> None:
+    def __init__(
+        self,
+        client: PostgresClient,
+        launcher: Launcher | None = None,
+        *,
+        down_polls_before_failed: int = 2,
+    ) -> None:
         self._client = client
         self._jobs = JobStore(client)
         self._plans = PlanStore(client)
         self._launcher = launcher or NoopLauncher()
+        self._down_polls_before_failed = max(1, down_polls_before_failed)
+        # Consecutive DOWN readings per rank. A single bad poll must not fail a
+        # rank: the operator recomputes status on its own cadence and a rolling
+        # update briefly reports zero ready replicas.
+        self._down_streak: dict[str, int] = {}
+        # Ranks observed serving at least once. Before that, zero ready replicas
+        # means "still launching"; after it, the same reading means "died".
+        self._served_rank_ids: set[str] = set()
 
     def apply_pending(self, user_id: str) -> int:
         """Apply every unapplied plan for a user. Returns plans applied."""
@@ -172,6 +195,135 @@ class Orca:
                 # Another Orca worker already applied it; CAS lost the race.
                 logger.info("plan %s already applied, skipping", plan.plan_id)
         return applied
+
+    def reconcile_rank_health(self, user_id: str) -> list[RankHealth]:
+        """Move ranks.status to match what each rank's DGD reports.
+
+        This is the only path by which a RUNNING rank can reach FAILED: plan
+        application sets RUNNING once the API server accepts the DGD and never
+        revisits it, so without this poll a rank whose workers died stays
+        RUNNING forever and keeps receiving routed traffic.
+
+        Returns the effective health of every active rank so the caller can
+        publish it to the job routers.
+        """
+        k8s_for_rank = getattr(self._launcher, "k8s_for_rank", None)
+        if k8s_for_rank is None:
+            return []  # NoopLauncher: no cluster to observe.
+
+        results: list[RankHealth] = []
+        active_rank_ids: set[str] = set()
+        for running in self._jobs.running_jobs(user_id):
+            job_id = running.job.job_id
+            # One DGD list per cluster, not per rank: a job's ranks may span
+            # kube contexts but usually share one.
+            by_cluster: dict[int, tuple[Any, list[Rank]]] = {}
+            for allocation in running.ranks:
+                rank = Rank(
+                    rank_id=allocation.rank_id,
+                    job_id=job_id,
+                    plan_id=allocation.plan_id,
+                    role=allocation.role,
+                    shape_json=dict(allocation.shape_json),
+                    n_replicas=allocation.n_replicas,
+                    status=allocation.status,
+                    reason_code=allocation.reason_code,
+                )
+                try:
+                    k8s = k8s_for_rank(rank)
+                except ValueError:
+                    logger.exception("no cluster client for rank %s", rank.rank_id)
+                    continue
+                by_cluster.setdefault(id(k8s), (k8s, []))[1].append(rank)
+
+            for k8s, ranks in by_cluster.values():
+                try:
+                    deployments = dgd_by_rank_id(k8s.job_dgds(job_id))
+                except Exception:
+                    logger.exception("DGD status read failed for job %s", job_id)
+                    continue
+                for rank in ranks:
+                    active_rank_ids.add(rank.rank_id)
+                    results.append(
+                        self._apply_rank_health(
+                            k8s,
+                            rank,
+                            rank_health(
+                                job_id,
+                                rank.rank_id,
+                                deployments.get(rank.rank_id),
+                                ever_served=rank.rank_id in self._served_rank_ids,
+                            ),
+                        )
+                    )
+
+        # A rank that left the active set takes its debounce state with it, so a
+        # relaunched rank_id starts clean rather than inheriting a stale streak.
+        self._down_streak = {
+            rank_id: streak
+            for rank_id, streak in self._down_streak.items()
+            if rank_id in active_rank_ids
+        }
+        self._served_rank_ids &= active_rank_ids
+        return results
+
+    def _apply_rank_health(self, k8s: Any, rank: Rank, health: RankHealth) -> RankHealth:
+        """Record one rank's health, returning the debounced verdict."""
+        if health.verdict is Verdict.SERVING:
+            self._served_rank_ids.add(rank.rank_id)
+            self._down_streak.pop(rank.rank_id, None)
+            # Only promote out of LAUNCHING. set_rank_status writes
+            # reason_code and updated_at unconditionally, so a no-op CAS would
+            # erase failure provenance and reset every age-based rule.
+            if rank.status is RankStatus.LAUNCHING:
+                self._jobs.set_rank_status(rank.rank_id, RankStatus.RUNNING, [RankStatus.LAUNCHING])
+                logger.info(
+                    "rank %s serving with %s replica(s)", rank.rank_id, health.serving_replicas
+                )
+            return health
+
+        if health.verdict is Verdict.UNKNOWN:
+            self._down_streak.pop(rank.rank_id, None)
+            return health
+
+        streak = self._down_streak.get(rank.rank_id, 0) + 1
+        self._down_streak[rank.rank_id] = streak
+        if streak < self._down_polls_before_failed:
+            # Not yet conclusive. Report no opinion rather than DOWN so a
+            # single bad reading cannot evict every session homed on this rank.
+            return replace(
+                health,
+                verdict=Verdict.UNKNOWN,
+                reason_code=None,
+                detail=f"{health.detail} ({streak}/{self._down_polls_before_failed})",
+            )
+
+        reason_code, detail = self._failure_cause(k8s, rank, health)
+        if self._jobs.set_rank_status(
+            rank.rank_id,
+            RankStatus.FAILED,
+            list(ACTIVE_RANK_STATUSES),
+            reason_code=reason_code,
+        ):
+            logger.warning("rank %s failed (%s): %s", rank.rank_id, reason_code, detail)
+        return replace(health, reason_code=reason_code, detail=detail)
+
+    def _failure_cause(self, k8s: Any, rank: Rank, health: RankHealth) -> tuple[str, str]:
+        """Prefer the container's own termination reason over the DGD's silence.
+
+        The DGD reports that replicas are not ready, never why. Pod termination
+        state is the only place OOMKilled and CrashLoopBackOff surface, and it
+        is read here rather than every poll because this runs once per failure.
+        """
+        try:
+            pods = k8s.rank_pods(rank.job_id, rank.rank_id)
+        except Exception:
+            logger.exception("pod lookup failed for rank %s", rank.rank_id)
+            pods = []
+        cause = termination_reason_code(pods)
+        if cause is not None:
+            return cause
+        return health.reason_code or ReasonCode.FAILED, health.detail
 
     def reconcile_running(self, user_id: str) -> int:
         """Restore infrastructure, local configs, and tunnels after Orca restarts."""
@@ -254,7 +406,9 @@ class Orca:
 
     def _preempt(self, plan: Plan, action: PlanAction) -> None:
         """running -> paused: tear down the job's ranks, keep the job row."""
-        self._teardown_ranks(action.job_id)
+        # Record why: without it a preempted rank is indistinguishable from one
+        # that finished cleanly, since STOPPED is written on both paths.
+        self._teardown_ranks(action.job_id, ReasonCode.PREEMPTED)
         moved = self._jobs.transition(action.job_id, JobStatus.PAUSED, [JobStatus.RUNNING])
         if not moved:
             logger.warning("preempt: job %s was not running", action.job_id)
@@ -343,17 +497,22 @@ class Orca:
             self._jobs.set_rank_status(rank.rank_id, RankStatus.RUNNING, [rank.status])
         return recorded
 
-    def _teardown_ranks(self, job_id: str) -> None:
+    def _teardown_ranks(self, job_id: str, reason_code: str | None = None) -> None:
         rank_ids = self._active_rank_ids(job_id)
         self._launcher.teardown_job(job_id)
-        self._stop_ranks(rank_ids)
+        self._stop_ranks(rank_ids, reason_code)
 
     def _active_rank_ids(self, job_id: str) -> set[str]:
         return {rank.rank_id for rank in self._jobs.active_ranks(job_id)}
 
-    def _stop_ranks(self, rank_ids: set[str]) -> None:
+    def _stop_ranks(self, rank_ids: set[str], reason_code: str | None = None) -> None:
         for rank_id in rank_ids:
-            self._jobs.set_rank_status(rank_id, RankStatus.STOPPED, list(ACTIVE_RANK_STATUSES))
+            self._jobs.set_rank_status(
+                rank_id,
+                RankStatus.STOPPED,
+                list(ACTIVE_RANK_STATUSES),
+                reason_code=reason_code,
+            )
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -386,6 +545,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--interval-seconds",
         type=float,
         default=float(os.getenv("TANDEMN_ORCA_POLL_SECONDS", "5")),
+    )
+    parser.add_argument(
+        "--down-polls-before-failed",
+        type=int,
+        default=int(os.getenv("TANDEMN_DOWN_POLLS_BEFORE_FAILED", "2")),
+        help="consecutive DGD polls reporting no ready replica before a rank is failed",
+    )
+    parser.add_argument(
+        "--no-rank-health",
+        dest="rank_health",
+        action="store_false",
+        help="skip the DGD-status rank health poll (leaves ranks.status at plan-apply values)",
     )
     parser.add_argument("--once", action="store_true")
     parser.add_argument("--skip-capacity-refresh", action="store_true")
@@ -453,7 +624,11 @@ def main(argv: list[str] | None = None) -> None:
         tunnels=tunnel_manager,
         routers=router_manager,
     )
-    orca = Orca(client, launcher=launcher)
+    orca = Orca(client, launcher=launcher, down_polls_before_failed=args.down_polls_before_failed)
+    telemetry_token = os.getenv("TANDEMN_ROUTER_TELEMETRY_TOKEN")
+    health_publisher = (
+        RankHealthPublisher(telemetry_token) if telemetry_token and args.rank_health else None
+    )
     previous_sigterm = None
     if tunnel_manager is not None:
 
@@ -472,6 +647,13 @@ def main(argv: list[str] | None = None) -> None:
             logger.info("reconciled %s running job(s)", reconciled)
         except Exception:
             logger.exception("running job reconciliation failed")
+        if args.rank_health:
+            try:
+                health = orca.reconcile_rank_health(args.user_id)
+                if health_publisher is not None and health:
+                    health_publisher.publish(health)
+            except Exception:
+                logger.exception("rank health reconciliation failed")
         if args.once:
             return
         while True:
@@ -486,6 +668,13 @@ def main(argv: list[str] | None = None) -> None:
                 logger.info("applied %s plan(s) for user %s", applied, args.user_id)
             except Exception:
                 logger.exception("orca apply loop failed")
+            if args.rank_health:
+                try:
+                    health = orca.reconcile_rank_health(args.user_id)
+                    if health_publisher is not None and health:
+                        health_publisher.publish(health)
+                except Exception:
+                    logger.exception("rank health reconciliation failed")
     finally:
         if router_manager is not None:
             router_manager.close()

--- a/src/tandemn_orca/rank_health.py
+++ b/src/tandemn_orca/rank_health.py
@@ -1,0 +1,255 @@
+"""Derive rank serving health from DynamoGraphDeployment status.
+
+Why the DGD is the source of truth for "is this rank up":
+
+The operator configures each worker container's readiness probe as an HTTP GET
+against the worker's own ``/health`` on ``DYN_SYSTEM_PORT``, with
+``DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS=["generate"]``. That endpoint answers
+503 until the generate endpoint is actually served and 200 afterwards, so a
+replica counted ready by kubelet is one whose serving path works -- not merely a
+live process. The operator aggregates those counts onto ``.status.services``,
+which makes the DGD a strictly stronger signal than either the Prometheus
+scrape (which lags service discovery on cold start) or the frontend's own
+``/health`` (whose instance list is a lease-based etcd registration that
+outlives an OOMKill).
+
+Two traps this module exists to avoid:
+
+1. The replica count lives in a different field per workload kind, and the
+   unused field is omitted from the JSON rather than zeroed. Reading
+   ``readyReplicas`` on a PodCliqueScalingGroup returns None, which a naive
+   ``or 0`` turns into "zero ready" for a perfectly healthy rank.
+2. A rank is only usable when both its worker *and* its LocalRouter are up --
+   Orca inserts the LocalRouter hop, so workers alone serving nothing is a
+   reachable state the operator reports as partially available.
+
+Version note: the platform install is Dynamo 1.0.x, whose DGD CRD serves only
+``nvidia.com/v1alpha1``. The status map there is ``.status.services``;
+``.status.components`` and ``v1beta1`` first appear in 1.2.0 and would 404.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from tandemn_system_data.models.enums import ReasonCode
+
+logger = logging.getLogger(__name__)
+
+# Service keys rendered by dynamo_compiler.render_rank_dgd. The operator copies
+# spec.services keys verbatim into status.services.
+WORKER_SERVICE = "VllmDecodeWorker"
+ROUTER_SERVICE = "LocalRouter"
+
+# Which .status.services[*] field carries the ready count, per workload kind the
+# operator chose. The other field is absent from the JSON, never zero, so this
+# must be a dispatch and not a `ready or available` fallback.
+#   Deployment           readyReplicas    counts pods
+#   PodClique            readyReplicas    counts pods
+#   LeaderWorkerSet      readyReplicas    counts groups
+#   PodCliqueScalingGroup availableReplicas counts gangs
+SERVING_REPLICA_FIELD = {
+    "Deployment": "readyReplicas",
+    "PodClique": "readyReplicas",
+    "LeaderWorkerSet": "readyReplicas",
+    "PodCliqueScalingGroup": "availableReplicas",
+}
+
+# DGD lifecycle states (v1alpha1 DGDState).
+STATE_FAILED = "failed"
+STATE_SUCCESSFUL = "successful"
+PENDING_STATES = frozenset({"initializing", "pending", ""})
+
+# Container termination reasons worth translating into a rank reason code.
+_TERMINATION_REASONS = {
+    "OOMKilled": ReasonCode.OOM,
+    "Error": ReasonCode.PROCESS_CRASH,
+    "ContainerCannotRun": ReasonCode.PROCESS_CRASH,
+    "DeadlineExceeded": ReasonCode.PROCESS_CRASH,
+}
+
+
+class Verdict(StrEnum):
+    """Serving health of one rank as read from its DGD."""
+
+    SERVING = "serving"
+    DOWN = "down"
+    # No conclusion: still launching, or the operator has not yet reconciled the
+    # generation Orca applied. Callers must not fail a rank on UNKNOWN.
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RankHealth:
+    """One rank's serving verdict and the evidence behind it."""
+
+    rank_id: str
+    job_id: str
+    verdict: Verdict
+    serving_replicas: int | None
+    reason_code: str | None
+    detail: str
+
+
+def rank_health(
+    job_id: str,
+    rank_id: str,
+    dgd: Mapping[str, Any] | None,
+    *,
+    ever_served: bool = False,
+) -> RankHealth:
+    """Read one rank's serving health from its DynamoGraphDeployment.
+
+    ``ever_served`` distinguishes the two ways a rank can report zero ready
+    replicas. Before a rank has ever served, zero means "still coming up" --
+    Karpenter provisioning plus image pull plus model load runs 8-12 minutes,
+    and the operator holds the DGD in ``pending`` throughout. After a rank has
+    served, zero means it died, and the operator recomputing ``pending`` must
+    not be read as launching again.
+    """
+    if dgd is None:
+        return RankHealth(
+            rank_id,
+            job_id,
+            Verdict.DOWN,
+            0,
+            ReasonCode.NODE_LOST,
+            "no DynamoGraphDeployment carries this rank's label",
+        )
+
+    metadata = dgd.get("metadata") or {}
+    status = dgd.get("status") or {}
+    state = str(status.get("state") or "")
+
+    # The operator has not yet processed the spec Orca applied, so the replica
+    # counts below still describe the previous generation.
+    observed = status.get("observedGeneration")
+    generation = metadata.get("generation")
+    if isinstance(observed, int) and isinstance(generation, int) and observed < generation:
+        return _unknown(job_id, rank_id, f"operator has not reconciled generation {generation}")
+
+    if state == STATE_FAILED:
+        return RankHealth(
+            rank_id,
+            job_id,
+            Verdict.DOWN,
+            0,
+            ReasonCode.FAILED,
+            f"DGD state=failed: {_condition_detail(status)}",
+        )
+
+    services = status.get("services")
+    if not isinstance(services, dict) or WORKER_SERVICE not in services:
+        if ever_served:
+            return RankHealth(
+                rank_id,
+                job_id,
+                Verdict.DOWN,
+                0,
+                ReasonCode.HEARTBEAT_TIMEOUT,
+                "worker service vanished from DGD status",
+            )
+        return _unknown(job_id, rank_id, f"DGD state={state or 'unset'}, no worker status yet")
+
+    workers = serving_replicas(services[WORKER_SERVICE])
+    if workers is None:
+        return _unknown(job_id, rank_id, "worker service reports no recognized replica field")
+    if workers == 0:
+        if not ever_served and state in PENDING_STATES:
+            return _unknown(job_id, rank_id, f"no worker ready yet, DGD state={state or 'unset'}")
+        return RankHealth(
+            rank_id,
+            job_id,
+            Verdict.DOWN,
+            0,
+            ReasonCode.HEARTBEAT_TIMEOUT,
+            f"0 worker replicas ready (DGD state={state or 'unset'})",
+        )
+
+    # Orca inserts a LocalRouter between the frontend and the workers, so ready
+    # workers alone do not make the rank routable.
+    router_status = services.get(ROUTER_SERVICE)
+    if router_status is not None:
+        routers = serving_replicas(router_status)
+        if routers == 0:
+            return RankHealth(
+                rank_id,
+                job_id,
+                Verdict.DOWN,
+                workers,
+                ReasonCode.PROCESS_CRASH,
+                f"{workers} worker replica(s) ready but LocalRouter has none",
+            )
+
+    return RankHealth(rank_id, job_id, Verdict.SERVING, workers, None, "")
+
+
+def serving_replicas(service_status: Mapping[str, Any]) -> int | None:
+    """Ready replica count for one service, or None when it cannot be read."""
+    kind = service_status.get("componentKind")
+    field = SERVING_REPLICA_FIELD.get(str(kind))
+    if field is None:
+        logger.warning("unrecognized componentKind %r in DGD status", kind)
+        return None
+    value = service_status.get(field)
+    if not isinstance(value, int) or isinstance(value, bool):
+        return None
+    return max(0, value)
+
+
+def dgd_by_rank_id(items: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index DGDs by the rank they carry, dropping unlabeled objects."""
+    indexed: dict[str, dict[str, Any]] = {}
+    for item in items:
+        labels = (item.get("metadata") or {}).get("labels") or {}
+        rank_id = labels.get("tandemn.com/rank-id")
+        if rank_id:
+            indexed[str(rank_id)] = item
+    return indexed
+
+
+def termination_reason_code(pods: list[dict[str, Any]]) -> tuple[str, str] | None:
+    """Translate the newest container termination into (reason_code, detail).
+
+    Only the DGD's replica counts say a rank is down; they never say why. Pod
+    termination state is the one place the real cause surfaces, so callers look
+    it up on the failing transition rather than on every poll.
+    """
+    for pod in pods:
+        statuses = ((pod.get("status") or {}).get("containerStatuses")) or []
+        for container in statuses:
+            terminated = (container.get("lastState") or {}).get("terminated") or {}
+            reason = terminated.get("reason")
+            code = _TERMINATION_REASONS.get(str(reason))
+            if code is not None:
+                name = (pod.get("metadata") or {}).get("name", "?")
+                return code, f"{name}/{container.get('name', '?')} terminated: {reason}"
+            waiting = (container.get("state") or {}).get("waiting") or {}
+            if str(waiting.get("reason")) == "CrashLoopBackOff":
+                name = (pod.get("metadata") or {}).get("name", "?")
+                return ReasonCode.PROCESS_CRASH, f"{name} in CrashLoopBackOff"
+    return None
+
+
+def _unknown(job_id: str, rank_id: str, detail: str) -> RankHealth:
+    return RankHealth(rank_id, job_id, Verdict.UNKNOWN, None, None, detail)
+
+
+def _condition_detail(status: Mapping[str, Any]) -> str:
+    """Summarize the most informative non-True condition, if any."""
+    conditions = status.get("conditions")
+    if not isinstance(conditions, list):
+        return "no conditions reported"
+    for condition in conditions:
+        if not isinstance(condition, dict) or condition.get("status") == "True":
+            continue
+        parts = [
+            str(condition.get(key)) for key in ("type", "reason", "message") if condition.get(key)
+        ]
+        if parts:
+            return " / ".join(parts)
+    return "no failing condition reported"

--- a/src/tandemn_orca/router_health.py
+++ b/src/tandemn_orca/router_health.py
@@ -1,0 +1,105 @@
+"""Publish rank serving health to each job's router process.
+
+The router decides which rank a session lands on and must not route to a rank
+whose workers are gone. It is a Go process with no database access, so Orca --
+which already holds the Kubernetes credentials and the Postgres connection --
+pushes the verdicts it derived from DGD status.
+
+Level-triggered: every poll sends the full set of active ranks for a job. A rank
+that drops out of the payload has left the active set (failed, stopped, or
+replaced by a new plan), and the router ages it out rather than pinning a stale
+verdict forever.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+from tandemn_orca.dynamo_compiler import router_listen_port
+from tandemn_orca.rank_health import RankHealth
+
+logger = logging.getLogger(__name__)
+
+RANK_STATUS_PATH = "/internal/rank-status"
+
+
+def rank_status_payload(
+    job_id: str,
+    ranks: Sequence[RankHealth],
+    observed_at: datetime,
+) -> dict[str, object]:
+    """Build the router's rank-status body.
+
+    Wire contract with tandemn-router's RankStatusReport. That decoder sets
+    DisallowUnknownFields, so an extra key here is a 400 rather than a warning:
+    the two sides must change together.
+    """
+    return {
+        "job_id": job_id,
+        "observed_at": observed_at.isoformat(),
+        "ranks": [
+            {
+                "rank_id": item.rank_id,
+                "verdict": item.verdict.value,
+                "serving_replicas": item.serving_replicas,
+                "reason": item.detail,
+            }
+            for item in ranks
+        ],
+    }
+
+
+class RankHealthPublisher:
+    """POST rank health to the per-job router that owns those ranks."""
+
+    def __init__(
+        self,
+        token: str,
+        url_template: str | None = None,
+        timeout: float = 5.0,
+    ) -> None:
+        self.token = token
+        self.url_template = url_template
+        self.timeout = timeout
+
+    def publish(self, health: Sequence[RankHealth]) -> int:
+        """Send one batch per job. Returns the number of jobs published."""
+        by_job: dict[str, list[RankHealth]] = defaultdict(list)
+        for item in health:
+            by_job[item.job_id].append(item)
+
+        observed_at = datetime.now(UTC)
+        published = 0
+        for job_id, ranks in by_job.items():
+            payload = rank_status_payload(job_id, ranks, observed_at)
+            try:
+                self._post(job_id, payload)
+                published += 1
+            except (urllib.error.URLError, TimeoutError, OSError) as error:
+                # A router that is down or not yet started is not an Orca
+                # failure; the next poll republishes the full set.
+                logger.warning("rank health push failed for job %s: %s", job_id, error)
+        return published
+
+    def _post(self, job_id: str, payload: dict[str, object]) -> None:
+        if self.url_template:
+            base_url = self.url_template.format(job_id=job_id).rstrip("/")
+        else:
+            base_url = f"http://127.0.0.1:{router_listen_port(job_id)}"
+        request = urllib.request.Request(
+            f"{base_url}{RANK_STATUS_PATH}",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout):
+            pass

--- a/tests/test_dynamo_kubernetes.py
+++ b/tests/test_dynamo_kubernetes.py
@@ -7,6 +7,7 @@ from tandemn_orca.dynamo_kubernetes import (
     DGD_PLURAL,
     FIELD_MANAGER,
     GROUP,
+    REQUEST_TIMEOUT_SECONDS,
     VERSION,
     DynamoKubernetesClient,
     job_selector,
@@ -35,8 +36,8 @@ class FakeCustom:
     def patch_namespaced_custom_object(self, *args, **kwargs):
         self.applied.append((args, kwargs))
 
-    def delete_namespaced_custom_object(self, *args):
-        self.deleted.append(args)
+    def delete_namespaced_custom_object(self, *args, **kwargs):
+        self.deleted.append((args, kwargs))
 
 
 def test_object_key_and_selector():
@@ -51,7 +52,10 @@ def test_list_job_objects_reads_dgds():
     assert client.list_job_objects("job_1") == {("DynamoGraphDeployment", "dgd")}
     assert custom.selector == (
         (GROUP, VERSION, "ns", DGD_PLURAL),
-        {"label_selector": "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1"},
+        {
+            "label_selector": "tandemn.com/managed-by=orca,tandemn.com/job-id=job_1",
+            "_request_timeout": REQUEST_TIMEOUT_SECONDS,
+        },
     )
 
 
@@ -63,7 +67,12 @@ def test_apply_many_uses_server_side_apply():
     assert custom.applied == [
         (
             (GROUP, VERSION, "ns", DGD_PLURAL, "dgd", _dgd("dgd")),
-            {"field_manager": FIELD_MANAGER, "force": True, "_content_type": APPLY},
+            {
+                "field_manager": FIELD_MANAGER,
+                "force": True,
+                "_content_type": APPLY,
+                "_request_timeout": REQUEST_TIMEOUT_SECONDS,
+            },
         )
     ]
 
@@ -74,12 +83,17 @@ def test_delete_many_deletes_dgds():
 
     client.delete_many({("DynamoGraphDeployment", "dgd")})
 
-    assert custom.deleted == [(GROUP, VERSION, "ns", DGD_PLURAL, "dgd")]
+    assert custom.deleted == [
+        (
+            (GROUP, VERSION, "ns", DGD_PLURAL, "dgd"),
+            {"_request_timeout": REQUEST_TIMEOUT_SECONDS},
+        )
+    ]
 
 
 def test_delete_ignores_not_found():
     class MissingCustom(FakeCustom):
-        def delete_namespaced_custom_object(self, *args):
+        def delete_namespaced_custom_object(self, *args, **kwargs):
             raise ApiException(status=404)
 
     DynamoKubernetesClient("ns", custom=MissingCustom()).delete("DynamoGraphDeployment", "dgd")
@@ -119,8 +133,52 @@ def test_load_kube_client_uses_explicit_context(monkeypatch):
         "tandemn_orca.dynamo_kubernetes.client.CustomObjectsApi",
         lambda loaded: ("custom", loaded),
     )
+    monkeypatch.setattr(
+        "tandemn_orca.dynamo_kubernetes.client.CoreV1Api",
+        lambda loaded: ("core", loaded),
+    )
 
     loaded = load_kube_client("serving", context="cloud-region")
 
     assert loaded.namespace == "serving"
     assert loaded.custom == ("custom", api_client)
+    assert loaded.core == ("core", api_client)
+
+
+def test_job_dgds_keeps_status():
+    """list_job_objects discards everything but names; the health poll needs status."""
+
+    class StatusCustom(FakeCustom):
+        def list_namespaced_custom_object(self, *args, **kwargs):
+            self.selector = (args, kwargs)
+            return {
+                "items": [
+                    {"metadata": {"name": "dgd"}, "status": {"state": "successful"}},
+                ]
+            }
+
+    client = DynamoKubernetesClient("ns", custom=StatusCustom())
+
+    assert client.job_dgds("job_1") == [
+        {"metadata": {"name": "dgd"}, "status": {"state": "successful"}}
+    ]
+
+
+def test_rank_pods_reads_raw_json_not_the_snake_cased_model():
+    class FakeResponse:
+        data = b'{"items": [{"status": {"containerStatuses": [{"name": "main"}]}}]}'
+
+    class FakeCore:
+        def list_namespaced_pod(self, *args, **kwargs):
+            self.call = (args, kwargs)
+            return FakeResponse()
+
+    core = FakeCore()
+    client = DynamoKubernetesClient("ns", custom=FakeCustom(), core=core)
+
+    pods = client.rank_pods("job_1", "rank_1")
+
+    # camelCase survives: the generated model's to_dict() would rename this.
+    assert pods[0]["status"]["containerStatuses"][0]["name"] == "main"
+    assert core.call[1]["label_selector"] == "tandemn.com/job-id=job_1,tandemn.com/rank-id=rank_1"
+    assert core.call[1]["_preload_content"] is False

--- a/tests/test_orca_rank_health.py
+++ b/tests/test_orca_rank_health.py
@@ -1,0 +1,275 @@
+"""Orca's DGD-status rank health reconciler.
+
+No Kubernetes and no Postgres: a fake cluster client serves DGD documents and a
+fake JobStore records every status write, so the debounce, the promotion guard,
+and the failure-cause lookup can be asserted directly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from tandemn_system_data.models.enums import RankRole, RankStatus, ReasonCode
+from tandemn_system_data.models.rank import Rank
+
+import tandemn_orca.orca as orca_mod
+from tandemn_orca.orca import Orca
+from tandemn_orca.rank_health import Verdict
+
+RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
+JOB_ID = "job-01JBM2YQYZ1KQ9C8GZP1XB6V5T"
+USER_ID = "usr_test"
+
+
+def _rank(status: RankStatus = RankStatus.RUNNING) -> Rank:
+    return Rank(
+        rank_id=RANK_ID,
+        job_id=JOB_ID,
+        plan_id="plan-1",
+        role=RankRole.AGGREGATE,
+        shape_json={"env": ["reserved", "aws", "us-east-1", "use1-az1", "L40S"]},
+        n_replicas=2,
+        status=status,
+    )
+
+
+def _dgd(worker: int, *, state: str = "successful", router: int = 1) -> dict:
+    def service(count: int) -> dict:
+        return {"componentKind": "Deployment", "replicas": count, "readyReplicas": count}
+
+    return {
+        "metadata": {
+            "name": "tdm-abc",
+            "generation": 1,
+            "labels": {"tandemn.com/rank-id": RANK_ID},
+        },
+        "status": {
+            "state": state,
+            "observedGeneration": 1,
+            "services": {"VllmDecodeWorker": service(worker), "LocalRouter": service(router)},
+        },
+    }
+
+
+class FakeJobStore:
+    def __init__(self, rank: Rank) -> None:
+        self.rank = rank
+        self.writes: list[tuple[str, RankStatus, list[RankStatus], str | None]] = []
+
+    def running_jobs(self, user_id):
+        return [SimpleNamespace(job=SimpleNamespace(job_id=JOB_ID), ranks=[self.rank])]
+
+    def set_rank_status(self, rank_id, to, expected, *, reason_code=None):
+        self.writes.append((rank_id, to, list(expected), reason_code))
+        if self.rank.status not in expected:
+            return False
+        self.rank = self.rank.model_copy(update={"status": to, "reason_code": reason_code})
+        return True
+
+
+class FakeK8s:
+    def __init__(self, dgds: list[dict], pods: list[dict] | None = None) -> None:
+        self.dgds = dgds
+        self.pods = pods or []
+        self.pod_lookups = 0
+
+    def job_dgds(self, job_id):
+        return self.dgds
+
+    def rank_pods(self, job_id, rank_id):
+        self.pod_lookups += 1
+        return self.pods
+
+
+class FakeLauncher:
+    def __init__(self, k8s: FakeK8s) -> None:
+        self.k8s = k8s
+
+    def k8s_for_rank(self, rank):
+        return self.k8s
+
+    def reconcile(self, job_id, ranks):  # pragma: no cover - unused here
+        pass
+
+    def teardown_job(self, job_id):  # pragma: no cover - unused here
+        pass
+
+
+def _orca(monkeypatch, store: FakeJobStore, k8s: FakeK8s, *, polls: int = 2) -> Orca:
+    monkeypatch.setattr(orca_mod, "JobStore", lambda client: store)
+    monkeypatch.setattr(orca_mod, "PlanStore", lambda client: object())
+    return Orca(client=object(), launcher=FakeLauncher(k8s), down_polls_before_failed=polls)
+
+
+# ----- promotion -------------------------------------------------------------
+
+
+def test_serving_promotes_a_launching_rank(monkeypatch):
+    store = FakeJobStore(_rank(RankStatus.LAUNCHING))
+    orca = _orca(monkeypatch, store, FakeK8s([_dgd(worker=2)]))
+
+    health = orca.reconcile_rank_health(USER_ID)
+
+    assert [item.verdict for item in health] == [Verdict.SERVING]
+    assert store.writes == [(RANK_ID, RankStatus.RUNNING, [RankStatus.LAUNCHING], None)]
+
+
+def test_serving_does_not_rewrite_an_already_running_rank(monkeypatch):
+    """set_rank_status writes reason_code and updated_at unconditionally, so a
+    no-op CAS every poll would erase failure provenance."""
+    store = FakeJobStore(_rank(RankStatus.RUNNING))
+    orca = _orca(monkeypatch, store, FakeK8s([_dgd(worker=2)]))
+
+    orca.reconcile_rank_health(USER_ID)
+    orca.reconcile_rank_health(USER_ID)
+
+    assert store.writes == []
+
+
+# ----- debounce --------------------------------------------------------------
+
+
+def test_one_down_poll_reports_no_opinion_and_writes_nothing(monkeypatch):
+    store = FakeJobStore(_rank())
+    orca = _orca(monkeypatch, store, FakeK8s([_dgd(worker=0)]))
+
+    health = orca.reconcile_rank_health(USER_ID)
+
+    assert health[0].verdict is Verdict.UNKNOWN
+    assert "1/2" in health[0].detail
+    assert store.writes == []
+
+
+def test_consecutive_down_polls_fail_the_rank(monkeypatch):
+    store = FakeJobStore(_rank())
+    orca = _orca(monkeypatch, store, FakeK8s([_dgd(worker=0)]))
+
+    orca.reconcile_rank_health(USER_ID)
+    health = orca.reconcile_rank_health(USER_ID)
+
+    assert health[0].verdict is Verdict.DOWN
+    assert store.writes == [
+        (
+            RANK_ID,
+            RankStatus.FAILED,
+            [RankStatus.LAUNCHING, RankStatus.RUNNING],
+            ReasonCode.HEARTBEAT_TIMEOUT,
+        )
+    ]
+
+
+def test_a_recovered_rank_resets_the_streak(monkeypatch):
+    store = FakeJobStore(_rank())
+    k8s = FakeK8s([_dgd(worker=0)])
+    orca = _orca(monkeypatch, store, k8s)
+
+    orca.reconcile_rank_health(USER_ID)
+    k8s.dgds = [_dgd(worker=2)]
+    orca.reconcile_rank_health(USER_ID)
+    k8s.dgds = [_dgd(worker=0)]
+    orca.reconcile_rank_health(USER_ID)
+
+    assert store.writes == []
+
+
+# ----- launching vs died -----------------------------------------------------
+
+
+def test_zero_replicas_while_pending_never_fails_a_new_rank(monkeypatch):
+    """Karpenter plus image pull plus model load runs 8-12 minutes."""
+    store = FakeJobStore(_rank(RankStatus.LAUNCHING))
+    orca = _orca(monkeypatch, store, FakeK8s([_dgd(worker=0, state="pending")]))
+
+    for _ in range(5):
+        health = orca.reconcile_rank_health(USER_ID)
+
+    assert health[0].verdict is Verdict.UNKNOWN
+    assert store.writes == []
+
+
+def test_zero_replicas_after_serving_fails_even_while_pending(monkeypatch):
+    store = FakeJobStore(_rank())
+    k8s = FakeK8s([_dgd(worker=2)])
+    orca = _orca(monkeypatch, store, k8s)
+
+    orca.reconcile_rank_health(USER_ID)
+    k8s.dgds = [_dgd(worker=0, state="pending")]
+    orca.reconcile_rank_health(USER_ID)
+    orca.reconcile_rank_health(USER_ID)
+
+    assert store.writes[-1][1] is RankStatus.FAILED
+
+
+# ----- failure cause ---------------------------------------------------------
+
+
+def test_pod_termination_reason_beats_the_generic_code(monkeypatch):
+    pods = [
+        {
+            "metadata": {"name": "worker-0"},
+            "status": {
+                "containerStatuses": [
+                    {"name": "main", "lastState": {"terminated": {"reason": "OOMKilled"}}}
+                ]
+            },
+        }
+    ]
+    store = FakeJobStore(_rank())
+    k8s = FakeK8s([_dgd(worker=0)], pods)
+    orca = _orca(monkeypatch, store, k8s)
+
+    orca.reconcile_rank_health(USER_ID)
+    orca.reconcile_rank_health(USER_ID)
+
+    assert store.writes[-1][3] == ReasonCode.OOM
+    # Pods are read once, on the failing transition, not on every poll.
+    assert k8s.pod_lookups == 1
+
+
+def test_pod_lookup_failure_falls_back_to_the_dgd_reason(monkeypatch):
+    class ExplodingK8s(FakeK8s):
+        def rank_pods(self, job_id, rank_id):
+            raise RuntimeError("api server unreachable")
+
+    store = FakeJobStore(_rank())
+    orca = _orca(monkeypatch, store, ExplodingK8s([_dgd(worker=0)]))
+
+    orca.reconcile_rank_health(USER_ID)
+    orca.reconcile_rank_health(USER_ID)
+
+    assert store.writes[-1][3] == ReasonCode.HEARTBEAT_TIMEOUT
+
+
+# ----- degraded environments -------------------------------------------------
+
+
+def test_noop_launcher_reconciles_nothing(monkeypatch):
+    store = FakeJobStore(_rank())
+    monkeypatch.setattr(orca_mod, "JobStore", lambda client: store)
+    monkeypatch.setattr(orca_mod, "PlanStore", lambda client: object())
+
+    assert Orca(client=object()).reconcile_rank_health(USER_ID) == []
+    assert store.writes == []
+
+
+def test_a_failed_dgd_read_does_not_abort_the_pass(monkeypatch):
+    class ExplodingK8s(FakeK8s):
+        def job_dgds(self, job_id):
+            raise RuntimeError("api server unreachable")
+
+    store = FakeJobStore(_rank())
+    orca = _orca(monkeypatch, store, ExplodingK8s([]))
+
+    assert orca.reconcile_rank_health(USER_ID) == []
+    assert store.writes == []
+
+
+@pytest.mark.parametrize("polls", [0, -3])
+def test_debounce_threshold_is_at_least_one_poll(monkeypatch, polls):
+    store = FakeJobStore(_rank())
+    orca = _orca(monkeypatch, store, FakeK8s([_dgd(worker=0)]), polls=polls)
+
+    orca.reconcile_rank_health(USER_ID)
+
+    assert store.writes[-1][1] is RankStatus.FAILED

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -10,11 +10,13 @@ import tandemn_orca.orca as mod
 class FakeOrca:
     instances: ClassVar[list[FakeOrca]] = []
 
-    def __init__(self, client, launcher) -> None:
+    def __init__(self, client, launcher, **kwargs) -> None:
         self.client = client
         self.launcher = launcher
+        self.kwargs = kwargs
         self.applied_users: list[str] = []
         self.reconciled_users: list[str] = []
+        self.health_users: list[str] = []
         FakeOrca.instances.append(self)
 
     def apply_pending(self, user_id: str) -> int:
@@ -24,6 +26,10 @@ class FakeOrca:
     def reconcile_running(self, user_id: str) -> int:
         self.reconciled_users.append(user_id)
         return 0
+
+    def reconcile_rank_health(self, user_id: str) -> list:
+        self.health_users.append(user_id)
+        return []
 
 
 class FailingOnceOrca(FakeOrca):

--- a/tests/test_orca_smoke.py
+++ b/tests/test_orca_smoke.py
@@ -562,8 +562,15 @@ def test_preempt_tears_down_and_pauses(monkeypatch):
 
     assert orca.apply_pending("user_1") == 1
     assert orca._launcher.torn_down_jobs == ["job_E"]
+    # Preemption records why, so a preempted rank is distinguishable from one
+    # that stopped because its job finished.
     assert orca._jobs.rank_status == [
-        (OLD_RANK_ID, RankStatus.STOPPED, [RankStatus.LAUNCHING, RankStatus.RUNNING], None),
+        (
+            OLD_RANK_ID,
+            RankStatus.STOPPED,
+            [RankStatus.LAUNCHING, RankStatus.RUNNING],
+            ReasonCode.PREEMPTED,
+        ),
     ]
     assert orca._jobs.transitions == [("job_E", JobStatus.PAUSED, [JobStatus.RUNNING])]
 

--- a/tests/test_rank_health.py
+++ b/tests/test_rank_health.py
@@ -1,0 +1,211 @@
+"""Parsing DGD status into a rank serving verdict.
+
+The dispatch tests matter more than they look: the operator omits the replica
+field it does not use rather than zeroing it, so reading the wrong one reports
+a healthy rank as down.
+"""
+
+from __future__ import annotations
+
+from tandemn_system_data.models.enums import ReasonCode
+
+from tandemn_orca.rank_health import (
+    Verdict,
+    dgd_by_rank_id,
+    rank_health,
+    serving_replicas,
+    termination_reason_code,
+)
+
+RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
+JOB_ID = "job-01JBM2YQYZ1KQ9C8GZP1XB6V5T"
+
+
+def _service(kind: str, count: int) -> dict:
+    field = "availableReplicas" if kind == "PodCliqueScalingGroup" else "readyReplicas"
+    return {"componentKind": kind, "replicas": count, field: count}
+
+
+def _dgd(
+    *,
+    state: str = "successful",
+    worker: int | None = 2,
+    worker_kind: str = "Deployment",
+    router: int | None = 1,
+    generation: int = 4,
+    observed: int | None = 4,
+    conditions: list[dict] | None = None,
+) -> dict:
+    services = {}
+    if worker is not None:
+        services["VllmDecodeWorker"] = _service(worker_kind, worker)
+    if router is not None:
+        services["LocalRouter"] = _service("Deployment", router)
+    status: dict = {"state": state, "services": services}
+    if observed is not None:
+        status["observedGeneration"] = observed
+    if conditions is not None:
+        status["conditions"] = conditions
+    return {
+        "metadata": {
+            "name": "tdm-abc",
+            "generation": generation,
+            "labels": {"tandemn.com/rank-id": RANK_ID},
+        },
+        "status": status,
+    }
+
+
+# ----- replica field dispatch ------------------------------------------------
+
+
+def test_deployment_reads_ready_replicas():
+    assert serving_replicas(_service("Deployment", 3)) == 3
+
+
+def test_pod_clique_reads_ready_replicas():
+    assert serving_replicas(_service("PodClique", 2)) == 2
+
+
+def test_leader_worker_set_reads_ready_replicas():
+    assert serving_replicas(_service("LeaderWorkerSet", 1)) == 1
+
+
+def test_scaling_group_reads_available_replicas():
+    """Multinode Grove: readyReplicas is absent, not zero."""
+    status = _service("PodCliqueScalingGroup", 2)
+    assert "readyReplicas" not in status
+    assert serving_replicas(status) == 2
+
+
+def test_scaling_group_is_not_read_as_zero_by_the_ready_field():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(worker=2, worker_kind="PodCliqueScalingGroup"))
+    assert health.verdict is Verdict.SERVING
+    assert health.serving_replicas == 2
+
+
+def test_unknown_component_kind_yields_no_count():
+    assert serving_replicas({"componentKind": "StatefulSet", "readyReplicas": 4}) is None
+
+
+def test_absent_replica_field_yields_no_count():
+    assert serving_replicas({"componentKind": "Deployment"}) is None
+
+
+# ----- verdicts --------------------------------------------------------------
+
+
+def test_serving_when_worker_and_router_are_up():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(worker=3, router=1))
+    assert health.verdict is Verdict.SERVING
+    assert health.serving_replicas == 3
+    assert health.reason_code is None
+
+
+def test_missing_deployment_is_down():
+    health = rank_health(JOB_ID, RANK_ID, None)
+    assert health.verdict is Verdict.DOWN
+    assert health.reason_code == ReasonCode.NODE_LOST
+
+
+def test_failed_state_reports_the_failing_condition():
+    dgd = _dgd(
+        state="failed",
+        conditions=[
+            {"type": "Ready", "status": "False", "reason": "ImagePullFailure", "message": "no auth"}
+        ],
+    )
+    health = rank_health(JOB_ID, RANK_ID, dgd)
+    assert health.verdict is Verdict.DOWN
+    assert health.reason_code == ReasonCode.FAILED
+    assert "ImagePullFailure" in health.detail
+
+
+def test_unreconciled_generation_is_unknown():
+    """Replica counts still describe the spec before Orca's patch."""
+    health = rank_health(JOB_ID, RANK_ID, _dgd(generation=9, observed=8, worker=0))
+    assert health.verdict is Verdict.UNKNOWN
+
+
+def test_zero_workers_while_launching_is_unknown():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(state="pending", worker=0), ever_served=False)
+    assert health.verdict is Verdict.UNKNOWN
+
+
+def test_zero_workers_after_serving_is_down():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(state="pending", worker=0), ever_served=True)
+    assert health.verdict is Verdict.DOWN
+    assert health.reason_code == ReasonCode.HEARTBEAT_TIMEOUT
+
+
+def test_zero_workers_with_successful_state_is_down_even_before_serving():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(state="successful", worker=0), ever_served=False)
+    assert health.verdict is Verdict.DOWN
+
+
+def test_missing_worker_service_while_launching_is_unknown():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(state="initializing", worker=None))
+    assert health.verdict is Verdict.UNKNOWN
+
+
+def test_missing_worker_service_after_serving_is_down():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(worker=None), ever_served=True)
+    assert health.verdict is Verdict.DOWN
+
+
+def test_dead_local_router_is_down_despite_ready_workers():
+    """Orca inserts the LocalRouter hop, so ready workers alone serve nothing."""
+    health = rank_health(JOB_ID, RANK_ID, _dgd(worker=4, router=0))
+    assert health.verdict is Verdict.DOWN
+    assert health.reason_code == ReasonCode.PROCESS_CRASH
+    assert health.serving_replicas == 4
+
+
+def test_absent_local_router_entry_does_not_veto():
+    health = rank_health(JOB_ID, RANK_ID, _dgd(worker=1, router=None))
+    assert health.verdict is Verdict.SERVING
+
+
+# ----- helpers ---------------------------------------------------------------
+
+
+def test_dgd_by_rank_id_indexes_on_the_label():
+    indexed = dgd_by_rank_id([_dgd(), {"metadata": {"name": "unlabeled"}}])
+    assert set(indexed) == {RANK_ID}
+
+
+def test_termination_reason_maps_oom_kill():
+    pods = [
+        {
+            "metadata": {"name": "worker-0"},
+            "status": {
+                "containerStatuses": [
+                    {"name": "main", "lastState": {"terminated": {"reason": "OOMKilled"}}}
+                ]
+            },
+        }
+    ]
+    assert termination_reason_code(pods) == (
+        ReasonCode.OOM,
+        "worker-0/main terminated: OOMKilled",
+    )
+
+
+def test_termination_reason_maps_crash_loop():
+    pods = [
+        {
+            "metadata": {"name": "worker-1"},
+            "status": {
+                "containerStatuses": [
+                    {"name": "main", "state": {"waiting": {"reason": "CrashLoopBackOff"}}}
+                ]
+            },
+        }
+    ]
+    code, detail = termination_reason_code(pods)
+    assert code == ReasonCode.PROCESS_CRASH
+    assert "CrashLoopBackOff" in detail
+
+
+def test_termination_reason_absent_for_healthy_pods():
+    assert termination_reason_code([{"metadata": {"name": "w"}, "status": {}}]) is None

--- a/tests/test_router_health.py
+++ b/tests/test_router_health.py
@@ -1,0 +1,127 @@
+"""Publishing rank health to the per-job router.
+
+The payload shape is a cross-repository contract: tandemn-router decodes it with
+DisallowUnknownFields, and its config-reload goroutine logs and continues on a
+rejected request rather than exiting, so a mismatch fails silently. The Go side
+holds the matching test over testdata/rank_status_orca.json.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+import tandemn_orca.router_health as router_health_mod
+from tandemn_orca.dynamo_compiler import router_listen_port
+from tandemn_orca.rank_health import RankHealth, Verdict
+from tandemn_orca.router_health import RankHealthPublisher, rank_status_payload
+
+JOB_ID = "job-01JBM2YQYZ1KQ9C8GZP1XB6V5T"
+RANK_ID = "rank_01JBM2YQYZ1KQ9C8GZP1XB6V5T"
+OTHER_RANK_ID = "rank_01JBM30YQ7X3WQAR6HF8C2Q9T8"
+
+
+class FakeResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _capture(monkeypatch) -> list:
+    sent: list = []
+
+    def urlopen(request, timeout=None):
+        sent.append((request.full_url, json.loads(request.data), dict(request.headers)))
+        return FakeResponse()
+
+    monkeypatch.setattr(router_health_mod.urllib.request, "urlopen", urlopen)
+    return sent
+
+
+def test_payload_uses_the_wire_vocabulary():
+    payload = rank_status_payload(
+        JOB_ID,
+        [
+            RankHealth(RANK_ID, JOB_ID, Verdict.SERVING, 2, None, ""),
+            RankHealth(OTHER_RANK_ID, JOB_ID, Verdict.UNKNOWN, None, None, "0 workers (1/2)"),
+        ],
+        datetime(2026, 8, 21, 12, 0, 0, tzinfo=UTC),
+    )
+
+    assert payload == {
+        "job_id": JOB_ID,
+        "observed_at": "2026-08-21T12:00:00+00:00",
+        "ranks": [
+            {"rank_id": RANK_ID, "verdict": "serving", "serving_replicas": 2, "reason": ""},
+            {
+                "rank_id": OTHER_RANK_ID,
+                "verdict": "unknown",
+                "serving_replicas": None,
+                "reason": "0 workers (1/2)",
+            },
+        ],
+    }
+
+
+def test_payload_keeps_zero_distinct_from_no_count():
+    payload = rank_status_payload(
+        JOB_ID,
+        [RankHealth(RANK_ID, JOB_ID, Verdict.DOWN, 0, "OOM", "worker died")],
+        datetime.now(UTC),
+    )
+    assert payload["ranks"][0]["serving_replicas"] == 0
+
+
+def test_publish_posts_to_the_jobs_deterministic_router_port(monkeypatch):
+    sent = _capture(monkeypatch)
+    publisher = RankHealthPublisher("secret-token")
+
+    assert publisher.publish([RankHealth(RANK_ID, JOB_ID, Verdict.SERVING, 1, None, "")]) == 1
+
+    url, body, headers = sent[0]
+    assert url == f"http://127.0.0.1:{router_listen_port(JOB_ID)}/internal/rank-status"
+    assert body["job_id"] == JOB_ID
+    assert headers["Authorization"] == "Bearer secret-token"
+
+
+def test_publish_sends_one_batch_per_job(monkeypatch):
+    sent = _capture(monkeypatch)
+    other_job = "job-01JBM30YQ7X3WQAR6HF8C2Q9T8"
+    health = [
+        RankHealth(RANK_ID, JOB_ID, Verdict.SERVING, 1, None, ""),
+        RankHealth(OTHER_RANK_ID, JOB_ID, Verdict.DOWN, 0, "OOM", "died"),
+        RankHealth(RANK_ID, other_job, Verdict.SERVING, 1, None, ""),
+    ]
+
+    assert RankHealthPublisher("t").publish(health) == 2
+
+    by_job = {body["job_id"]: body for _, body, _ in sent}
+    assert len(by_job[JOB_ID]["ranks"]) == 2
+    assert len(by_job[other_job]["ranks"]) == 1
+
+
+def test_a_router_that_is_down_does_not_break_the_poll(monkeypatch):
+    def urlopen(request, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(router_health_mod.urllib.request, "urlopen", urlopen)
+
+    assert (
+        RankHealthPublisher("t").publish([RankHealth(RANK_ID, JOB_ID, Verdict.DOWN, 0, None, "")])
+        == 0
+    )
+
+
+@pytest.mark.parametrize("template", ["http://router.local:9000", "http://router.local:9000/"])
+def test_url_template_overrides_the_derived_port(monkeypatch, template):
+    sent = _capture(monkeypatch)
+
+    RankHealthPublisher("t", url_template=template).publish(
+        [RankHealth(RANK_ID, JOB_ID, Verdict.SERVING, 1, None, "")]
+    )
+
+    assert sent[0][0] == "http://router.local:9000/internal/rank-status"


### PR DESCRIPTION
## Problem

`ranks.status` is fiction after launch.

`_launch_ranks` sets a rank `RUNNING` as soon as the API server accepts its DGD — not when pods are ready, not when the model loads — and nothing revisits it. The only write of `RankStatus.FAILED` is guarded `expected=[LAUNCHING]`, so a `RUNNING` rank can never reach `FAILED`; the CAS returns `rowcount 0`. A worker that OOMs at minute 40 leaves the rank `RUNNING`, still routable, forever.

Of the nine `ReasonCode` values, exactly two are ever written (`LAUNCH_FAILED`, `MODEL_CATALOG_INVALID`). `HEARTBEAT_TIMEOUT`, `OOM`, `NODE_LOST`, `PREEMPTED`, `PROCESS_CRASH` are declared and unused — there are no heartbeats. `_stop_ranks` passes no `reason_code`, so a deliberately preempted rank is byte-identical in the table to one that finished cleanly.

## Approach

Orca reads each running job's DGD status on the existing poll loop, moves `ranks.status` to match, and publishes the same verdict to that job's router — so routing eligibility and the ranks table cannot disagree.

```
DGD .status ──> Orca.reconcile_rank_health() ──┬──> ranks.status + reason_code
                                                └──> POST /internal/rank-status ──> router
```

`.status.services` is the right source because the operator drives each worker's readiness probe from the worker's own `/health` gated on `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS=["generate"]`, which answers 503 until the generate endpoint is actually served. A ready replica there is one whose serving path works — stronger than a Prometheus scrape (which lags service discovery on cold start) and stronger than the frontend's `/health`, whose instance list is a lease-based etcd registration that outlives an OOMKill.

## What's here

**`rank_health.py`** — pure parsing, no I/O.

- `rank_health(job_id, rank_id, dgd, *, ever_served)` → `SERVING | DOWN | UNKNOWN`.
- `serving_replicas()` **dispatches on `componentKind`** rather than falling back. The unused replica field is *absent* from the JSON, not zero, so `readyReplicas or availableReplicas` would read a healthy PodCliqueScalingGroup as down:

  | componentKind | field | counts |
  |---|---|---|
  | `Deployment` | `readyReplicas` | pods |
  | `PodClique` | `readyReplicas` | pods |
  | `LeaderWorkerSet` | `readyReplicas` | groups |
  | `PodCliqueScalingGroup` | `availableReplicas` | gangs |

- Requires **both** the worker and `LocalRouter` services. Orca inserts the LocalRouter hop, so ready workers behind a dead router serve nothing while the operator still reports them available.
- Checks `observedGeneration` against `metadata.generation`, so a rank is never judged on a spec the operator hasn't processed.
- `ever_served` splits the two meanings of zero replicas: still launching (the 8–12 min Karpenter + image pull + model load window, during which the DGD sits in `pending`) versus died.
- `termination_reason_code()` maps `OOMKilled` → `OOM`, `CrashLoopBackOff` → `PROCESS_CRASH`. The DGD reports *that* replicas aren't ready, never *why*.

**`orca.py`**

- `reconcile_rank_health(user_id)` — one DGD list per cluster per job, debounced over N consecutive readings (default 2), returns the effective verdicts for publishing.
- Promotes `LAUNCHING → RUNNING` **only on that transition**. `set_rank_status` writes `reason_code` and `updated_at` unconditionally, so re-asserting `RUNNING` every poll would erase failure provenance and reset any age-based rule.
- Failure writes pass `expected=[LAUNCHING, RUNNING]` — the change that makes `RUNNING → FAILED` reachable.
- Pod termination state is read **once, on the failing transition**, not every poll.
- `_stop_ranks` records `ReasonCode.PREEMPTED` on the preempt path.

**`router_health.py`** — `RankHealthPublisher` posts level-triggered batches to each job's router at its deterministic port. A rank absent from a batch has left the active set and ages out rather than pinning a stale verdict. A router that is down logs and the next poll republishes.

**`dynamo_kubernetes.py`** — `job_dgds()` keeps the status `list_job_objects()` discarded; `rank_pods()` reads raw JSON because the generated client's `to_dict()` snake-cases keys. **Every call is now bounded by `_request_timeout=10`** — the Python client defaults to none and the poll loop is single-threaded, so a blackholed API server would have stalled plan application, not just the read.

## Ordering

Pairs with the `/internal/rank-status` endpoint in `tandemn-router`. **Ship the router first:** a config reload failure there logs and continues rather than exiting, so a new field reaching an old binary silently pins the stale registry while it keeps routing. This side degrades cleanly against a router without the endpoint (404 → warn → next poll republishes).

The reconciler is on by default and can be disabled with `--no-rank-health`; the debounce is `--down-polls-before-failed` (default 2).

## Verification

`ruff` + `mypy` clean, **156 tests pass**. New coverage: the componentKind dispatch (including that a PCSG is not read as zero), launching-vs-died, the LocalRouter veto, debounce, the no-op-CAS guard, pod-cause precedence, and graceful degradation when the API server or a router is unreachable.

Not settled from source — worth one command against the cluster before this runs for real:

```bash
kubectl get dgd -l tandemn.com/managed-by=orca -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.services.VllmDecodeWorker.componentKind}{"\n"}{end}'
```

If that returns `Deployment`, the PCSG branch never fires here. The table stays either way — it's cheap insurance and correct for whichever pathway the operator is running.

## Notes

- Based on `feat/orca` (the 6 upstream commits since my checkout are hardware-catalog work on disjoint files).
- `src/tandemn_orca/backend_common.py` is uncommitted in my working copy and is **not** part of this branch. `router_health.py` imports `router_listen_port` from `dynamo_compiler`, where `endpoint.py` and `gpu_metrics_collector.py` already get it.
- `src/tandemn_orca/scripts/azure_hardware_catalog.py` fails `ruff format --check` on the base branch; left untouched to keep this diff scoped.
