### PR TITLE
Handle absent DCGM reserved memory metric

### DIFF
--- a/src/tandemn_orca/scripts/gpu_metrics_collector.py
+++ b/src/tandemn_orca/scripts/gpu_metrics_collector.py
@@ -77,8 +77,7 @@ COLLECT_INTERVAL_SECONDS = 5
 GPU_QUERIES: dict[str, str] = {
     "gpu_mem_used_fraction": (
         "DCGM_FI_DEV_FB_USED{{{gpu}}} / "
-        "(DCGM_FI_DEV_FB_USED{{{gpu}}} + DCGM_FI_DEV_FB_FREE{{{gpu}}} "
-        "+ DCGM_FI_DEV_FB_RESERVED{{{gpu}}})"
+        "(DCGM_FI_DEV_FB_USED{{{gpu}}} + DCGM_FI_DEV_FB_FREE{{{gpu}}})"
     ),
     "vram_headroom_gb": "DCGM_FI_DEV_FB_FREE{{{gpu}}} / 1024",
     "sm_utilization": "DCGM_FI_PROF_SM_ACTIVE{{{gpu}}}",

--- a/tests/test_gpu_metrics_collector.py
+++ b/tests/test_gpu_metrics_collector.py
@@ -11,6 +11,7 @@ from tandemn_system_data.models import Rank, RankRole, ResourceMap
 
 from tandemn_orca.dynamo_compiler import router_listen_port
 from tandemn_orca.scripts.gpu_metrics_collector import (
+    GPU_QUERIES,
     KubeWorkerIndex,
     PrometheusClient,
     RankTelemetrySnapshot,
@@ -24,6 +25,16 @@ from tandemn_orca.scripts.gpu_metrics_collector import (
     resolve_instance_price_per_hour,
     validate_rank_identity,
 )
+
+
+def test_gpu_memory_fraction_uses_available_dcgm_fields():
+    query = GPU_QUERIES["gpu_mem_used_fraction"]
+
+    assert query == (
+        "DCGM_FI_DEV_FB_USED{{{gpu}}} / "
+        "(DCGM_FI_DEV_FB_USED{{{gpu}}} + DCGM_FI_DEV_FB_FREE{{{gpu}}})"
+    )
+    assert "DCGM_FI_DEV_FB_RESERVED" not in query
 
 
 def test_worker_index_uses_single_and_multinode_grove_indexes():


### PR DESCRIPTION
## Summary
- calculate GPU memory use from DCGM used and free memory
- avoid requiring the unavailable `DCGM_FI_DEV_FB_RESERVED` series on GKE
- add a regression assertion for the rendered PromQL

## Verification
- Ruff check and formatting for changed files
- direct rendered PromQL assertion

`pytest tests/test_gpu_metrics_collector.py` could not run in the isolated worktree because its editable sibling `tandemn-store` dependency is unavailable there; the regular project environment also has the existing missing `pandas` dependency in `tests/conftest.py`.