### PR TITLE
Mount local model weights PVC

### DIFF
--- a/src/tandemn_orca/batch_compiler.py
+++ b/src/tandemn_orca/batch_compiler.py
@@ -8,6 +8,9 @@ from tandemn_system_data.models.rank import Rank
 
 from tandemn_orca.compiler_common import (
     labels,
+    local_model_path,
+    model_weights_mount,
+    model_weights_volume,
     rank_node_count,
     required,
     validate_unique_ranks,
@@ -94,7 +97,10 @@ def render_chain(
             "periodSeconds": 10,
             "timeoutSeconds": 2,
         },
-        "volumeMounts": [{"name": "dshm", "mountPath": "/dev/shm"}],
+        "volumeMounts": [
+            {"name": "dshm", "mountPath": "/dev/shm"},
+            model_weights_mount(),
+        ],
     }
     if worker_secret:
         common["envFrom"] = [{"secretRef": {"name": worker_secret, "optional": False}}]
@@ -115,7 +121,7 @@ def render_chain(
                         "terminationGracePeriodSeconds": 90,
                         "nodeSelector": _node_selector(rank),
                         "containers": [common],
-                        "volumes": [_dshm("96Gi")],
+                        "volumes": [_dshm("96Gi"), model_weights_volume()],
                     },
                 },
             },
@@ -123,7 +129,7 @@ def render_chain(
 
     common["name"] = "tandemn-batched-leader"
     common["resources"] = _resources(gpus_per_node, memory=True)
-    model = required(rank.shape_json, "model_id")
+    model = local_model_path(rank.shape_json)
     parallel_args = _parallel_args(rank)
     distributed_args = (
         f"{parallel_args} --nnodes $(LWS_GROUP_SIZE) --node-rank $(LWS_WORKER_INDEX) "
@@ -144,7 +150,7 @@ def render_chain(
                         "terminationGracePeriodSeconds": 90,
                         "nodeSelector": _node_selector(rank),
                         "containers": [common],
-                        "volumes": [_dshm("16Gi")],
+                        "volumes": [_dshm("16Gi"), model_weights_volume()],
                     },
                 },
                 "workerTemplate": {
@@ -158,10 +164,13 @@ def render_chain(
                                 "command": ["sh", "-c"],
                                 "args": [f"vllm serve {model} {distributed_args} --headless"],
                                 "resources": _resources(gpus_per_node),
-                                "volumeMounts": [{"name": "dshm", "mountPath": "/dev/shm"}],
+                                "volumeMounts": [
+                                    {"name": "dshm", "mountPath": "/dev/shm"},
+                                    model_weights_mount(),
+                                ],
                             }
                         ],
-                        "volumes": [_dshm("16Gi")],
+                        "volumes": [_dshm("16Gi"), model_weights_volume()],
                     },
                 },
             },
