### PR TITLE
Extend batch vLLM readiness timeout

### DIFF
--- a/src/tandemn_orca/batch_compiler.py
+++ b/src/tandemn_orca/batch_compiler.py
@@ -194,6 +194,7 @@ def _leader_env(
     env = [
         {"name": "TD_VLLM_MODEL", "value": local_model_path(rank.shape_json)},
         {"name": "TD_VLLM_HOST", "value": "0.0.0.0"},
+        {"name": "TD_VLLM_READY_TIMEOUT_SECONDS", "value": "1800"},
         {"name": "TD_VLLM_EXTRA_ARGS", "value": args},
         {"name": "TD_CHUNK_MANAGER_ADDRESS", "value": chunk_manager_address},
         {"name": "TD_JOB_ID", "value": rank.job_id.removeprefix("job_")},

--- a/tests/test_batch_compiler.py
+++ b/tests/test_batch_compiler.py
@@ -51,6 +51,7 @@ def test_compile_single_node_job_per_chain():
     assert _env(container) == {
         "TD_VLLM_MODEL": "/models/phi-4",
         "TD_VLLM_HOST": "0.0.0.0",
+        "TD_VLLM_READY_TIMEOUT_SECONDS": "1800",
         "TD_VLLM_EXTRA_ARGS": "--pipeline-parallel-size=2 --tensor-parallel-size=2",
         "TD_CHUNK_MANAGER_ADDRESS": "chunk-manager:9090",
         "TD_JOB_ID": "01JBM2YQYZ1KQ9C8GZP1XB6V5T",


### PR DESCRIPTION
## Summary
- set batch leader vLLM readiness timeout to 30 minutes
- assert the emitted worker environment includes the timeout

## Verification
- `uv run ruff check src/tandemn_orca/batch_compiler.py tests/test_batch_compiler.py`
- `uv run ruff format --check src/tandemn_orca/batch_compiler.py tests/test_batch_compiler.py`
- direct PP=2 batch compiler smoke check

`uv run pytest tests/test_batch_compiler.py` is blocked locally because `tests/conftest.py` imports unavailable `pandas`.