### PR TITLE
Initialize GKE GPU libraries for Dynamo workers

### DIFF
--- a/examples/dynamo-dgd-glm-pp2-dp2.yaml
+++ b/examples/dynamo-dgd-glm-pp2-dp2.yaml
@@ -1,0 +1,116 @@
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: tdm-lm-pp2-dp2-4699f42b
+  labels:
+    tandemn.com/managed-by: orca
+    tandemn.com/job-id: job_example_glm_pp2_dp2
+    tandemn.com/rank-id: rank_example_glm_pp2_dp2
+    tandemn.com/resource-kind: pool
+    tandemn.com/pool-key: rank-example-glm-pp2-dp2-g4-standard-192-rtx-pro-6000
+spec:
+  backendFramework: vllm
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_glm_pp2_dp2
+          tandemn.com/rank-id: rank_example_glm_pp2_dp2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.2
+          command:
+            - python3
+            - -m
+            - dynamo.frontend
+          args:
+            - --router-mode
+            - round-robin
+            - --model-name
+            - zai-org/GLM-4.5-Air
+    LocalRouter:
+      componentType: default
+      replicas: 1
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_glm_pp2_dp2
+          tandemn.com/rank-id: rank_example_glm_pp2_dp2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.2
+          env:
+            - name: DYN_SYSTEM_PORT
+              value: "9090"
+          command:
+            - python3
+            - -m
+            - dynamo.router
+          args:
+            - --endpoint
+            - dynamo-system-tdm-lm-pp2-dp2-4699f42b.router.generate
+            - --router-block-size
+            - "16"
+    VllmDecodeWorker:
+      componentType: worker
+      subComponentType: decode
+      scalingAdapter:
+        enabled: true
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_glm_pp2_dp2
+          tandemn.com/rank-id: rank_example_glm_pp2_dp2
+          tandemn.com/pods-discovery: dynamo-worker
+      resources:
+        requests:
+          gpu: "4"
+        limits:
+          gpu: "4"
+      multinode:
+        nodeCount: 2
+      extraPodSpec:
+        nodeSelector:
+          cloud.google.com/gke-nodepool: g4-standard-192
+          node.kubernetes.io/instance-type: g4-standard-192
+        volumes:
+          - name: model-weights
+            persistentVolumeClaim:
+              claimName: model-weights
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.2
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - sh
+            - -c
+          args:
+            - |-
+              export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH
+              export PATH=$PATH:/usr/local/nvidia/bin:/usr/local/nvidia/lib64
+              /sbin/ldconfig
+              exec python3 -m dynamo.vllm --model /models/GLM-4.5-Air --served-model-name zai-org/GLM-4.5-Air --tensor-parallel-size 4 --pipeline-parallel-size 2
+          volumeMounts:
+            - name: model-weights
+              mountPath: /models
+              readOnly: true
+    Planner:
+      componentType: planner
+      replicas: 1
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_glm_pp2_dp2
+          tandemn.com/rank-id: rank_example_glm_pp2_dp2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.4.2
+          command:
+            - python3
+            - -m
+            - dynamo.planner
+          args:
+            - --config
+            - '{"mode":"agg","backend":"vllm","environment":"kubernetes","optimization_target":"sla","enable_throughput_scaling":false,"enable_load_scaling":true,"pre_deployment_sweeping_mode":"none","load_predictor":"prophet","load_adjustment_interval_seconds":5,"min_endpoint":1,"max_gpu_budget":16,"ttft_ms":2200.0,"itl_ms":50.0}'

--- a/examples/dynamo-dgd-llama-1b-dp2.yaml
+++ b/examples/dynamo-dgd-llama-1b-dp2.yaml
@@ -1,0 +1,114 @@
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: tdm-ama-1b-dp2-e60f1b2e
+  labels:
+    tandemn.com/managed-by: orca
+    tandemn.com/job-id: job_example_llama_1b_dp2
+    tandemn.com/rank-id: rank_example_llama_1b_dp2
+    tandemn.com/resource-kind: pool
+    tandemn.com/pool-key: rank-example-llama-1b-dp2-g2-standard-24-l4
+spec:
+  backendFramework: vllm
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_llama_1b_dp2
+          tandemn.com/rank-id: rank_example_llama_1b_dp2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.2
+          command:
+            - python3
+            - -m
+            - dynamo.frontend
+          args:
+            - --router-mode
+            - round-robin
+            - --model-name
+            - meta-llama/Llama-3.2-1B-Instruct
+    LocalRouter:
+      componentType: default
+      replicas: 1
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_llama_1b_dp2
+          tandemn.com/rank-id: rank_example_llama_1b_dp2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.2
+          env:
+            - name: DYN_SYSTEM_PORT
+              value: "9090"
+          command:
+            - python3
+            - -m
+            - dynamo.router
+          args:
+            - --endpoint
+            - dynamo-system-tdm-ama-1b-dp2-e60f1b2e.router.generate
+            - --router-block-size
+            - "16"
+    VllmDecodeWorker:
+      componentType: worker
+      subComponentType: decode
+      scalingAdapter:
+        enabled: true
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_llama_1b_dp2
+          tandemn.com/rank-id: rank_example_llama_1b_dp2
+          tandemn.com/pods-discovery: dynamo-worker
+      resources:
+        requests:
+          gpu: "1"
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        nodeSelector:
+          cloud.google.com/gke-nodepool: g2-standard-24
+          node.kubernetes.io/instance-type: g2-standard-24
+        volumes:
+          - name: model-weights
+            persistentVolumeClaim:
+              claimName: model-weights
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.2
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - sh
+            - -c
+          args:
+            - |-
+              export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH
+              export PATH=$PATH:/usr/local/nvidia/bin:/usr/local/nvidia/lib64
+              /sbin/ldconfig
+              exec python3 -m dynamo.vllm --model /models/Llama-3.2-1B-Instruct --served-model-name meta-llama/Llama-3.2-1B-Instruct --tensor-parallel-size 1
+          volumeMounts:
+            - name: model-weights
+              mountPath: /models
+              readOnly: true
+    Planner:
+      componentType: planner
+      replicas: 1
+      extraPodMetadata:
+        labels:
+          tandemn.com/job-id: job_example_llama_1b_dp2
+          tandemn.com/rank-id: rank_example_llama_1b_dp2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.4.2
+          command:
+            - python3
+            - -m
+            - dynamo.planner
+          args:
+            - --config
+            - '{"mode":"agg","backend":"vllm","environment":"kubernetes","optimization_target":"sla","enable_throughput_scaling":false,"enable_load_scaling":true,"pre_deployment_sweeping_mode":"none","load_predictor":"prophet","load_adjustment_interval_seconds":5,"min_endpoint":1,"max_gpu_budget":2,"ttft_ms":500.0,"itl_ms":50.0}'