@@ -183,7 +192,7 @@ def _leader_env(
             "--master-addr $(LWS_LEADER_ADDRESS)"
         )
     env = [
-        {"name": "TD_VLLM_MODEL", "value": required(rank.shape_json, "model_id")},
+        {"name": "TD_VLLM_MODEL", "value": local_model_path(rank.shape_json)},
         {"name": "TD_VLLM_HOST", "value": "0.0.0.0"},
         {"name": "TD_VLLM_EXTRA_ARGS", "value": args},
         {"name": "TD_CHUNK_MANAGER_ADDRESS", "value": chunk_manager_address},

--- a/src/tandemn_orca/compiler_common.py
+++ b/src/tandemn_orca/compiler_common.py
@@ -50,6 +50,21 @@ def required(shape: dict[str, Any], key: str) -> str:
     return str(value)
 
 
+def local_model_path(shape: dict[str, Any]) -> str:
+    return f"/models/{required(shape, 'model_id').rsplit('/', 1)[-1]}"
+
+
+def model_weights_volume() -> dict[str, Any]:
+    return {
+        "name": "model-weights",
+        "persistentVolumeClaim": {"claimName": "model-weights"},
+    }
+
+
+def model_weights_mount() -> dict[str, str | bool]:
+    return {"name": "model-weights", "mountPath": "/models", "readOnly": True}
+
+
 def worker_gpu_count(rank: Rank) -> int:
     count = rank.shape_json.get("count")
     if type(count) is not int or count <= 0:

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -22,6 +22,9 @@ from tandemn_system_data.models.rank import Rank
 from tandemn_orca.compiler_common import (
     k8s_name,
     labels,
+    local_model_path,
+    model_weights_mount,
+    model_weights_volume,
     rank_node_count,
     required,
     validate_unique_ranks,
@@ -214,6 +217,7 @@ def render_rank_dgd(
                     **({"multinode": {"nodeCount": node_count}} if node_count > 1 else {}),
                     "extraPodSpec": {
                         "nodeSelector": node_selector(shape),
+                        "volumes": [model_weights_volume()],
                         "tolerations": [
                             {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}
                         ],
@@ -222,6 +226,7 @@ def render_rank_dgd(
                             "workingDir": "/workspace/examples/backends/vllm",
                             "command": ["python3", "-m", "dynamo.vllm"],
                             "args": worker_args(shape),
+                            "volumeMounts": [model_weights_mount()],
                             **(
                                 {
                                     "envFrom": [
@@ -274,7 +279,7 @@ def node_selector(shape: dict[str, Any]) -> dict[str, str]:
 
 
 def worker_args(shape: dict[str, Any]) -> list[str]:
-    args = ["--model", required(shape, "model_id")]
+    args = ["--model", local_model_path(shape)]
     optional = {
         "tp": "--tensor-parallel-size",
         "pp": "--pipeline-parallel-size",
@@ -306,7 +311,7 @@ def worker_args(shape: dict[str, Any]) -> list[str]:
         if spec_method and str(spec_method).lower() != "none":
             args.extend(["--spec-method", str(spec_method)])
         if draft_model:
-            args.extend(["--spec-model", str(draft_model)])
+            args.extend(["--spec-model", f"/models/{str(draft_model).rsplit('/', 1)[-1]}"])
         if spec_tokens:
             args.extend(["--spec-tokens", str(spec_tokens)])
     return args

--- a/tests/test_batch_compiler.py
+++ b/tests/test_batch_compiler.py
@@ -49,7 +49,7 @@ def test_compile_single_node_job_per_chain():
     assert container["resources"]["limits"]["nvidia.com/gpu"] == "4"
     assert container["readinessProbe"]["httpGet"] == {"path": "/health", "port": "vllm"}
     assert _env(container) == {
-        "TD_VLLM_MODEL": "microsoft/phi-4",
+        "TD_VLLM_MODEL": "/models/phi-4",
         "TD_VLLM_HOST": "0.0.0.0",
         "TD_VLLM_EXTRA_ARGS": "--pipeline-parallel-size=2 --tensor-parallel-size=2",
         "TD_CHUNK_MANAGER_ADDRESS": "chunk-manager:9090",
@@ -57,6 +57,14 @@ def test_compile_single_node_job_per_chain():
         "TD_RANK_ID": "01JBM30YQ7X3WQAR6HF8C2Q9T8",
         "TD_CHAIN_ID": "0",
     }
+    assert pod["volumes"] == [
+        {"name": "dshm", "emptyDir": {"medium": "Memory", "sizeLimit": "96Gi"}},
+        {"name": "model-weights", "persistentVolumeClaim": {"claimName": "model-weights"}},
+    ]
+    assert container["volumeMounts"] == [
+        {"name": "dshm", "mountPath": "/dev/shm"},
+        {"name": "model-weights", "mountPath": "/models", "readOnly": True},
+    ]
 
 
 def test_compile_multinode_lws_per_chain():
@@ -81,6 +89,14 @@ def test_compile_multinode_lws_per_chain():
     assert worker["resources"]["limits"]["nvidia.com/gpu"] == "2"
     assert "--nnodes $(LWS_GROUP_SIZE)" in _env(leader)["TD_VLLM_EXTRA_ARGS"]
     assert "--headless" in worker["args"][0]
+    assert _env(leader)["TD_VLLM_MODEL"] == "/models/phi-4"
+    assert "vllm serve /models/phi-4" in worker["args"][0]
+    assert leader["volumeMounts"][1] == {
+        "name": "model-weights",
+        "mountPath": "/models",
+        "readOnly": True,
+    }
+    assert worker["volumeMounts"][1] == leader["volumeMounts"][1]
 
 
 def test_batch_workload_name_is_stable_across_plans():

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -112,9 +112,15 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
         "karpenter.sh/capacity-type": "reserved",
     }
     assert worker["resources"] == {"requests": {"gpu": "1"}, "limits": {"gpu": "1"}}
+    assert worker["extraPodSpec"]["volumes"] == [
+        {"name": "model-weights", "persistentVolumeClaim": {"claimName": "model-weights"}}
+    ]
+    assert worker["extraPodSpec"]["mainContainer"]["volumeMounts"] == [
+        {"name": "model-weights", "mountPath": "/models", "readOnly": True}
+    ]
     assert worker["extraPodSpec"]["mainContainer"]["args"] == [
         "--model",
-        "meta-llama/Llama-3.1-8B-Instruct",
+        "/models/Llama-3.1-8B-Instruct",
         "--tensor-parallel-size",
         "1",
         "--max-num-seqs",
@@ -285,7 +291,7 @@ def test_worker_args_adds_quantization_and_spec_decoding_flags():
     assert args[args.index("--quantization") + 1] == "awq"
     assert "--spec-method" in args
     assert args[args.index("--spec-method") + 1] == "draft_model"
-    assert args[args.index("--spec-model") + 1] == "draft/model"
+    assert args[args.index("--spec-model") + 1] == "/models/model"
     assert args[args.index("--spec-tokens") + 1] == "4"
 
 


### PR DESCRIPTION
## Summary
- Mount the fixed read-only model-weights PVC at /models for Dynamo and batch workers.
- Resolve Hugging Face-style model IDs to /models/<model-name> before invoking vLLM.
- Cover single-node, multi-node, and speculative-model rendering.

## Validation
- ruff check and ruff format --check for changed files.
- Python syntax compilation for changed files.
- Pytest collection is blocked locally because the environment is missing pandas required by tests/conftest.py.