### PR TITLE
Tear down ranks for finished jobs

### DIFF
--- a/src/tandemn_orca/orca.py
+++ b/src/tandemn_orca/orca.py
@@ -328,6 +328,21 @@ class Orca:
             return cause
         return health.reason_code or ReasonCode.FAILED, health.detail
 
+    def reconcile_finished(self, user_id: str) -> int:
+        """Tear down active ranks whose owning jobs are already finished."""
+        reconciled = 0
+        # ponytail: list_jobs currently caps this recovery scan at 200 jobs.
+        for job in self._jobs.list_jobs(user_id):
+            if job.status is not JobStatus.FINISHED:
+                continue
+            rank_ids = self._active_rank_ids(job.job_id)
+            if not rank_ids:
+                continue
+            self._launcher.teardown_job(job.job_id)
+            self._stop_ranks(rank_ids, job.finish_reason)
+            reconciled += 1
+        return reconciled
+
     def reconcile_running(self, user_id: str) -> int:
         """Restore infrastructure, local configs, and tunnels after Orca restarts."""
         reconciled = 0
@@ -644,6 +659,11 @@ def main(argv: list[str] | None = None) -> None:
         except Exception:
             logger.exception("initial plan apply failed")
         try:
+            reconciled = orca.reconcile_finished(args.user_id)
+            logger.info("reconciled %s finished job(s)", reconciled)
+        except Exception:
+            logger.exception("finished job reconciliation failed")
+        try:
             reconciled = orca.reconcile_running(args.user_id)
             logger.info("reconciled %s running job(s)", reconciled)
         except Exception:
@@ -669,6 +689,11 @@ def main(argv: list[str] | None = None) -> None:
                 logger.info("applied %s plan(s) for user %s", applied, args.user_id)
             except Exception:
                 logger.exception("orca apply loop failed")
+            try:
+                reconciled = orca.reconcile_finished(args.user_id)
+                logger.info("reconciled %s finished job(s)", reconciled)
+            except Exception:
+                logger.exception("finished job reconciliation failed")
             if args.rank_health:
                 try:
                     health = orca.reconcile_rank_health(args.user_id)

--- a/tests/test_orca_runner.py
+++ b/tests/test_orca_runner.py
@@ -15,6 +15,7 @@ class FakeOrca:
         self.launcher = launcher
         self.kwargs = kwargs
         self.applied_users: list[str] = []
+        self.finished_users: list[str] = []
         self.reconciled_users: list[str] = []
         self.health_users: list[str] = []
         FakeOrca.instances.append(self)
@@ -25,6 +26,10 @@ class FakeOrca:
 
     def reconcile_running(self, user_id: str) -> int:
         self.reconciled_users.append(user_id)
+        return 0
+
+    def reconcile_finished(self, user_id: str) -> int:
+        self.finished_users.append(user_id)
         return 0
 
     def reconcile_rank_health(self, user_id: str) -> list:
@@ -112,6 +117,7 @@ def test_main_once_uses_dynamo_launcher(monkeypatch):
     assert FakeOrca.instances[0].launcher is FakeMultiClusterLauncher.instances[0]
     assert FakeMultiClusterLauncher.instances[0].default_cluster == "default"
     assert FakeOrca.instances[0].applied_users == ["default"]
+    assert FakeOrca.instances[0].finished_users == ["default"]
     assert FakeOrca.instances[0].reconciled_users == ["default"]
     assert FakeRefresher.instances[0].client == "client"
     assert FakeRefresher.instances[0].regions == [

--- a/tests/test_orca_smoke.py
+++ b/tests/test_orca_smoke.py
@@ -93,6 +93,12 @@ class FakeJobStore:
             if rank.job_id == job_id and rank.status in (RankStatus.LAUNCHING, RankStatus.RUNNING)
         ]
 
+    def list_jobs(self, user_id):
+        return [
+            SimpleNamespace(job_id=job_id, status=status, finish_reason=None)
+            for job_id, status in self.job_statuses.items()
+        ]
+
     def running_jobs(self, user_id):
         return [
             SimpleNamespace(job=SimpleNamespace(job_id=job_id), ranks=self.active_ranks(job_id))
@@ -541,6 +547,31 @@ def test_reconcile_running_restores_active_rank(monkeypatch):
     assert orca.reconcile_running("user_1") == 1
     assert orca._launcher.reconciled[0][0] == "job_B"
     assert [restored.rank_id for restored in orca._launcher.reconciled[0][1]] == [RANK_ID]
+
+
+def test_reconcile_finished_tears_down_active_ranks_once(monkeypatch):
+    rank = Rank(
+        rank_id=RANK_ID,
+        job_id="job_B",
+        plan_id="plan_1",
+        role=RankRole.AGGREGATE,
+        status=RankStatus.RUNNING,
+        shape_json={"count": 1},
+        n_replicas=1,
+    )
+    orca = _build_orca(
+        monkeypatch,
+        [],
+        active=[rank],
+        job_statuses={"job_B": JobStatus.FINISHED},
+    )
+
+    assert orca.reconcile_finished("user_1") == 1
+    assert orca.reconcile_finished("user_1") == 0
+    assert orca._launcher.torn_down_jobs == ["job_B"]
+    assert orca._jobs.rows[RANK_ID].status is RankStatus.STOPPED
+    assert orca._jobs.rows[RANK_ID].reason_code is None
+    assert orca._jobs.job_statuses["job_B"] is JobStatus.FINISHED
 
 
 def test_preempt_tears_down_and_pauses(monkeypatch):


### PR DESCRIPTION
## Summary
- reconcile finished Store jobs that still own active ranks
- tear down their Kubernetes deployments, routers, and tunnels without requiring a Koi preempt plan
- stop rank rows with the job finish reason and skip already-clean jobs for idempotence
- run cleanup independently at Orca startup and on every poll

## Lifecycle
`tandemn-sim` PR #30 now marks the canonical Store job `FINISHED` when AIPerf exits. This PR makes that terminal Store transition the durable teardown hook consumed by Orca.

## Verification
- `uv run --frozen --with pandas pytest -q tests/test_orca_smoke.py tests/test_orca_runner.py` — 30 passed
- `uv run --frozen ruff check src/tandemn_orca/orca.py tests/test_orca_smoke.py tests/test_orca_runner.py`
- `uv run --frozen ruff format --check src/tandemn_orca/orca.py tests/test_orca_smoke.py tests/test_orca_runner.py`
- `uv run --frozen mypy src`

## Known ceiling
The cleanup scan uses `JobStore.list_jobs()`, which currently returns the newest 200 jobs for the user. A dedicated finished-job query should replace it if terminal cleanup can lag beyond that window.