--- a/src/tandemn_orca/dynamo_compiler.py
+++ b/src/tandemn_orca/dynamo_compiler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shlex
 from typing import Any
 
 from tandemn_system_data.models.rank import Rank
@@ -152,6 +153,21 @@ def render_rank_dgd(
             f"evenly across node_count={node_count}"
         )
     gpus_per_node = gpu_count // node_count
+    worker_command = ["python3", "-m", "dynamo.vllm"]
+    worker_arguments = worker_args(shape)
+    env = shape.get("env")
+    if isinstance(env, (list, tuple)) and len(env) > 1 and env[1] == "gcp":
+        worker_command = ["sh", "-c"]
+        worker_arguments = [
+            "\n".join(
+                [
+                    "export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH",
+                    "export PATH=$PATH:/usr/local/nvidia/bin:/usr/local/nvidia/lib64",
+                    "/sbin/ldconfig",
+                    f"exec {shlex.join(['python3', '-m', 'dynamo.vllm', *worker_arguments])}",
+                ]
+            )
+        ]
     return {
         "apiVersion": "nvidia.com/v1alpha1",
         "kind": "DynamoGraphDeployment",
@@ -224,8 +240,8 @@ def render_rank_dgd(
                         "mainContainer": {
                             "image": RUNTIME_IMAGE,
                             "workingDir": "/workspace/examples/backends/vllm",
-                            "command": ["python3", "-m", "dynamo.vllm"],
-                            "args": worker_args(shape),
+                            "command": worker_command,
+                            "args": worker_arguments,
                             "volumeMounts": [model_weights_mount()],
                             **(
                                 {

--- a/tests/test_dynamo_compiler.py
+++ b/tests/test_dynamo_compiler.py
@@ -275,6 +275,29 @@ def test_gcp_selector_uses_node_pool_and_instance_type():
     }
 
 
+def test_gcp_worker_initializes_gpu_libraries_before_vllm():
+    rank = _rank("g2-standard-48", "L4")
+    rank.shape_json["env"] = ["on_demand", "gcp", "us-central1", "us-central1-a", "L4"]
+
+    container = render_rank_dgd("job_1", rank, "default")["spec"]["services"]["VllmDecodeWorker"][
+        "extraPodSpec"
+    ]["mainContainer"]
+
+    assert container["command"] == ["sh", "-c"]
+    assert container["args"] == [
+        "export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH\n"
+        "export PATH=$PATH:/usr/local/nvidia/bin:/usr/local/nvidia/lib64\n"
+        "/sbin/ldconfig\n"
+        "exec python3 -m dynamo.vllm --model /models/Llama-3.1-8B-Instruct "
+        "--served-model-name meta-llama/Llama-3.1-8B-Instruct "
+        "--tensor-parallel-size 1 --max-num-seqs 64 "
+        "--max-num-batched-tokens 32768 --gpu-memory-utilization 0.9 "
+        "--max-model-len 8192 --block-size 16 --kv-cache-dtype auto "
+        "--scheduling-policy fcfs --enable-prefix-caching --enable-chunked-prefill "
+        "--dtype bfloat16"
+    ]
+
+
 def test_worker_args_adds_quantization_and_spec_decoding_flags():
     shape = dict(_rank("p5.48xlarge", "H100").shape_json)
     shape.update(


### PR DESCRIPTION
## Summary
- initialize GKE NVIDIA driver paths before starting Dynamo vLLM workers
- preserve direct worker startup outside GCP
- add compiler-generated GKE DGD examples for Llama DP and GLM PP

## Verification
- `uv run ruff check src/tandemn_orca/dynamo_compiler.py tests/test_dynamo_compiler.py`
- `uv run ruff format --check src/tandemn_orca/dynamo_compiler.py tests/test_dynamo_compiler.py`
- direct compiler checks confirming both examples match the current render

`uv run pytest tests/test_dynamo_compiler.py` is blocked locally because `tests/conftest.py` imports unavailable `pandas`.