### PR TITLE
Keep model IDs when loading weights from PVC

### DIFF
--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -279,7 +279,12 @@ def node_selector(shape: dict[str, Any]) -> dict[str, str]:
 
 
 def worker_args(shape: dict[str, Any]) -> list[str]:
-    args = ["--model", local_model_path(shape)]
+    args = [
+        "--model",
+        local_model_path(shape),
+        "--served-model-name",
+        required(shape, "model_id"),
+    ]
     optional = {
         "tp": "--tensor-parallel-size",
         "pp": "--pipeline-parallel-size",

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -121,6 +121,8 @@ def test_compile_job_renders_self_contained_dgd_for_each_gpu_pool():
     assert worker["extraPodSpec"]["mainContainer"]["args"] == [
         "--model",
         "/models/Llama-3.1-8B-Instruct",
+        "--served-model-name",
+        "meta-llama/Llama-3.1-8B-Instruct",
         "--tensor-parallel-size",
         "1",
         "--max-num-seqs",


### PR DESCRIPTION
## Summary
- Mount local model weights from the shared PVC.
- Keep the original model ID as vLLM's served model name.
- Let clients request `microsoft/phi-4` while vLLM loads `/models/phi-4`.

## Validation
- `uv run ruff check src/tandemn_orca/dynamo_compiler.py tests/test_dynamo_compiler.py`
- `uv run ruff format --check src/tandemn_orca/dynamo_compiler.py tests/test_dynamo_compiler.py`
- `.venv/bin/mypy src/tandemn_orca/dynamo_compiler.py`
- Direct `worker_args()` assertion for PVC path and served model ID.

`pytest tests/test_dynamo_compiler.py` could not run locally because the current test environment is missing `pandas`, required by `tests/conftest.py`.